### PR TITLE
feat(ui): add initial BlogCard component

### DIFF
--- a/src/app/components/BlogCard.tsx
+++ b/src/app/components/BlogCard.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+
+interface BlogCardProps {
+  title: string;
+  description: string;
+  publishedAt: string;
+  image?: string;
+  slug: string;
+}
+
+export function BlogCard({
+  title,
+  description,
+  publishedAt,
+  image = "",
+  slug,
+}: BlogCardProps) {
+  return (
+    <>
+      <div>
+        {image && <img src={image} alt="Alt Text" width={500} height={300} />}
+        <div className="flex-1">
+          <h3 className="my-2 text-xl font-bold">{title}</h3>
+          <p className="mb-4 text-base text-gray-800">{description}</p>
+          <p className="text-sm text-gray-500">
+            {new Date(`${publishedAt}`).toLocaleDateString()}
+          </p>
+        </div>
+        <Link
+          href={`blog/${slug}`}
+          className="text-indigo-600 hover:text-indigo-900"
+        >
+          Read More
+        </Link>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
### TL;DR
This pull request introduces a new BlogCard component to the codebase. 

### Why make this change? 
The BlogCard component is designed to display a blog post preview, including the title, description, publication date, optional image, and a link to the full post. The addition of this component enhances the UI by providing a reusable and visually appealing way to showcase blog posts.

---

