### PR TITLE
feat(ui): add initial work detail template page

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,10 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://brewww.studio/why-us</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://brewww.studio/capabilities</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://brewww.studio</loc><changefreq>daily</changefreq><priority>0.8</priority></url>
+<url><loc>https://brewww.studio/work</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://brewww.studio/insights</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://brewww.studio/contact</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://brewww.studio/capabilities</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/why-us</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio</loc><changefreq>daily</changefreq><priority>0.8</priority></url>
 <url><loc>https://brewww.studio/about</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://brewww.studio/work</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/work/concrete-catholic-faith-media</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/work/custom-home-design-san-antonio</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/work/led-lighting-solutions</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/work/reentry-home-for-ex-offenders</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/work/joyful-wedding-celebration</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/work/faith-and-fitness-online-community</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/work/authentic-faith-based-media</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/work/modern-catholic-school-website</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/work/acoustical-ceiling-installation</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/work/catholic-church-discipleship-pathway</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/work/dynamic-catholic-church-website</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/app/(app)/work/WorkGrid.tsx
+++ b/src/app/(app)/work/WorkGrid.tsx
@@ -1,35 +1,5 @@
-import fs from "fs";
-import path from "path";
 import { WorkCard } from "@/app/components/WorkCard";
-
-interface Project {
-  id: string;
-  client: string;
-
-  title: string;
-  thumbnail: string;
-}
-
-function getProjects(): Project[] {
-  const projectsDirectory = path.join(process.cwd(), "src/app/data/projects");
-  const fileNames = fs.readdirSync(projectsDirectory);
-
-  const allProjects = fileNames.map((fileName) => {
-    const filePath = path.join(projectsDirectory, fileName);
-    const fileContents = fs.readFileSync(filePath, "utf-8");
-    const projectData = JSON.parse(fileContents);
-
-    return {
-      id: projectData.id,
-      client: projectData.client,
-      title: projectData.title,
-      thumbnail: projectData.thumbnail,
-    };
-  });
-
-  return allProjects;
-}
-
+import { getProjects } from "@/app/lib/projects";
 export function WorkGrid() {
   const projects = getProjects();
 
@@ -45,6 +15,7 @@ export function WorkGrid() {
               client={project.client}
               thumbnail={project.thumbnail}
               title={project.title}
+              slug={project.slug}
             />
           ))}
         </div>

--- a/src/app/(app)/work/[slug]/page.tsx
+++ b/src/app/(app)/work/[slug]/page.tsx
@@ -1,0 +1,68 @@
+import { getProjects } from "@/app/lib/projects";
+import { notFound } from "next/navigation";
+
+export async function generateStaticParams() {
+  const projects = getProjects();
+  return projects.map((project) => ({
+    slug: project.slug,
+  }));
+}
+
+export default function ProjectPage({ params }: { params: { slug: string } }) {
+  const projects = getProjects();
+  const project = projects.find((p) => p.slug === params.slug);
+  if (!project) {
+    notFound();
+  }
+
+  return (
+    <>
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="mb-4 text-4xl font-bold">{project.title}</h1>
+        <div className="mb-4">
+          <span className="font-semibold">client:</span> {project.client}
+        </div>
+        <div className="mb-4">
+          <span className="font-semibold">location:</span> {project.location}
+        </div>
+        <div className="mb-4">
+          <span className="font-semibold">year:</span> {project.year}
+        </div>
+        <img
+          src={project.heroImage}
+          alt={project.title}
+          className="mb-4 h-64 w-full object-cover"
+        />
+        <div>
+          <span className="font-semibold">Services:</span>{" "}
+          {project.services.join(", ")}
+        </div>
+        <div>
+          <span className="font-semibold">Industry:</span>{" "}
+          {project.industry.join(", ")}
+        </div>
+        <a
+          href={project.liveUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-500 hover:underline"
+        >
+          Visit Live Site
+        </a>
+        {project.sections.map((section, index) => (
+          <div key={index} className="mt-8">
+            <h2 className="mb-2 text-2xl font-semibold">{section.title}</h2>
+            <p>{section.content}</p>
+            {section.highlights && (
+              <ul className="mt-2 list-inside list-disc">
+                {section.highlights.map((highlight, i) => (
+                  <li key={i}>{highlight}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/app/components/WorkCard.tsx
+++ b/src/app/components/WorkCard.tsx
@@ -1,18 +1,29 @@
+import Link from "next/link";
+
 interface WorkCardProps {
   id: string;
   client: string;
   title: string;
   thumbnail: string;
+  slug: string;
 }
 
-export function WorkCard({ id, client, title, thumbnail }: WorkCardProps) {
+export function WorkCard({
+  id,
+  client,
+  title,
+  thumbnail,
+  slug,
+}: WorkCardProps) {
   return (
-    <div className="m-4 max-w-sm overflow-hidden rounded shadow-lg">
-      <img className="w-full" src={thumbnail} alt={title} />
-      <div className="px-6 py-4">
-        <div className="mb-2 text-xl font-bold">{title}</div>
-        <p className="text-base text-gray-700">{client}</p>
+    <Link href={` /work/${slug}`}>
+      <div className="m-4 max-w-sm overflow-hidden rounded shadow-lg">
+        <img className="w-full" src={thumbnail} alt={title} />
+        <div className="px-6 py-4">
+          <div className="mb-2 text-xl font-bold">{title}</div>
+          <p className="text-base text-gray-700">{client}</p>
+        </div>
       </div>
-    </div>
+    </Link>
   );
 }

--- a/src/app/lib/projects.ts
+++ b/src/app/lib/projects.ts
@@ -1,0 +1,40 @@
+import fs from "fs";
+import path from "path";
+
+export interface Project {
+  id: string;
+  client: string;
+  location: string;
+  year: string;
+  title: string;
+  slug: string;
+  category: string[];
+  services: string[];
+  industry: string[];
+  thumbnail: string;
+  heroImage: string;
+  liveUrl: string;
+  seo: {
+    title: string;
+    description: string;
+  };
+  sections: {
+    type: string;
+    title?: string;
+    content?: string;
+    highlights: string[];
+  }[];
+}
+
+export function getProjects(): Project[] {
+  const projectsDirectory = path.join(process.cwd(), "src/app/data/projects");
+  const fileNames = fs.readdirSync(projectsDirectory);
+
+  const allProjects = fileNames.map((fileName) => {
+    const filePath = path.join(projectsDirectory, fileName);
+    const fileContents = fs.readFileSync(filePath, "utf-8");
+    return JSON.parse(fileContents) as Project;
+  });
+
+  return allProjects;
+}


### PR DESCRIPTION
### TL;DR

Updated sitemap.xml, refactored WorkGrid component to use lib, added project pages

### What changed?
- Updated sitemap.xml with new project URLs
- Refactored WorkGrid component to use the new getProjects function from lib
- Added dynamic project pages generated using slugs

### How to test?
1. Check that sitemap.xml is updated correctly
2. Verify that the WorkGrid component renders projects correctly with links
3. Ensure that individual project pages can be accessed and display the correct data

### Why make this change?
This change improves the site structure by generating individual pages for each project. It streamlines how projects are managed and displayed.

---

