### PR TITLE
feat(ui): add team intro image to about page

### DIFF
--- a/app/about/components/AboutGood.tsx
+++ b/app/about/components/AboutGood.tsx
@@ -1,0 +1,27 @@
+export function AboutGood() {
+  return (
+    <>
+      <div>
+        <div
+          className="h-full w-full cursor-none bg-neutral-900 pl-0 pr-28 text-white"
+          id="div-1"
+        >
+          <div
+            className="flex h-screen w-full max-w-full overflow-visible"
+            id="div-2"
+          >
+            <img
+              src="https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5f53f60a0033860407ff3718_ThebyWessa2020-6960.jpeg"
+              alt="Theby Wessa 2020"
+              className="h-full w-full object-cover"
+              style={{
+                objectPosition: "50% 50%",
+                backgroundAttachment: "fixed",
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,6 +1,7 @@
 import { AboutHero } from "./components/AboutHero";
 import { AboutIntro } from "./components/AboutIntro";
 import { AboutPartner } from "./components/AboutPartner";
+import { AboutGood } from "./components/AboutGood";
 
 export default function Page() {
   return (
@@ -8,6 +9,7 @@ export default function Page() {
       <AboutHero />
       <AboutIntro />
       <AboutPartner />
+      <AboutGood />
     </main>
   );
 }


### PR DESCRIPTION
### TL;DR

This PR introduces a new `AboutGood` component to the About page.

### What changed?

- Added a new `AboutGood` component with an `img` section, styled to cover the full viewport height and width.
- Imported and included the `AboutGood` component in the About page's main component.

### How to test?

1. Run the app.
2. Navigate to the About page.
3. Ensure that the new `AboutGood` component, including the image, is rendered correctly.

### Why make this change?

This change enhances the visual appeal of the About page by adding a new image section, providing visitors with a richer visual experience.


---

