### PR TITLE
feat(ui): add values section to about page

### DIFF
--- a/app/about/components/AboutPartner.tsx
+++ b/app/about/components/AboutPartner.tsx
@@ -1,0 +1,43 @@
+export function AboutPartner() {
+  return (
+    <>
+      <div>
+        <div
+          className="relative cursor-none content-stretch items-start justify-start bg-neutral-900 px-24 py-36 font-light text-white"
+          id="div-1"
+        >
+          <div
+            className="relative grid auto-cols-fr grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr] grid-rows-[auto_auto_auto_auto_auto_auto] gap-4"
+            id="div-2"
+          >
+            <div className="col-start-3 col-end-6 row-start-1 row-end-2 flex h-full w-full flex-col items-end justify-start font-bold uppercase">
+              <div className="pb-5">+ Our Values</div>
+            </div>
+            <div
+              className="z-10 col-span-3 col-start-4 row-start-4 flex h-full w-full flex-col items-center justify-center self-stretch text-[2.63rem] leading-none"
+              id="div-3"
+              style={{
+                justifySelf: "stretch",
+              }}
+            >
+              <h2 className="mb-8 min-h-[0vw]">
+                We are committed to treating everyone right, leaving our ego at
+                the door, and truly partnering with our clients.
+              </h2>
+            </div>
+            <div
+              className="relative col-span-5 col-start-1 row-start-2 row-end-6 h-[75vh] self-stretch overflow-hidden"
+              id="div-4"
+            >
+              <img
+                src="https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5f0ce068d8b392674335dbfe_DSC04489.1920.jpg"
+                alt="Partner Image"
+                className="h-full w-full object-cover"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,11 +1,13 @@
 import { AboutHero } from "./components/AboutHero";
 import { AboutIntro } from "./components/AboutIntro";
+import { AboutPartner } from "./components/AboutPartner";
 
 export default function Page() {
   return (
     <main>
       <AboutHero />
       <AboutIntro />
+      <AboutPartner />
     </main>
   );
 }


### PR DESCRIPTION
### TL;DR
Add a new 'AboutPartner' component to the 'about' page.

### What changed?
- Introduced a new component 'AboutPartner' in 'app/about/components/AboutPartner.tsx'.
- Enhanced 'app/about/page.tsx' by including the 'AboutPartner' component.

### How to test?
1. Navigate to the 'about' page.
2. Verify the presence of a section titled 'Our Values' with a substantial image and content centered around partnership values.

### Why make this change?
To highlight the company's values and commitment to partners in a dedicated section on the 'about' page.

---

