### PR TITLE
feat(ui): add brewww pre-footer to about page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -3,6 +3,7 @@ import { AboutIntro } from "./components/AboutIntro";
 import { AboutPartner } from "./components/AboutPartner";
 import { AboutGood } from "./components/AboutGood";
 import { AboutTeam } from "./components/AboutTeam";
+import { PreFooter } from "../components/PreFooter";
 
 export default function Page() {
   return (
@@ -12,6 +13,7 @@ export default function Page() {
       <AboutPartner />
       <AboutGood />
       <AboutTeam />
+      <PreFooter />
     </main>
   );
 }

--- a/app/capabilities/page.tsx
+++ b/app/capabilities/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <main></main>;
+}

--- a/app/components/PreFooter.tsx
+++ b/app/components/PreFooter.tsx
@@ -1,0 +1,128 @@
+export function PreFooter() {
+  return (
+    <>
+      <div>
+        <div
+          className="relative h-full w-full overflow-visible bg-neutral-900 py-20 font-light text-white"
+          id="div-1"
+        >
+          <div
+            className="relative m-auto items-center justify-center"
+            id="div-2"
+          >
+            <div
+              className="relative mx-auto mb-12 block content-stretch items-start justify-start p-4"
+              id="div-3"
+            >
+              <div className="m-auto flex justify-center" id="div-4">
+                <div className="relative w-64 px-1" id="div-5">
+                  <div className="relative">
+                    <div className="h-80" id="div-6">
+                      <img
+                        className="inline-block h-full w-full max-w-full object-cover align-middle"
+                        src="https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5e6978ff0936456344b8032b_b-waves-home.1200.jpg"
+                        srcSet="https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5e6978ff0936456344b8032b_b-waves-home.1200-p-500.jpeg 500w, https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5e6978ff0936456344b8032b_b-waves-home.1200.jpg 800w"
+                      />
+                    </div>
+                    <div className="absolute left-1/2 top-[98%] z-0 text-7xl font-bold lowercase text-white/[0.8]">
+                      <div>B</div>
+                    </div>
+                    <div className="absolute left-1/2 top-[98%] z-[2] text-7xl font-bold lowercase text-white/[0.8]">
+                      <div>B</div>
+                    </div>
+                  </div>
+                </div>
+                <div className="w-64 px-1" id="div-7">
+                  <div className="relative">
+                    <div className="h-80" id="div-8">
+                      <img
+                        className="inline-block h-full w-full max-w-full object-cover align-middle"
+                        src="https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5e6979bb1958ea05484725f4_k%26c-bride-and-groom-smiling.1200.JPG"
+                        srcSet="https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5e6979bb1958ea05484725f4_k%26c-bride-and-groom-smiling.1200-p-1080.jpeg 1080w, https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5e6979bb1958ea05484725f4_k%26c-bride-and-groom-smiling.1200.JPG 1200w"
+                      />
+                    </div>
+                    <div className="absolute left-1/2 top-[98%] z-0 text-7xl font-bold lowercase text-white/[0.8]">
+                      <div>R</div>
+                    </div>
+                    <div className="absolute left-1/2 top-[98%] z-[2] text-7xl font-bold lowercase text-white/[0.8]">
+                      <div>R</div>
+                    </div>
+                  </div>
+                </div>
+                <div className="w-64 px-1" id="div-9">
+                  <div className="relative">
+                    <div className="h-80" id="div-10">
+                      <img
+                        className="inline-block h-full w-full max-w-full object-cover align-middle"
+                        src="https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5e40f2f2c6829fb27fc7560e_bg-approach.1200.jpg"
+                        srcSet="https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5e40f2f2c6829fb27fc7560e_bg-approach.1200-p-500.jpeg 500w, https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5e40f2f2c6829fb27fc7560e_bg-approach.1200.jpg 800w"
+                      />
+                    </div>
+                    <div className="absolute left-1/2 top-[98%] z-0 text-7xl font-bold lowercase text-white/[0.8]">
+                      <div>E</div>
+                    </div>
+                    <div className="absolute left-1/2 top-[98%] z-[2] text-7xl font-bold lowercase text-white/[0.8]">
+                      <div>E</div>
+                    </div>
+                  </div>
+                </div>
+                <div className="w-64 px-1" id="div-11">
+                  <div className="relative">
+                    <div className="h-80" id="div-12">
+                      <img
+                        className="inline-block h-full w-full max-w-full object-cover align-middle"
+                        src="https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5e697af349a01f58309d775e_Christine-beautiful-sky.1200.jpg"
+                        srcSet="https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5e697af349a01f58309d775e_Christine-beautiful-sky.1200-p-500.jpeg 500w, https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5e697af349a01f58309d775e_Christine-beautiful-sky.1200.jpg 799w"
+                      />
+                    </div>
+                    <div className="absolute left-1/2 top-[98%] z-0 text-7xl font-bold lowercase text-white/[0.8]">
+                      <div>W</div>
+                    </div>
+                    <div className="absolute left-1/2 top-[98%] z-[2] text-7xl font-bold lowercase text-white/[0.8]">
+                      <div>W</div>
+                    </div>
+                  </div>
+                </div>
+                <div className="w-64 px-1" id="div-13">
+                  <div className="relative">
+                    <div className="h-80" id="div-14">
+                      <img
+                        className="inline-block h-full w-full max-w-full object-cover align-middle"
+                        src="https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5e40f2f21b7f2bcbeb4fe6c4_bg-services.1200.jpg"
+                        srcSet="https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5e40f2f21b7f2bcbeb4fe6c4_bg-services.1200-p-500.jpeg 500w, https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5e40f2f21b7f2bcbeb4fe6c4_bg-services.1200.jpg 800w"
+                      />
+                    </div>
+                    <div className="absolute left-1/2 top-[98%] z-0 text-7xl font-bold lowercase text-white/[0.8]">
+                      <div>W</div>
+                    </div>
+                    <div className="absolute left-1/2 top-[98%] z-[2] text-7xl font-bold lowercase text-white/[0.8]">
+                      <div>W</div>
+                    </div>
+                  </div>
+                </div>
+                <div className="w-64 px-1" id="div-15">
+                  <div className="relative">
+                    <div className="h-80" id="div-16">
+                      <img
+                        className="inline-block h-full w-full max-w-full object-cover align-middle"
+                        src="https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5e40f2f11b7f2b9a534fe6a1_bg-contact.1200.jpg"
+                        srcSet="https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5e40f2f11b7f2b9a534fe6a1_bg-contact.1200-p-800.jpeg 800w, https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5e40f2f11b7f2b9a534fe6a1_bg-contact.1200-p-1080.jpeg 1080w, https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5e40f2f11b7f2b9a534fe6a1_bg-contact.1200.jpg 1200w"
+                      />
+                    </div>
+                    <div className="absolute left-1/2 top-[98%] z-0 text-7xl font-bold lowercase text-white/[0.8]">
+                      <div>W</div>
+                    </div>
+                    <div className="absolute left-1/2 top-[98%] z-[2] text-7xl font-bold lowercase text-white/[0.8]">
+                      <div>W</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="absolute bottom-[-20vh] left-0 right-0 z-[55] h-80 bg-[linear-gradient(rgb(23,_23,_25),_rgba(0,_0,_0,_0)_100%,_rgba(0,_0,_0,_0))]" />
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION

### TL;DR

Added a new PreFooter component to the About page and created a placeholder Capabilities page.

### What changed?

- Imported and incorporated a new `PreFooter` component into `app/about/page.tsx`
- Created a new placeholder `Capabilities` page at `app/capabilities/page.tsx`
- Developed the `PreFooter` component with placeholder content and images.

### How to test?

1. Go to the About page and verify that the PreFooter component is displayed correctly.
2. Navigate to the Capabilities page to ensure it's accessible and shows a blank main section.

### Why make this change?

This update introduces a new visual component to enhance the About page, and sets up the structure for future development of the Capabilities page.

---

