### PR TITLE
feat(data): add challenge, insight, strategy, solution sections to client data

### DIFF
--- a/src/app/data/projects/st-john-the-evangelist.json
+++ b/src/app/data/projects/st-john-the-evangelist.json
@@ -10,5 +10,36 @@
   "industry": ["church"],
   "thumbnail": "url-to-thumbnail-image",
   "heroImage": "url-to-hero-image",
-  "liveUrl": "https://www.saintjohnpc.org"
+  "liveUrl": "https://www.saintjohnpc.org",
+  "seo": {
+    "title": "Dynamic School of Prayer - Brewww Studio",
+    "description": "Discover how Saint John the Evangelist Catholic Church transformed their website into a dynamic school of prayer with Brewww Studio."
+  },
+  "sections": [
+    {
+      "type": "challenge",
+      "title": "Creating an Engaging, Dynamic Website for a Catholic Church",
+      "content": "Saint John the Evangelist is a Catholic Church in Panama City with a rich tradition. The pastor, Fr. Thomas Kennell, approached us to consider a website rebuild. Initially, the project focus was just to bring them up to date and move past their static and out-of-date Squarespace website. However, through our discovery process, more was desired. Often in the Catholic Church, people in the pews 'graduate' from their faith after confirmation, thinking there is little left to learn, and engagement drops. The pastor envisioned the parish (and its website) as a school of prayer, where education on the faith could exist in every element of parish life, continually educating the parish on 'why' everything is done. Another challenge was they had pretty much no content or photography on their site. Everything would need to be generated."
+    },
+    {
+      "type": "insight",
+      "title": "Key Insight",
+      "content": "If someone wants to learn more about their Catholic faith, they rarely go to their parish website, which exists primarily to serve the bulletin and inform about events. But why isn't their parish the best starting point for them to not only be aware of events but also learn about their faith? This gap presented a significant opportunity."
+    },
+    {
+      "type": "strategy",
+      "title": "Our Strategy",
+      "content": "We aimed to build a beautiful website that echoes the pastoral vision as a 'school of prayer', dynamically changing with the liturgical season. This involved creating engaging content, generating new photography, and ensuring the site was a resource for both information and education."
+    },
+    {
+      "type": "solution",
+      "title": "Solution at a Glance",
+      "content": "Our solution was to create a dynamic, visually appealing website that serves as a living bulletin and a school of prayer. The site is designed to change with the liturgical seasons, providing fresh content and educational resources to keep parishioners engaged.",
+      "highlights": [
+        "Dynamic content that changes with the liturgical seasons",
+        "Engaging educational resources",
+        "New photography and visual elements"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
### TL;DR
Expanded the JSON data structure for projects to include more fields, sections, and SEO data. 

### What was added?
- live URL
- SEO information, 
- detailed sections covering challenges, insights, strategy, and solutions. 

### How to Test
You can navigate to /data/projects/st-john-the-evangelist.json to make sure the first draft of the project is there. 

### Why make this change? 
While developing the structure of case studies, more fields feel obvious to include to help the end user better understand the challenges we faced and how we overcame those challenges. This will continue to evolve as completed project assets are developed and included in the project. 
