### PR TITLE
feat(ui): add hero and prefooter to insights page

### DIFF
--- a/app/capabilities/components/CapabilitiesContent.tsx
+++ b/app/capabilities/components/CapabilitiesContent.tsx
@@ -3,7 +3,7 @@ export function CapabilitiesContent() {
     <>
       <div>
         <div
-          className="relative cursor-none items-center justify-center overflow-visible font-light text-neutral-900"
+          className="relative items-center justify-center overflow-visible font-light text-neutral-900"
           id="div-1"
         >
           <div className="absolute left-0 right-0 top-0 z-[1] h-[40vh] bg-neutral-900" />

--- a/app/capabilities/components/CapabilitiesWeb.tsx
+++ b/app/capabilities/components/CapabilitiesWeb.tsx
@@ -3,7 +3,7 @@ export function CapabilitiesWeb() {
     <>
       <div>
         <div
-          className="relative cursor-none items-center justify-center bg-neutral-900 font-light text-white"
+          className="relative items-center justify-center bg-neutral-900 font-light text-white"
           id="div-1"
         >
           <div className="absolute left-0 right-0 top-0 z-[1] h-[40vh] bg-white" />

--- a/app/insights/components/InsightsHero.tsx
+++ b/app/insights/components/InsightsHero.tsx
@@ -1,0 +1,25 @@
+export function InsightsHero() {
+  return (
+    <>
+      <div>
+        <div
+          className="flex flex-col content-stretch items-start justify-end bg-neutral-900 px-24 pb-24 pt-60 font-light text-white"
+          id="div-1"
+        >
+          <div
+            className="m-auto flex w-full max-w-[62.50rem] flex-grow auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto_auto] flex-col items-stretch justify-center gap-4 self-start font-bold"
+            id="div-2"
+          >
+            <div className="pb-5 text-center uppercase">+ Insights</div>
+            <h1 className="mx-0 my-3 mb-8 min-h-[0vw] text-center  text-[6.75rem] leading-none">
+              Their insights are simply...brilliant.
+            </h1>
+            <div className="pb-5 text-center uppercase text-neutral-400">
+              - Our Moms (probably)
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/insights/components/InsightsWonder.tsx
+++ b/app/insights/components/InsightsWonder.tsx
@@ -1,0 +1,27 @@
+export function InsightsWonder() {
+  return (
+    <>
+      <div>
+        <div
+          className="content-stretch items-start justify-start bg-neutral-900 px-24 py-36 font-light text-white"
+          id="div-1"
+        >
+          <div
+            className="m-auto content-stretch items-start justify-start px-24 py-36"
+            id="div-2"
+          >
+            <div className="pb-5 text-center font-bold uppercase">
+              + Its time to wonder
+            </div>
+            <h2 className="mb-8 min-h-[0vw] text-center text-[2.63rem] leading-none">
+              Brewww is a creative studio that finds the places where{" "}
+              <strong className="font-extrabold">needs</strong>,{" "}
+              <strong className="font-extrabold">stories</strong>, and{" "}
+              <strong className="font-extrabold">technology</strong> overlap.
+            </h2>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -1,0 +1,10 @@
+import { InsightsHero } from "./components/InsightsHero";
+import { InsightsWonder } from "./components/InsightsWonder";
+export default function Page() {
+  return (
+    <main>
+      <InsightsHero />
+      <InsightsWonder />
+    </main>
+  );
+}


### PR DESCRIPTION
### TL;DR
Added `InsightsHero` and `InsightsWonder` components to new insights page.

### What changed?
- Added `InsightsHero` component to provide a hero section for the Insights page.
- Added `InsightsWonder` component to provide a wonder section for the Insights page.
- Removed `cursor-none` class from certain divs in `CapabilitiesContent` and `CapabilitiesWeb` components.
- Updated the `insights` page to utilize the new `InsightsHero` and `InsightsWonder` components.

### How to test?
1. Navigate to the Insights page and verify that the hero and wonder sections are displayed correctly with appropriate styling.
2. Verify that the cursor behavior in the `CapabilitiesContent` and `CapabilitiesWeb` components works as expected after the removal of the `cursor-none` class. This is a remnant of the original Brewww 2020 website code.

### Why make this change?
To enhance the Insights page with new sections and fix cursor behavior in existing components.

---

