### PR TITLE
feat(ui): add team section to about page

### DIFF
--- a/app/about/components/AboutTeam.tsx
+++ b/app/about/components/AboutTeam.tsx
@@ -1,0 +1,59 @@
+export function AboutTeam() {
+  return (
+    <>
+      <div>
+        <div
+          className="content-stretch items-start justify-start bg-neutral-900 px-24 py-48 font-light text-white"
+          id="div-1"
+        >
+          <div
+            className="m-auto flex w-full max-w-[62.50rem] flex-grow auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto_auto] flex-col items-stretch justify-center self-start"
+            id="div-2"
+          >
+            <div
+              className="grid auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto] gap-x-[3.13rem] gap-y-[6.25rem]"
+              id="div-3"
+            >
+              <div className="flex flex-col items-center text-center">
+                <div className="h-[37.50rem] w-96 pb-8" id="div-4">
+                  <div className="overflow-hidden rounded-xl">
+                    <img
+                      className="inline-block h-[37.50rem] w-96 max-w-full object-cover align-middle"
+                      id="img-1"
+                      src="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f53f8986ce296e3d5512d59_kevin-profile-pic.1920.jpg"
+                      srcSet="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f53f8986ce296e3d5512d59_kevin-profile-pic.1920-p-500.jpeg 500w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f53f8986ce296e3d5512d59_kevin-profile-pic.1920.jpg 1280w"
+                    />
+                  </div>
+                </div>
+                <div className="flex h-full max-w-[25.00rem] flex-col items-center justify-start pt-9">
+                  Founder + Lead Engineer
+                  <h4 className="mb-8 min-h-[0vw] text-lg font-bold">
+                    Kevin Wessa
+                  </h4>
+                </div>
+              </div>
+              <div className="flex flex-col items-center text-center">
+                <div className="h-[37.50rem] w-96 pb-8" id="div-5">
+                  <div className="overflow-hidden rounded-xl">
+                    <img
+                      className="inline-block h-[37.50rem] w-96 max-w-full object-cover align-middle"
+                      id="img-2"
+                      src="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f53f783d20ccc4fe020678f_christine-profile-pic.1920.jpg"
+                      srcSet="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f53f783d20ccc4fe020678f_christine-profile-pic.1920-p-500.jpeg 500w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f53f783d20ccc4fe020678f_christine-profile-pic.1920-p-800.jpeg 800w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f53f783d20ccc4fe020678f_christine-profile-pic.1920-p-1080.jpeg 1080w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f53f783d20ccc4fe020678f_christine-profile-pic.1920.jpg 1280w"
+                    />
+                  </div>
+                </div>
+                <div className="flex h-full max-w-[25.00rem] flex-col items-center justify-start pt-9">
+                  Founder + Lead Designer
+                  <h4 className="mb-8 min-h-[0vw] text-lg font-bold">
+                    Christine Wessa
+                  </h4>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,6 +2,7 @@ import { AboutHero } from "./components/AboutHero";
 import { AboutIntro } from "./components/AboutIntro";
 import { AboutPartner } from "./components/AboutPartner";
 import { AboutGood } from "./components/AboutGood";
+import { AboutTeam } from "./components/AboutTeam";
 
 export default function Page() {
   return (
@@ -10,6 +11,7 @@ export default function Page() {
       <AboutIntro />
       <AboutPartner />
       <AboutGood />
+      <AboutTeam />
     </main>
   );
 }


### PR DESCRIPTION

### TL;DR
- Introduced the `AboutTeam` component to the About page.
- Displays profile pictures and brief descriptions of team members.
- Profiles for Kevin Wessa (Founder + Lead Engineer) and Christine Wessa (Founder + Lead Designer) are included.

### What changed?
- Created a new `AboutTeam` component in `app/about/components/AboutTeam.tsx`.
- Imported and included the `AboutTeam` component in `app/about/page.tsx`.

### How to test?
- Navigate to the About page.
- Verify that the team section displays correctly with the profile pictures and descriptions of both Kevin and Christine Wessa.

### Why make this change?
- To provide visitors with information about the key team members behind the project, enhancing transparency and credibility.

---

