### PR TITLE
chores: update Next build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && next-sitemap",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "clean": "rm -rf .next/ && rm -rf node_modules/ && npm install"
   },
   "dependencies": {
     "react": "^18",


### PR DESCRIPTION
### TL;DR

This pull request updates the build script to include generating a sitemap and adds a clean script.

### What changed?

In `package.json`, the build script has been updated to also run `next-sitemap` post-build. Additionally, a 'clean' script has been added which removes all existing Node modules and the .next directory before reinstalling all dependencies.

### How to test?

You can test these scripts by running 'npm run build' to see that a sitemap is generated and 'npm run clean' to see that the .next directory and node_modules are removed and reinstalled.

### Why make this change?

This change is made to automate the sitemap generation and provide a simple way to reset the project workspace by removing all existing Node modules and the .next directory before reinstalling all dependencies.

---

