### PR TITLE
feat(ui): add initial reasons section on why us page

### DIFF
--- a/src/app/(app)/why-us/WhyHeroNumbers.tsx
+++ b/src/app/(app)/why-us/WhyHeroNumbers.tsx
@@ -1,0 +1,50 @@
+export function WhyHeroNumbers() {
+  return (
+    <div className="grid w-full grid-cols-3 gap-x-20 bg-black px-6 py-10 font-light text-white">
+      <div className="mb-10 pb-10 min-[1000px]:mb-0 min-[1000px]:pb-0">
+        <h2 className="mb-6 text-[2.63rem] leading-none min-[1000px]:mb-8 min-[1000px]:max-w-[84%]">
+          Brand Strategy
+        </h2>
+        <p className="text-lg text-zinc-400">
+          Strategy underpins everything we brewww, and we consider every
+          touchpoint of your brand. From buttons to billboards, we aim for a
+          strategic narrative that helps tell your story in a way that
+          resonates. Our brands are empowered for now, and ready for what's
+          next.
+        </p>
+        <div className="mt-6 text-[10.63rem] leading-none min-[1000px]:mt-12">
+          01
+        </div>
+      </div>
+      <div className="mb-10 pb-10 min-[1000px]:mb-0 min-[1000px]:pb-0">
+        <h2 className="mb-6 text-[2.63rem] leading-none min-[1000px]:mb-8 min-[1000px]:max-w-[84%]">
+          Design Systems
+        </h2>
+        <p className="text-lg text-zinc-400">
+          Design goes beyond pixels and color palletes - it needs a home and a
+          structure. We build design systems that echo across print, social, and
+          web. We seek to empower marketing teams and owners to utilize their
+          branding to the fullest extent. We aim for the atomic, solving the
+          now, and adaptable for tomorrow. Made for your audience to help
+          recognize who you are.
+        </p>
+        <div className="mt-6 text-[10.63rem] leading-none min-[1000px]:mt-12">
+          02
+        </div>
+      </div>
+      <div>
+        <h2 className="mb-6 text-[2.63rem] leading-none min-[1000px]:mb-8 min-[1000px]:max-w-[84%]">
+          Digital Execution
+        </h2>
+        <p className="text-lg text-zinc-400">
+          Our web team builds SEO optimised CMS websites in either Webflow or
+          Next: giving your team a drop-dead simple to use system to update
+          content, drive growth, and create a unique experience for your users.
+        </p>
+        <div className="mt-6 text-[10.63rem] leading-none min-[1000px]:mt-12">
+          03
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/why-us/page.tsx
+++ b/src/app/(app)/why-us/page.tsx
@@ -1,8 +1,10 @@
 import { WhyHero } from "./WhyHero";
+import { WhyHeroNumbers } from "./WhyHeroNumbers";
 export default function Page() {
   return (
     <main>
       <WhyHero />
+      <WhyHeroNumbers />
     </main>
   );
 }


### PR DESCRIPTION
### TL;DR

Added the `WhyHeroNumbers` component to the `why-us` page.

### What changed?

The `WhyHeroNumbers` component was introduced to display brand strategy, design systems, and digital execution sections.

### How to test?

1. Navigate to the `why-us` page.
2. Observe the new `WhyHeroNumbers` section displaying three sections: Brand Strategy, Design Systems, and Digital Execution.

### Why make this change?

This change was made to enhance the content and layout of the `why-us` page, providing visitors with detailed insights into our offerings and capabilities.

---

