### PR TITLE
feat(ui): add hero section to capabilities page

### DIFF
--- a/app/capabilities/components/CapabilitiesHero.tsx
+++ b/app/capabilities/components/CapabilitiesHero.tsx
@@ -1,0 +1,50 @@
+export function CapabilitiesHero() {
+  return (
+    <>
+      <div>
+        <div
+          className="relative content-stretch items-start justify-start bg-neutral-900 px-36 pb-36 pt-48 font-light text-white"
+          id="div-1"
+        >
+          <div
+            className="relative grid auto-cols-fr grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr] grid-rows-[auto_auto_auto_auto_auto_auto] gap-4"
+            id="div-2"
+          >
+            <div className="col-span-4 row-start-1 row-end-2 flex h-full w-full flex-col items-start justify-center justify-self-start font-bold uppercase">
+              <div className="pb-5">
+                <span className="text-orange-400">/ </span>
+                Our Capabilities
+              </div>
+            </div>
+            <div
+              className="col-span-4 col-start-1 row-start-2 flex h-full w-full flex-col items-center justify-center text-[4.13rem] leading-none"
+              id="div-3"
+            >
+              <h1 className="mx-0 my-3 min-h-[0vw]">
+                We build brands, websites, and creative that engages you. Your
+                audience. Your vision.{" "}
+                <strong className="font-extrabold">Your story.</strong>
+              </h1>
+            </div>
+            <div id="div-4" />
+            <div
+              className="relative col-start-5 col-end-6 row-start-5 row-end-7 flex h-full max-h-[9.38rem] min-h-[6.25rem] w-full items-end justify-start"
+              id="div-5"
+              style={{
+                gridArea: "5/5/7/6",
+              }}
+            >
+              <a
+                className="relative inline-block h-full w-3 max-w-full self-end overflow-hidden"
+                href="/#start"
+              >
+                <div className="absolute left-[0.38rem] top-0 z-[1] h-full w-0 bg-white/[0.35]" />
+                <div className="absolute left-[0.38rem] top-0 h-full w-0 bg-white" />
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/capabilities/page.tsx
+++ b/app/capabilities/page.tsx
@@ -1,3 +1,9 @@
+import { CapabilitiesHero } from "./components/CapabilitiesHero";
+
 export default function Page() {
-  return <main></main>;
+  return (
+    <main>
+      <CapabilitiesHero />
+    </main>
+  );
 }

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -12,7 +12,7 @@ export function Footer() {
           >
             <a
               className="col-start-1 col-end-4 row-start-1 row-end-2 m-auto inline-block max-w-full self-center justify-self-center text-[4.38rem] font-bold leading-none"
-              href="https://brewwwllc.webflow.io/hire-us"
+              href="/hire-us"
             >
               <div className="m-auto h-full w-full overflow-hidden py-3">
                 <h4 className="mx-auto mb-8 min-h-[0vw] max-w-[43.75rem] text-center">


### PR DESCRIPTION
### TL;DR

This PR introduces the `CapabilitiesHero` component in the capabilities section of the application. It includes the markup and styles for the component and integrates it into the capabilities page. Additionally, it updates a link in the `Footer` component to fix a navigation issue.

### What changed?
- Created `CapabilitiesHero` component with markup and styles
- Updated `capabilities/page.tsx` to include `CapabilitiesHero`
- Modified `Footer.tsx` to update the link to 'Hire Us' page

### How to test?
1. Navigate to `/capabilities` and verify that the `CapabilitiesHero` component is rendered correctly.
2. Check the `Footer` component and ensure the 'Hire Us' link navigates to the correct URL (`/hire-us`).

### Why make this change?
This change enhances the capabilities page by introducing a new hero section and fixes the navigation issue in the footer.

---

