### PR TITLE
feat(ui): add initial static blog cards

### DIFF
--- a/app/insights/components/InsightsBody.tsx
+++ b/app/insights/components/InsightsBody.tsx
@@ -1,0 +1,243 @@
+export function InsightsBody() {
+  return (
+    <>
+      <div>
+        <div
+          className="relative content-stretch items-start justify-start bg-slate-50 px-24 py-12 font-light text-neutral-900"
+          id="div-1"
+        >
+          <div className="mb-12 flex items-center justify-between text-[2.13rem] leading-9">
+            <h3 className="min-h-[0vw]" id="h3-1">
+              Recent Posts
+            </h3>
+          </div>
+          <div className="relative font-bold">
+            <div
+              className="grid auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto_auto] gap-4"
+              id="div-2"
+            >
+              <a
+                className="inline-block w-full max-w-full auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto_auto] gap-4 overflow-hidden"
+                href="/insights/project-launch-ies-national-sustainable-lighting-by-design"
+              >
+                <div className="h-96 w-full overflow-hidden rounded-lg">
+                  <img
+                    className="inline-block h-full w-full max-w-full object-cover align-middle"
+                    src="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5fff5a156b619199f61e880f_IES%20Mark%20300x300.jpg"
+                    srcSet="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5fff5a156b619199f61e880f_IES%20Mark%20300x300-p-500.jpeg 500w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5fff5a156b619199f61e880f_IES%20Mark%20300x300-p-800.jpeg 800w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5fff5a156b619199f61e880f_IES%20Mark%20300x300-p-1080.jpeg 1080w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5fff5a156b619199f61e880f_IES%20Mark%20300x300.jpg 1251w"
+                  />
+                </div>
+                <div className="relative flex items-stretch justify-start pb-3 pt-5">
+                  <div className="relative">
+                    <div className="ml-auto">Branding</div>
+                    <div className="absolute bottom-[0.25rem] left-0 right-0 top-auto z-[-2] h-1 bg-orange-400" />
+                  </div>
+                </div>
+                <div className="relative">
+                  <h4 className="mb-8 min-h-[0vw] text-4xl font-light capitalize">
+                    Project Launch: IES National - Sustainable Lighting by
+                    Design
+                  </h4>
+                  <div className="absolute bottom-[-0.50rem] left-0 right-0 top-auto h-0.5 w-96 bg-orange-400" />
+                </div>
+              </a>
+              <a
+                className="inline-block w-full max-w-full auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto_auto] gap-4 overflow-hidden"
+                href="/insights/seo-without-ux-is-dead"
+              >
+                <div className="h-96 w-full overflow-hidden rounded-lg">
+                  <img
+                    className="inline-block h-full w-full max-w-full object-cover align-middle"
+                    src="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5fa772f9e1eb2524a6ff7e71_happy-yellow-wall.1920.jpg"
+                    srcSet="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5fa772f9e1eb2524a6ff7e71_happy-yellow-wall.1920-p-500.jpeg 500w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5fa772f9e1eb2524a6ff7e71_happy-yellow-wall.1920-p-1080.jpeg 1080w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5fa772f9e1eb2524a6ff7e71_happy-yellow-wall.1920-p-1600.jpeg 1600w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5fa772f9e1eb2524a6ff7e71_happy-yellow-wall.1920.jpg 1920w"
+                  />
+                </div>
+                <div className="relative flex items-stretch justify-start pb-3 pt-5">
+                  <div className="relative">
+                    <div className="ml-auto">Branding</div>
+                    <div className="absolute bottom-[0.25rem] left-0 right-0 top-auto z-[-2] h-1 bg-orange-400" />
+                  </div>
+                </div>
+                <div className="relative">
+                  <h4 className="mb-8 min-h-[0vw] text-4xl font-light capitalize">
+                    SEO (Without UX) Is Dead
+                  </h4>
+                  <div className="absolute bottom-[-0.50rem] left-0 right-0 top-auto h-0.5 w-96 bg-orange-400" />
+                </div>
+              </a>
+              <a
+                className="inline-block w-full max-w-full auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto_auto] gap-4 overflow-hidden"
+                href="/insights/the-importance-of-a-mobile-friendly-website-and-how-to-test-yours"
+              >
+                <div className="h-96 w-full overflow-hidden rounded-lg">
+                  <img
+                    className="inline-block h-full w-full max-w-full object-cover align-middle"
+                    src="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f629a4559811072bbfe7192_mobile-friendly-hero.1920.jpg"
+                    srcSet="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f629a4559811072bbfe7192_mobile-friendly-hero.1920-p-500.jpeg 500w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f629a4559811072bbfe7192_mobile-friendly-hero.1920-p-800.jpeg 800w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f629a4559811072bbfe7192_mobile-friendly-hero.1920-p-1080.jpeg 1080w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f629a4559811072bbfe7192_mobile-friendly-hero.1920.jpg 1280w"
+                  />
+                </div>
+                <div className="relative flex items-stretch justify-start pb-3 pt-5">
+                  <div className="relative">
+                    <div className="ml-auto">Web</div>
+                    <div className="absolute bottom-[0.25rem] left-0 right-0 top-auto z-[-2] h-1 bg-orange-400" />
+                  </div>
+                </div>
+                <div className="relative">
+                  <h4 className="mb-8 min-h-[0vw] text-4xl font-light capitalize">
+                    The Importance of a Mobile-Friendly Website (and How to Test
+                    Yours)
+                  </h4>
+                  <div className="absolute bottom-[-0.50rem] left-0 right-0 top-auto h-0.5 w-96 bg-orange-400" />
+                </div>
+              </a>
+              <a
+                className="inline-block w-full max-w-full auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto_auto] gap-4 overflow-hidden"
+                href="/insights/what-are-the-differences-between-branding-and-marketing"
+              >
+                <div className="h-96 w-full overflow-hidden rounded-lg">
+                  <img
+                    className="inline-block h-full w-full max-w-full object-cover align-middle"
+                    src="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f4ae76042e3d8ce344a2b23_mountain-and-couch.1920.jpg"
+                    srcSet="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f4ae76042e3d8ce344a2b23_mountain-and-couch.1920-p-1080.jpeg 1080w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f4ae76042e3d8ce344a2b23_mountain-and-couch.1920-p-1600.jpeg 1600w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f4ae76042e3d8ce344a2b23_mountain-and-couch.1920.jpg 1920w"
+                  />
+                </div>
+                <div className="relative flex items-stretch justify-start pb-3 pt-5">
+                  <div className="relative">
+                    <div className="ml-auto">Branding</div>
+                    <div className="absolute bottom-[0.25rem] left-0 right-0 top-auto z-[-2] h-1 bg-orange-400" />
+                  </div>
+                </div>
+                <div className="relative">
+                  <h4 className="mb-8 min-h-[0vw] text-4xl font-light capitalize">
+                    What Are the Differences Between Branding and Marketing?
+                  </h4>
+                  <div className="absolute bottom-[-0.50rem] left-0 right-0 top-auto h-0.5 w-96 bg-orange-400" />
+                </div>
+              </a>
+              <a
+                className="inline-block w-full max-w-full auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto_auto] gap-4 overflow-hidden"
+                href="/insights/savoring-the-sweetness-meet-the-leadership-of-brewww"
+              >
+                <div className="h-96 w-full overflow-hidden rounded-lg">
+                  <img
+                    className="inline-block h-full w-full max-w-full object-cover align-middle"
+                    src="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5de2f67a3719a10bf3e510ae_k%26c-bride-and-groom-smiling.JPG"
+                    srcSet="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5de2f67a3719a10bf3e510ae_k%26c-bride-and-groom-smiling-p-1080.jpeg 1080w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5de2f67a3719a10bf3e510ae_k%26c-bride-and-groom-smiling-p-1600.jpeg 1600w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5de2f67a3719a10bf3e510ae_k%26c-bride-and-groom-smiling.JPG 1920w"
+                  />
+                </div>
+                <div className="relative flex items-stretch justify-start pb-3 pt-5">
+                  <div className="relative">
+                    <div className="ml-auto">Studio</div>
+                    <div className="absolute bottom-[0.25rem] left-0 right-0 top-auto z-[-2] h-1 bg-orange-400" />
+                  </div>
+                </div>
+                <div className="relative">
+                  <h4 className="mb-8 min-h-[0vw] text-4xl font-light capitalize">
+                    Savoring the Sweetness: Meet the Leadership of Brewww
+                  </h4>
+                  <div className="absolute bottom-[-0.50rem] left-0 right-0 top-auto h-0.5 w-96 bg-orange-400" />
+                </div>
+              </a>
+              <a
+                className="inline-block w-full max-w-full auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto_auto] gap-4 overflow-hidden"
+                href="/insights/independence-from-boring-websites"
+              >
+                <div className="h-96 w-full overflow-hidden rounded-lg">
+                  <img
+                    className="inline-block h-full w-full max-w-full object-cover align-middle"
+                    src="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5e0e79e277ff441dde662479_website-liberty.jpg"
+                    srcSet="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5e0e79e277ff441dde662479_website-liberty-p-800.jpeg 800w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5e0e79e277ff441dde662479_website-liberty-p-1080.jpeg 1080w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5e0e79e277ff441dde662479_website-liberty-p-1600.jpeg 1600w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5e0e79e277ff441dde662479_website-liberty.jpg 1920w"
+                  />
+                </div>
+                <div className="relative flex items-stretch justify-start pb-3 pt-5">
+                  <div className="relative">
+                    <div className="ml-auto">Web</div>
+                    <div className="absolute bottom-[0.25rem] left-0 right-0 top-auto z-[-2] h-1 bg-orange-400" />
+                  </div>
+                </div>
+                <div className="relative">
+                  <h4 className="mb-8 min-h-[0vw] text-4xl font-light capitalize">
+                    Independence from Boring Websites
+                  </h4>
+                  <div className="absolute bottom-[-0.50rem] left-0 right-0 top-auto h-0.5 w-96 bg-orange-400" />
+                </div>
+              </a>
+              <a
+                className="inline-block w-full max-w-full auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto_auto] gap-4 overflow-hidden"
+                href="/insights/taking-on-the-behemoth"
+              >
+                <div className="h-96 w-full overflow-hidden rounded-lg">
+                  <img
+                    className="inline-block h-full w-full max-w-full object-cover align-middle"
+                    src="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5ebacde3b50a8fa3494800c1_giant-squid.1920.jpg"
+                    srcSet="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5ebacde3b50a8fa3494800c1_giant-squid.1920-p-1080.jpeg 1080w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5ebacde3b50a8fa3494800c1_giant-squid.1920-p-1600.jpeg 1600w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5ebacde3b50a8fa3494800c1_giant-squid.1920.jpg 1920w"
+                  />
+                </div>
+                <div className="relative flex items-stretch justify-start pb-3 pt-5">
+                  <div className="relative">
+                    <div className="ml-auto">Studio</div>
+                    <div className="absolute bottom-[0.25rem] left-0 right-0 top-auto z-[-2] h-1 bg-orange-400" />
+                  </div>
+                </div>
+                <div className="relative">
+                  <h4 className="mb-8 min-h-[0vw] text-4xl font-light capitalize">
+                    Taking on the Behemoth
+                  </h4>
+                  <div className="absolute bottom-[-0.50rem] left-0 right-0 top-auto h-0.5 w-96 bg-orange-400" />
+                </div>
+              </a>
+              <a
+                className="inline-block w-full max-w-full auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto_auto] gap-4 overflow-hidden"
+                href="/insights/remembering-your-first-birthday"
+              >
+                <div className="h-96 w-full overflow-hidden rounded-lg">
+                  <img
+                    className="inline-block h-full w-full max-w-full object-cover align-middle"
+                    src="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5e0e79bf930a8b7434ca51c5_your-first-birthday.jpg"
+                    srcSet="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5e0e79bf930a8b7434ca51c5_your-first-birthday-p-800.jpeg 800w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5e0e79bf930a8b7434ca51c5_your-first-birthday-p-1080.jpeg 1080w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5e0e79bf930a8b7434ca51c5_your-first-birthday.jpg 1525w"
+                  />
+                </div>
+                <div className="relative flex items-stretch justify-start pb-3 pt-5">
+                  <div className="relative">
+                    <div className="ml-auto">Studio</div>
+                    <div className="absolute bottom-[0.25rem] left-0 right-0 top-auto z-[-2] h-1 bg-orange-400" />
+                  </div>
+                </div>
+                <div className="relative">
+                  <h4 className="mb-8 min-h-[0vw] text-4xl font-light capitalize">
+                    Remembering your first birthday
+                  </h4>
+                  <div className="absolute bottom-[-0.50rem] left-0 right-0 top-auto h-0.5 w-96 bg-orange-400" />
+                </div>
+              </a>
+              <a
+                className="inline-block w-full max-w-full auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto_auto] gap-4 overflow-hidden"
+                href="/insights/hello-there-how-do-ya-brewww"
+              >
+                <div className="h-96 w-full overflow-hidden rounded-lg">
+                  <img
+                    className="inline-block h-full w-full max-w-full object-cover align-middle"
+                    src="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5e0e799dd4243bcfd42f7ea2_brewww-pour-over.jpg"
+                    srcSet="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5e0e799dd4243bcfd42f7ea2_brewww-pour-over-p-1080.jpeg 1080w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5e0e799dd4243bcfd42f7ea2_brewww-pour-over-p-1600.jpeg 1600w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5e0e799dd4243bcfd42f7ea2_brewww-pour-over.jpg 1920w"
+                  />
+                </div>
+                <div className="relative flex items-stretch justify-start pb-3 pt-5">
+                  <div className="relative">
+                    <div className="ml-auto">Studio</div>
+                    <div className="absolute bottom-[0.25rem] left-0 right-0 top-auto z-[-2] h-1 bg-orange-400" />
+                  </div>
+                </div>
+                <div className="relative">
+                  <h4 className="mb-8 min-h-[0vw] text-4xl font-light capitalize">
+                    Hello there! How do ya brewww?
+                  </h4>
+                  <div className="absolute bottom-[-0.50rem] left-0 right-0 top-auto h-0.5 w-96 bg-orange-400" />
+                </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -1,9 +1,11 @@
 import { InsightsHero } from "./components/InsightsHero";
+import { InsightsBody } from "./components/InsightsBody";
 import { InsightsWonder } from "./components/InsightsWonder";
 export default function Page() {
   return (
     <main>
       <InsightsHero />
+      <InsightsBody />
       <InsightsWonder />
     </main>
   );


### PR DESCRIPTION
### TL;DR

This pull request introduces a new `InsightsBody` component in the `insights` section of the app.

### What changed?

- **New file**: `app/insights/components/InsightsBody.tsx`: Defines the new `InsightsBody` component which renders a responsive grid layout showcasing various insightful posts with images and titles.
- **Updated file**: `app/insights/page.tsx`: Integrates the `InsightsBody` component into the main insights page.

### How to test?

1. Navigate to the insights page in the app.
2. Check for the presence of the new grid layout under the hero section.
3. Verify that the layout is responsive and that each post correctly links to its respective detail page.

### Why make this change?

This change aims to enhance the insights page by adding a visually appealing grid layout of posts, making it easier for users to browse and select articles of interest. This static structure will soon be made dynamic. 

---

