### PR TITLE
feat(ui): add initial PlayHero component to new play page

### DIFF
--- a/src/app/(app)/play/PlayHero.tsx
+++ b/src/app/(app)/play/PlayHero.tsx
@@ -1,0 +1,18 @@
+export function PlayHero() {
+  return (
+    <>
+      <div>
+        <div className="max-w-[82.50rem] text-xl text-neutral-800 min-[480px]:max-w-[84.38rem] min-[720px]:max-w-[86.88rem] min-[720px]:pl-12 min-[720px]:pr-12 min-[1080px]:max-w-[89.38rem] min-[1080px]:pl-16 min-[1080px]:pr-16">
+          <h1 className="mb-1 mt-28 text-[2.88rem] font-light leading-none text-white">
+            Brewww Playground
+          </h1>
+          <p className="mb-24 max-w-[67.50rem] text-[2.88rem] leading-none text-neutral-500">
+            A playground where the artisans at Brewww share internal projects
+            that they are playing around with. From the ridiculous to the
+            somewhat useful, we hone skillsets through imagination and fun.
+          </p>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/(app)/play/page.tsx
+++ b/src/app/(app)/play/page.tsx
@@ -1,0 +1,9 @@
+import { PlayHero } from "./PlayHero";
+
+export default function Page() {
+  return (
+    <>
+      <PlayHero />
+    </>
+  );
+}


### PR DESCRIPTION
### TL;DR

This PR introduces the PlayHero component, which serves as a hero section for the play page. The PlayHero component includes a title and a brief description.

### What changed?

Two new files were added:
1. `PlayHero.tsx`: contains the PlayHero component.
2. `page.tsx`: leverages the PlayHero component to render the play page.

### How to test?

1. Navigate to the play page.
2. Verify that the PlayHero section appears as expected, with the correct title and description styles.

### Why make this change?

This change introduces a dedicated hero section for the play page to present Brewww Playground, thereby enhancing the page structure and visual hierarchy.

---

