### PR TITLE
feat(ui): add initial PlayCard component

### DIFF
--- a/src/app/components/PlayCard.tsx
+++ b/src/app/components/PlayCard.tsx
@@ -1,27 +1,19 @@
 import Link from "next/link";
 
-interface WorkCardProps {
+interface PlayCardProps {
   id: string;
-  client: string;
   title: string;
   thumbnail: string;
   slug: string;
 }
 
-export function WorkCard({
-  id,
-  client,
-  title,
-  thumbnail,
-  slug,
-}: WorkCardProps) {
+export function PlayCard({ id, title, thumbnail, slug }: PlayCardProps) {
   return (
-    <Link href={`/work/${slug}`}>
-      <div className="m-4 max-w-sm overflow-hidden rounded shadow-lg">
+    <Link href={`/play/${slug}`}>
+      <div className="m-4 max-w-sm cursor-pointer overflow-hidden rounded shadow-lg">
         <img className="w-full" src={thumbnail} alt={title} />
         <div className="px-6 py-4">
           <div className="mb-2 text-xl font-bold">{title}</div>
-          <p className="text-base text-gray-700">{client}</p>
         </div>
       </div>
     </Link>


### PR DESCRIPTION
This pull request introduces the `PlayCard` UI component and includes a bug fix in the `WorkCard` component. 

### TL;DR
Introduces a new `PlayCard` component and fixes a spacing issue in `WorkCard` component.

### What changed?
- Added a new `src/app/components/PlayCard.tsx` file to create the `PlayCard` component.
- Corrected the URL formatting in the `WorkCard` component.

### How to test?
- Verify the new `PlayCard` component renders correctly by navigating to routes using this component.
- Ensure the `WorkCard` URLs are formatted correctly without spaces.

### Why make this change?
The `PlayCard` component is needed to display playable content in a card format. The bug fix in `WorkCard` improves link formatting.

---

