### PR TITLE
feat(ui): add initial blog post grid to think page

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://brewww.studio/contact</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://brewww.studio</loc><changefreq>daily</changefreq><priority>0.8</priority></url>
-<url><loc>https://brewww.studio/insights</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://brewww.studio/play</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://brewww.studio/why-us</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://brewww.studio/about</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://brewww.studio/work</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://brewww.studio/capabilities</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://brewww.studio/play/call-me-maeby</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://brewww.studio/play/succinct-saints</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/insights</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/work</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/play</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/contact</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://brewww.studio/about</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://brewww.studio/work/concrete-catholic-faith-media</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://brewww.studio/work/custom-home-design-san-antonio</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://brewww.studio/work/led-lighting-solutions</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
@@ -18,7 +15,11 @@
 <url><loc>https://brewww.studio/work/faith-and-fitness-online-community</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://brewww.studio/work/authentic-faith-based-media</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://brewww.studio/work/modern-catholic-school-website</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://brewww.studio/work/acoustical-ceiling-installation</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://brewww.studio/work/catholic-church-discipleship-pathway</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://brewww.studio/work/dynamic-catholic-church-website</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/work/acoustical-ceiling-installation</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/play/call-me-maeby</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/play/succinct-saints</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/why-us</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/think</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/app/(app)/think/page.tsx
+++ b/src/app/(app)/think/page.tsx
@@ -1,0 +1,72 @@
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+import { BlogCard } from "@/app/components/BlogCard";
+
+interface PostMeta {
+  title: string;
+  publishedAt: string;
+  description: string;
+  author: string;
+}
+
+interface Post {
+  slug: string;
+  meta: PostMeta;
+}
+
+//* Set the location of the posts directory
+const postsDirectory = path.join(process.cwd(), "src/app/posts");
+
+console.log(postsDirectory);
+
+//* Find all the files in the blog directory
+const files = fs.readdirSync(path.join("src/app/posts"));
+
+console.log(files);
+
+//* Map over each post, extract the frontMatter, and adjust the slug
+const posts: Post[] = files.map((filename) => {
+  // Read the content of each post
+  const postContent = fs.readFileSync(
+    path.join(postsDirectory, filename),
+    "utf-8",
+  );
+  // Extract the frontMatter from each post
+  const { data: frontMatter } = matter(postContent);
+  // Ensure the frontMatter has the correct structure
+  const meta: PostMeta = {
+    title: frontMatter.title,
+    publishedAt: frontMatter.publishedAt,
+    description: frontMatter.description,
+    author: frontMatter.author,
+  };
+  // Return the result and set the slug
+  return {
+    meta,
+    slug: frontMatter.slug,
+  };
+});
+
+console.log(posts);
+
+export default function Page() {
+  return (
+    <>
+      <section className="m-auto flex min-h-32 max-w-6xl flex-grow flex-col items-center justify-center px-4">
+        <h2 className="mb-8 text-5xl">Blog</h2>
+        <div className="grid grid-cols-3 gap-4">
+          {posts.map((post) => (
+            <BlogCard
+              key={post.meta.title}
+              title={post.meta.title}
+              publishedAt={post.meta.publishedAt}
+              description={post.meta.description}
+              slug={post.slug}
+            />
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/app/components/BlogCard.tsx
+++ b/src/app/components/BlogCard.tsx
@@ -27,7 +27,7 @@ export function BlogCard({
           </p>
         </div>
         <Link
-          href={`blog/${slug}`}
+          href={`think/${slug}`}
           className="text-indigo-600 hover:text-indigo-900"
         >
           Read More


### PR DESCRIPTION
### TL;DR
This PR restructures the sitemap to update the URLs and introduces a new blog functionality under the /think directory.

### What changed?
- Sitemap.xml has been updated to include new URLs and remove old ones.
- A new page has been added for the blog functionality, which reads posts from the /posts directory and displays them.
- Adjusted BlogCard component to link to the new /think/* URL structure.

### How to test?
1. Open sitemap.xml and verify the new URLs are in place and the old ones are removed.
2. Navigate to the /think page and ensure that the blog posts are listed correctly.

### Why make this change?
The changes are made to improve content discoverability and add blog functionality to the site.

---

