### PR TITLE
build(deps): bump pretter-plugin-tailwindcss to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "eslint-config-next": "14.2.4",
         "postcss": "^8",
         "prettier": "^3.2.5",
-        "prettier-plugin-tailwindcss": "^0.5.13",
+        "prettier-plugin-tailwindcss": "^0.6.4",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
       }
@@ -5265,10 +5265,11 @@
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.14.tgz",
-      "integrity": "sha512-Puaz+wPUAhFp8Lo9HuciYKM2Y2XExESjeT+9NQoVFXZsPPnc9VYss2SpxdQ6vbatmt8/4+SN0oe0I1cPDABg9Q==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.4.tgz",
+      "integrity": "sha512-3vhbIvlKyAWPaw9bUr2cw6M1BGx2Oy9CCLJyv+nxEiBGCTcL69WcAz2IFMGqx8IXSzQCInGSo2ujAByg9poHLQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.21.3"
       },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eslint-config-next": "14.2.4",
     "postcss": "^8",
     "prettier": "^3.2.5",
-    "prettier-plugin-tailwindcss": "^0.5.13",
+    "prettier-plugin-tailwindcss": "^0.6.4",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
   }


### PR DESCRIPTION
### TL;DR
Updated `prettier-plugin-tailwindcss` to version `0.6.4` from `0.5.13`.

### What changed?

- Bumped `prettier-plugin-tailwindcss` version in `package.json` and `package-lock.json`.
- Updated relevant hashes and metadata in `package-lock.json`.

### How to test?
1. Run `npm install` to update the dependencies.
2. Run `prettier` and ensure that it works as expected with TailwindCSS classes.
3. Check for any lint or formatting errors.

### Why make this change?
Keeping dependencies up to date ensures that the project benefits from the latest features, bug fixes, and performance improvements. The newer version likely includes important updates and improvements.

---

