### PR TITLE
feat(ui): add initial reason cards to why us page

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+<url><loc>https://brewww.studio</loc><changefreq>daily</changefreq><priority>0.8</priority></url>
 <url><loc>https://brewww.studio/about</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/contact</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://brewww.studio/why-us</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://brewww.studio/insights</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://brewww.studio/capabilities</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://brewww.studio</loc><changefreq>daily</changefreq><priority>0.8</priority></url>
 </urlset>

--- a/src/app/(app)/why-us/WhyHeroNumbers.tsx
+++ b/src/app/(app)/why-us/WhyHeroNumbers.tsx
@@ -9,7 +9,7 @@ export function WhyHeroNumbers() {
           Strategy underpins everything we brewww, and we consider every
           touchpoint of your brand. From buttons to billboards, we aim for a
           strategic narrative that helps tell your story in a way that
-          resonates. Our brands are empowered for now, and ready for what's
+          resonates. Our brands are empowered for now, and ready for what is
           next.
         </p>
         <div className="mt-6 text-[10.63rem] leading-none min-[1000px]:mt-12">

--- a/src/app/(app)/why-us/WhyReasons.tsx
+++ b/src/app/(app)/why-us/WhyReasons.tsx
@@ -1,0 +1,56 @@
+export function WhyReasons() {
+  return (
+    <div className="mx-auto w-full max-w-6xl bg-black px-6 py-16 font-light text-white">
+      <h2 className="mb-10 text-center text-3xl leading-none">Why Us</h2>
+      <ul className="grid gap-10 border-t-2 border-neutral-600 pt-10 sm:grid-cols-2 lg:grid-cols-3">
+        <li className="space-y-2">
+          <div className="text-lg">🙅‍♂️ No Ego, Just Talent</div>
+          <div className="text-sm text-neutral-400">
+            We foster a collaborative and ego-free environment, where the best
+            ideas thrive, and our team's collective talent shines.
+          </div>
+        </li>
+        <li className="space-y-2">
+          <div className="text-lg">🧠 Strategy First, Design Second</div>
+          <div className="text-sm text-neutral-400">
+            Our process begins with a deep understanding of your business goals
+            and target audience, ensuring our designs are strategic and
+            purposeful.
+          </div>
+        </li>
+        <li className="space-y-2">
+          <div className="text-lg">🚀 Client Empowerment</div>
+          <div className="text-sm text-neutral-400">
+            We equip you with the tools and knowledge to succeed independently,
+            while remaining available for support whenever you need us.
+          </div>
+        </li>
+        <li className="space-y-2">
+          <div className="text-lg">
+            🤝 True Collaboration, Not Just Execution
+          </div>
+          <div className="text-sm text-neutral-400">
+            We see ourselves as an extension of your team, working alongside you
+            in a collaborative process to bring your vision to life.
+          </div>
+        </li>
+        <li className="space-y-2">
+          <div className="text-lg">🗣️ Honesty and Transparency</div>
+          <div className="text-sm text-neutral-400">
+            We value open communication and honesty above all else, providing
+            you with candid feedback and realistic expectations throughout our
+            partnership.
+          </div>
+        </li>
+        <li className="space-y-2">
+          <div className="text-lg">💪 Passion and Hard Work</div>
+          <div className="text-sm text-neutral-400">
+            Our team is driven by a passion for creating exceptional work and a
+            commitment to putting in the hard work necessary to achieve
+            outstanding results.
+          </div>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/src/app/(app)/why-us/page.tsx
+++ b/src/app/(app)/why-us/page.tsx
@@ -1,10 +1,12 @@
 import { WhyHero } from "./WhyHero";
 import { WhyHeroNumbers } from "./WhyHeroNumbers";
+import { WhyReasons } from "./WhyReasons";
 export default function Page() {
   return (
     <main>
       <WhyHero />
       <WhyHeroNumbers />
+      <WhyReasons />
     </main>
   );
 }


### PR DESCRIPTION
### TL;DR

- Added a new `WhyReasons` component to the `why-us` page
- Updated `sitemap.xml` to include new paths

### What changed?

- Introduced a new component `WhyReasons` that lists reasons to choose the service, on the `why-us` page.
- Updated `sitemap.xml` to reflect new and modified URLs.
- Fixed a minor typo in `WhyHeroNumbers` component text.

### How to test?

1. Navigate to the `why-us` page.
2. Verify the new section with reasons is displayed correctly.
3. Fetch and validate the `sitemap.xml` for correctness of URLs.
4. Ensure there are no typos in the `WhyHeroNumbers` component.

### Why make this change?

Enhance the `why-us` page with compelling reasons for clients to choose the service, and ensure the sitemap is up-to-date to improve SEO.

---

