### PR TITLE
feat(ui): add branding section to capabilities page

### DIFF
--- a/app/capabilities/components/CapabilitiesBranding.tsx
+++ b/app/capabilities/components/CapabilitiesBranding.tsx
@@ -1,0 +1,153 @@
+export function CapabilitiesBranding() {
+  return (
+    <>
+      <div>
+        <div
+          className="relative items-center justify-center overflow-visible font-light text-neutral-900"
+          id="div-1"
+        >
+          <div className="absolute left-0 right-0 top-0 z-[1] h-[40vh] bg-neutral-900" />
+          <div className="relative mr-48" id="div-2">
+            <div className="relative h-[75vh] overflow-hidden" id="div-3">
+              <div
+                className='absolute bottom-0 left-0 top-0 my-auto h-[120%] bg-[url("https://cdn.prod.website-files.com/5dad037b65b2d91cb0118b62/5ed6030ff722b820100aae21_branding-books.1920.jpg")] bg-cover'
+                style={{
+                  backgroundPosition: "50% 50%",
+                }}
+              />
+            </div>
+          </div>
+          <div
+            className="grid auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto_auto] gap-4 pb-12"
+            id="div-4"
+          >
+            <div className="mx-auto mt-48" id="div-5">
+              <div className="grid auto-cols-fr grid-cols-[1fr] grid-rows-[auto] gap-x-4 gap-y-48">
+                <div className="w-96" id="div-6">
+                  <div
+                    className="relative h-[37.50rem] overflow-hidden"
+                    id="div-7"
+                  >
+                    <div
+                      className='absolute bottom-0 left-0 top-0 my-auto h-[120%] bg-[url("https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5eed36194b80918b02fc20ac_capabilities-strategy.1920.jpg")] bg-cover'
+                      style={{
+                        backgroundPosition: "50% 50%",
+                      }}
+                    />
+                  </div>
+                  <div className="pr-10">
+                    <div className="my-4">
+                      <h3 className="mb-8 min-h-[0vw] text-[3.38rem] font-bold leading-none">
+                        Strategy
+                      </h3>
+                      <p className="mb-8 text-xl">
+                        Lets give them something to talk about. Lets give them a
+                        story worth sharing. Lets build your brand.{" "}
+                      </p>
+                    </div>
+                    <a
+                      className="relative mb-1 inline-block max-w-full font-bold"
+                      href="/capabilities/brand-strategy"
+                    >
+                      <div className="uppercase text-neutral-900" id="div-8">
+                        Learn More
+                      </div>
+                      <div className="absolute bottom-0 left-0 right-0 h-0.5 w-1/5 bg-neutral-900" />
+                    </a>
+                  </div>
+                </div>
+                <div className="w-96" id="div-9">
+                  <div
+                    className="relative h-[37.50rem] overflow-hidden"
+                    id="div-10"
+                  >
+                    <div
+                      className='absolute bottom-0 left-0 top-0 my-auto h-[120%] bg-[url("https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5eed360ed6642254e349b4c1_capabilities-identity.1920.jpg")] bg-cover'
+                      style={{
+                        backgroundPosition: "50% 50%",
+                      }}
+                    />
+                  </div>
+                  <div className="pr-10">
+                    <div className="my-4">
+                      <h3 className="mb-8 min-h-[0vw] text-[3.38rem] font-bold leading-none">
+                        Identity
+                      </h3>
+                      <p className="mb-8 text-xl">
+                        Your brand is unique and has an identity that sets you
+                        apart from everyone else.{" "}
+                      </p>
+                    </div>
+                    <a
+                      className="relative mb-1 inline-block max-w-full font-bold text-white"
+                      href="/capabilities/brand-identity"
+                    >
+                      <div className="uppercase text-neutral-900" id="div-11">
+                        Learn More
+                      </div>
+                      <div className="absolute bottom-0 left-0 right-0 h-0.5 w-1/5 bg-neutral-900" />
+                    </a>
+                  </div>
+                </div>
+                <div className="w-96" id="div-12">
+                  <div
+                    className="relative h-[37.50rem] overflow-hidden"
+                    id="div-13"
+                  >
+                    <div
+                      className='absolute bottom-0 left-0 top-0 my-auto h-[120%] bg-[url("https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f4549ec2590e22ab1deffc9_black-and-white-pencil.1920.jpg")] bg-cover'
+                      style={{
+                        backgroundPosition: "50% 50%",
+                      }}
+                    />
+                  </div>
+                  <div className="pr-10">
+                    <div className="my-4">
+                      <h3 className="mb-8 min-h-[0vw] text-[3.38rem] font-bold leading-none">
+                        Content
+                      </h3>
+                      <p className="mb-8 text-xl">
+                        Amplify your voice and be heard, be shared, be
+                        intentional. Generate great content for your audiences,
+                        big and small.{" "}
+                      </p>
+                    </div>
+                    <a
+                      className="relative mb-1 inline-block max-w-full font-bold text-white"
+                      href="/capabilities/brand-content"
+                    >
+                      <div className="uppercase text-neutral-900" id="div-14">
+                        Learn More
+                      </div>
+                      <div className="absolute bottom-0 left-0 right-0 h-0.5 w-1/5 bg-neutral-900" />
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className="pr-12" id="div-15">
+              <div
+                className="sticky h-screen items-center justify-center"
+                id="div-16"
+              >
+                <div className="sticky -mt-12" id="div-17">
+                  <h2 className="min-h-[0vw] text-[8.38rem] font-bold leading-none">
+                    Branding + Strategy
+                  </h2>
+                  <p className="mb-8 max-w-[37.50rem] text-4xl">
+                    Branding isnt rocket science. Its harder. Instead of
+                    machines and math, branding deals with feelings, intuitions,
+                    and reactions. We start by listening and let that shape our
+                    design process, with our clients as partners every step of
+                    the way.
+                    <br />
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/capabilities/page.tsx
+++ b/app/capabilities/page.tsx
@@ -1,9 +1,10 @@
 import { CapabilitiesHero } from "./components/CapabilitiesHero";
-
+import { CapabilitiesBranding } from "./components/CapabilitiesBranding";
 export default function Page() {
   return (
     <main>
       <CapabilitiesHero />
+      <CapabilitiesBranding />
     </main>
   );
 }


### PR DESCRIPTION
### TL;DR

Add a new `CapabilitiesBranding` component and integrate it into the capabilities page.

### What changed?

- Created `CapabilitiesBranding.tsx` component for showcasing branding and strategy capabilities.
- Updated `page.tsx` to include the new `CapabilitiesBranding` component after `CapabilitiesHero`.

### How to test?

1. Navigate to the capabilities page.
2. Verify the new branding and strategy section appears correctly, featuring strategy, identity, and content areas.

### Why make this change?

Enhance the capabilities page to provide a more comprehensive overview of the brand strategy services offered.

---

