### PR TITLE
feat(data): add initial Project Light Ministries project data

### DIFF
--- a/src/app/data/projects/project-light-ministries.json
+++ b/src/app/data/projects/project-light-ministries.json
@@ -1,0 +1,46 @@
+{
+  "id": "NC-PLM",
+  "client": "Project Light Ministries",
+  "location": "Raleigh, NC",
+  "year": "2020",
+  "title": "Illuminating Faith Through Authentic Storytelling",
+  "slug": "authentic-faith-based-media",
+  "category": ["strategy", "branding", "website", "design"],
+  "services": ["branding", "web design", "content strategy", "photography"],
+  "industry": ["non-profit", "media"],
+  "thumbnail": "url-to-thumbnail-image",
+  "heroImage": "https://assets-global.website-files.com/6399b4d7a8a9b7f2f7b2e9b5/63a0c5c5a8a9b7f2f7b2e9b6_Project%20Light%20Ministries%20Hero%20Image.jpg",
+  "liveUrl": "https://www.projectlightministries.com/",
+  "seo": {
+    "title": "Authentic Faith-Based Media - Brewww Studio",
+    "description": "Discover how Project Light Ministries' brand and website were transformed to foster authentic conversations through faith-based media with Brewww Studio."
+  },
+  "sections": [
+    {
+      "type": "challenge",
+      "title": "Fostering Authentic Conversations Through Media",
+      "content": "Project Light Ministries, founded by two youth ministers and mothers, had a vision to create resources that build trust, inspire vulnerability, and speak truth. Their challenge was to develop a brand and website that could effectively communicate this mission and showcase their films, retreats, and consulting services. They needed a platform that would not only present their content but also encourage authentic conversations and community building in a culture filled with confusing and conflicting messages."
+    },
+    {
+      "type": "insight",
+      "title": "Key Insight",
+      "content": "In a world where many feel isolated and misunderstood, there's a profound need for authentic, relatable faith-based content. By leveraging the power of storytelling through film and personal experiences, Project Light Ministries could create a space for genuine conversations and spiritual growth, meeting people wherever they are in their journey."
+    },
+    {
+      "type": "strategy",
+      "title": "Our Strategy",
+      "content": "We aimed to create a brand identity and website that reflects Project Light Ministries' commitment to authenticity and vulnerability. The strategy involved developing a clean, modern design that showcases their films and resources while emphasizing the power of personal stories. We focused on creating a user-friendly platform that not only presents their content but also encourages engagement and fosters a sense of community."
+    },
+    {
+      "type": "solution",
+      "title": "Solution at a Glance",
+      "content": "Our solution was to design a visually engaging website and brand identity that effectively communicates Project Light Ministries' mission of creating authentic conversations through media. The site features clear navigation, compelling content, and beautiful visuals that reflect their commitment to storytelling and community building.",
+      "highlights": [
+        "Clean, modern design with intuitive navigation",
+        "Engaging content sections highlighting films, retreats, and consulting services",
+        "Integration of multimedia elements to showcase storytelling",
+        "Emphasis on authenticity and community building throughout the site"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### TL;DR
Set up a new JSON data entry for the Project Light Ministries project, adding initial case study data. 

### What was added?
- client information
- location
- year
- project title
- slug 
- categories
- services provided
- industry
- images,
- live URL
- SEO information, 
- detailed sections covering challenges, insights, strategy, and solutions. 

### How to Test
You can navigate to /data/projects/project-light-ministries.json to make sure the first draft of the project is there. 

### Why make this change? 
Case studies take time to develop, and an initial version, a first draft, needs to be established until further details are written and the case study detail page is created. Then, further improvements to the case study with more pictures, details, and engaging copy will happen. 