### PR TITLE
feat(ui): add initial PlayProjects grid

### DIFF
--- a/src/app/(app)/play/PlayGrid.tsx
+++ b/src/app/(app)/play/PlayGrid.tsx
@@ -1,0 +1,25 @@
+import { getPlayProjects } from "@/app/lib/playProjects";
+import { PlayCard } from "@/app/components/PlayCard";
+
+export function PlayGrid() {
+  const playProjects = getPlayProjects();
+
+  return (
+    <>
+      <div className="container mx-auto px-4 py-12">
+        <h2 className="my-8 text-4xl font-bold">Our Play</h2>
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {playProjects.map((project) => (
+            <PlayCard
+              key={project.id}
+              id={project.id}
+              title={project.title}
+              thumbnail={project.thumbnail}
+              slug={project.slug}
+            />
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/(app)/play/page.tsx
+++ b/src/app/(app)/play/page.tsx
@@ -1,9 +1,11 @@
 import { PlayHero } from "./PlayHero";
+import { PlayGrid } from "./PlayGrid";
 
 export default function Page() {
   return (
     <>
       <PlayHero />
+      <PlayGrid />
     </>
   );
 }

--- a/src/app/(app)/work/WorkGrid.tsx
+++ b/src/app/(app)/work/WorkGrid.tsx
@@ -1,14 +1,14 @@
 import { WorkCard } from "@/app/components/WorkCard";
 import { getWorkProjects } from "@/app/lib/workProjects";
 export function WorkGrid() {
-  const projects = getWorkProjects();
+  const workProjects = getWorkProjects();
 
   return (
     <>
       <div className="container mx-auto px-4 py-12">
         <h2 className="my-8 text-4xl font-bold">Our Work</h2>
         <div className="lg: grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-          {projects.map((project) => (
+          {workProjects.map((project) => (
             <WorkCard
               id={project.id}
               key={project.id}


### PR DESCRIPTION
### TL;DR
Add a new 'PlayGrid' component and integrate it into the play page.

### What changed?
- Created a new 'PlayGrid' component to display play projects.
- Integrated 'PlayGrid' into the existing play page.
- Adjusted file structure to accommodate the new component.

### How to test?
1. Navigate to the play page.
2. Verify that the PlayGrid component renders correctly with all projects displayed.
3. Ensure there are no layout issues or console errors.

### Why make this change?
To enhance the play page by organizing play-related projects in a structured grid layout, improving the overall user experience.

---

