### PR TITLE
feat(data): add initial client project structure

### DIFF
--- a/src/app/data/projects/st-john-the-evangelist.json
+++ b/src/app/data/projects/st-john-the-evangelist.json
@@ -1,0 +1,14 @@
+{
+  "id": "FL-SJE",
+  "client": "Saint John the Evangelist",
+  "location": "Panama City, FL",
+  "year": "2024",
+  "title": "A Dynamic School of Prayer",
+  "slug": "dynamic-catholic-church-website",
+  "category": ["strategy", "branding", "website", "design"],
+  "services": ["branding", "web design", "content strategy", "photography"],
+  "industry": ["church"],
+  "thumbnail": "url-to-thumbnail-image",
+  "heroImage": "url-to-hero-image",
+  "liveUrl": "https://www.saintjohnpc.org"
+}


### PR DESCRIPTION
TL;DR

Add St John the Evangelist project data to the projects list.

### What changed?

- Created `st-john-the-evangelist.json` file in `src/app/data/projects/`
- Added client details: `id`, `client`, `location`, `year`, `title`, `slug`, `category`, `services`, `industry`, `thumbnail`, `heroImage`, `liveUrl`

### How to test?
1. Ensure the `st-john-the-evangelist.json` file is present in the `src/app/data/projects/` directory.
2. Verify that all fields contain correct and relevant data.
3. Visit the `liveUrl` to confirm it is correct and points to St John the Evangelist.

### Why make this change?

This change is necessary to begin to add (and shape) the data structure of client projects and case studies. This prep work will open up the site in future updates for displaying the information on the front end. 

---

