### PR TITLE
feat(ui): add static featured posts to temp home page

### DIFF
--- a/app/dev/components/HomePosts.tsx
+++ b/app/dev/components/HomePosts.tsx
@@ -1,0 +1,192 @@
+export function HomePosts() {
+  return (
+    <>
+      <div>
+        <div>
+          <div
+            className="content-stretch items-start justify-start bg-neutral-900 px-24 py-12 font-light text-white"
+            id="div-1"
+          >
+            <div
+              className="m-auto flex w-full max-w-[62.50rem] flex-grow auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto_auto] flex-col items-stretch justify-center gap-4 self-start"
+              id="div-2"
+            >
+              <div className="overflow-hidden font-bold uppercase">
+                <div className="flex flex-col items-start">
+                  <div className="pb-5 text-center">
+                    <span className="text-orange-400">/</span> Featured insights
+                  </div>
+                </div>
+              </div>
+              <div className="overflow-hidden text-[3.63rem] leading-none">
+                <div className="flex flex-col items-start">
+                  <h2 className="min-h-[0vw]">
+                    Branding, tech, and business{" "}
+                    <strong className="font-extrabold">insights.</strong>
+                  </h2>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div
+          className="relative cursor-none content-stretch items-start justify-start bg-neutral-900 px-24 py-36 font-light text-white"
+          id="div-1"
+        >
+          <div
+            className="relative m-auto flex w-full max-w-[100.00rem] flex-grow auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto_auto] flex-col items-stretch justify-center self-start font-bold"
+            id="div-2"
+          >
+            <div
+              className="m-auto grid auto-cols-fr grid-cols-[.5fr_1fr_1fr_1fr_1fr_.5fr_.5fr_1fr_1fr_1fr_1fr_.5fr] grid-rows-[auto_auto_auto_auto_auto_auto_auto_auto_auto_auto_auto_auto] gap-[0.63rem]"
+              id="div-3"
+            >
+              <div
+                className="relative col-start-1 col-end-6 row-start-1 row-end-5"
+                id="div-4"
+                style={{
+                  gridArea: "1/1/5/6",
+                }}
+              >
+                <div className="auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto_auto]">
+                  <a
+                    className="inline-block max-w-full"
+                    href="/insights/project-launch-ies-national-sustainable-lighting-by-design"
+                  >
+                    <div className="h-96 w-full overflow-hidden rounded-md">
+                      <img
+                        className="inline-block h-full w-full max-w-full object-cover align-middle"
+                        src="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5fff5a156b619199f61e880f_IES%20Mark%20300x300.jpg"
+                        srcSet="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5fff5a156b619199f61e880f_IES%20Mark%20300x300-p-500.jpeg 500w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5fff5a156b619199f61e880f_IES%20Mark%20300x300-p-800.jpeg 800w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5fff5a156b619199f61e880f_IES%20Mark%20300x300-p-1080.jpeg 1080w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5fff5a156b619199f61e880f_IES%20Mark%20300x300.jpg 1251w"
+                      />
+                    </div>
+                    <div className="relative flex items-stretch justify-start pb-3 pt-5">
+                      <div className="relative">
+                        <div className="ml-auto">Branding</div>
+                        <div className="absolute bottom-[0.25rem] left-0 right-0 top-auto z-[-2] h-1 bg-orange-400" />
+                      </div>
+                    </div>
+                    <div className="relative">
+                      <h4 className="min-h-[0vw] text-4xl">
+                        Project Launch: IES National - Sustainable Lighting by
+                        Design
+                      </h4>
+                      <div className="absolute bottom-[-0.50rem] left-0 right-0 top-auto h-0.5 w-96 bg-orange-400" />
+                    </div>
+                  </a>
+                </div>
+              </div>
+              <div
+                className="relative col-start-7 col-end-12 row-start-2 row-end-6"
+                id="div-5"
+                style={{
+                  gridArea: "2/7/6/12",
+                }}
+              >
+                <div className="auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto_auto]">
+                  <a
+                    className="inline-block max-w-full"
+                    href="/insights/the-importance-of-a-mobile-friendly-website-and-how-to-test-yours"
+                  >
+                    <div className="h-96 w-full overflow-hidden rounded-md">
+                      <img
+                        className="inline-block h-full w-full max-w-full object-cover align-middle"
+                        src="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f629a4559811072bbfe7192_mobile-friendly-hero.1920.jpg"
+                        srcSet="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f629a4559811072bbfe7192_mobile-friendly-hero.1920-p-500.jpeg 500w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f629a4559811072bbfe7192_mobile-friendly-hero.1920-p-800.jpeg 800w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f629a4559811072bbfe7192_mobile-friendly-hero.1920-p-1080.jpeg 1080w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f629a4559811072bbfe7192_mobile-friendly-hero.1920.jpg 1280w"
+                      />
+                    </div>
+                    <div className="relative flex items-stretch justify-start pb-3 pt-5">
+                      <div className="relative">
+                        <div className="ml-auto">Web</div>
+                        <div className="absolute bottom-[0.25rem] left-0 right-0 top-auto z-[-2] h-1 bg-orange-400" />
+                      </div>
+                    </div>
+                    <div className="relative">
+                      <h4 className="min-h-[0vw] text-4xl">
+                        The Importance of a Mobile-Friendly Website (and How to
+                        Test Yours)
+                      </h4>
+                      <div className="absolute bottom-[-0.50rem] left-0 right-0 top-auto h-0.5 w-96 bg-orange-400" />
+                    </div>
+                  </a>
+                </div>
+              </div>
+              <div
+                className="relative col-start-2 col-end-7 row-start-7"
+                id="div-6"
+                style={{
+                  gridArea: "7/2/11/7",
+                  gridRowEnd: "11",
+                }}
+              >
+                <div className="auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto_auto]">
+                  <a
+                    className="inline-block max-w-full"
+                    href="/insights/what-are-the-differences-between-branding-and-marketing"
+                  >
+                    <div className="h-96 w-full overflow-hidden rounded-md">
+                      <img
+                        className="inline-block h-full w-full max-w-full object-cover align-middle"
+                        src="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f4ae76042e3d8ce344a2b23_mountain-and-couch.1920.jpg"
+                        srcSet="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f4ae76042e3d8ce344a2b23_mountain-and-couch.1920-p-1080.jpeg 1080w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f4ae76042e3d8ce344a2b23_mountain-and-couch.1920-p-1600.jpeg 1600w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5f4ae76042e3d8ce344a2b23_mountain-and-couch.1920.jpg 1920w"
+                      />
+                    </div>
+                    <div className="relative flex items-stretch justify-start pb-3 pt-5">
+                      <div className="relative">
+                        <div className="ml-auto">Branding</div>
+                        <div className="absolute bottom-[0.25rem] left-0 right-0 top-auto z-[-2] h-1 bg-orange-400" />
+                      </div>
+                    </div>
+                    <div className="relative">
+                      <h4 className="min-h-[0vw] text-4xl">
+                        What Are the Differences Between Branding and Marketing?
+                      </h4>
+                      <div className="absolute bottom-[-0.50rem] left-0 right-0 top-auto h-0.5 w-96 bg-orange-400" />
+                    </div>
+                  </a>
+                </div>
+              </div>
+              <div
+                className="relative col-start-8 col-end-13"
+                id="div-7"
+                style={{
+                  gridArea: "8/8/12/13",
+                  gridRowEnd: "12",
+                  gridRowStart: "8",
+                }}
+              >
+                <div className="auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto_auto]">
+                  <a
+                    className="inline-block max-w-full"
+                    href="/insights/savoring-the-sweetness-meet-the-leadership-of-brewww"
+                  >
+                    <div className="h-96 w-full overflow-hidden rounded-md">
+                      <img
+                        className="inline-block h-full w-full max-w-full object-cover align-middle"
+                        src="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5de2f67a3719a10bf3e510ae_k%26c-bride-and-groom-smiling.JPG"
+                        srcSet="https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5de2f67a3719a10bf3e510ae_k%26c-bride-and-groom-smiling-p-1080.jpeg 1080w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5de2f67a3719a10bf3e510ae_k%26c-bride-and-groom-smiling-p-1600.jpeg 1600w, https://cdn.prod.website-files.com/5dad037b65b2d9bc97118b77/5de2f67a3719a10bf3e510ae_k%26c-bride-and-groom-smiling.JPG 1920w"
+                      />
+                    </div>
+                    <div className="relative flex items-stretch justify-start pb-3 pt-5">
+                      <div className="relative">
+                        <div className="ml-auto">Studio</div>
+                        <div className="absolute bottom-[0.25rem] left-0 right-0 top-auto z-[-2] h-1 bg-orange-400" />
+                      </div>
+                    </div>
+                    <div className="relative">
+                      <h4 className="min-h-[0vw] text-4xl">
+                        Savoring the Sweetness: Meet the Leadership of Brewww
+                      </h4>
+                      <div className="absolute bottom-[-0.50rem] left-0 right-0 top-auto h-0.5 w-96 bg-orange-400" />
+                    </div>
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/dev/page.tsx
+++ b/app/dev/page.tsx
@@ -1,6 +1,7 @@
 import { HomeHero } from "./components/HomeHero";
 import { HomeFeat } from "./components/HomeFeat";
 import { HomeFocus } from "./components/HomeFocus";
+import { HomePosts } from "./components/HomePosts";
 
 export default function Page() {
   return (
@@ -8,6 +9,7 @@ export default function Page() {
       <HomeHero />
       <HomeFeat />
       <HomeFocus />
+      <HomePosts />
     </main>
   );
 }


### PR DESCRIPTION
### TL;DR

This PR introduces the `HomePosts` component to the homepage, enabling the display of featured insights articles, complete with images, categories, and titles.

### What changed?

- Added `HomePosts` component in `HomePosts.tsx`
- Integrated `HomePosts` component into the main page structure in `page.tsx`

### How to test?

1. Navigate to the homepage.
2. Verify that the `HomePosts` section appears with correct images, categories, and titles.

### Why make this change?

To enhance the homepage by adding a section that highlights featured insights articles, providing users with valuable content and improving user engagement.

---

