### PR TITLE
feat(seo): add default SEO configuration to site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@tailwindcss/typography": "^0.5.13",
         "@vercel/speed-insights": "^1.0.12",
         "next": "14.2.4",
-        "next-seo": "^6.5.0",
         "next-sitemap": "^4.2.3",
         "react": "^18",
         "react-dom": "^18",
@@ -560,7 +559,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -8326,17 +8324,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-seo": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/next-seo/-/next-seo-6.5.0.tgz",
-      "integrity": "sha512-MfzUeWTN/x/rsKp/1n0213eojO97lIl0unxqbeCY+6pAucViHDA8GSLRRcXpgjsSmBxfCFdfpu7LXbt4ANQoNQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "next": "^8.1.1-canary.54 || >=9.0.0",
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
       }
     },
     "node_modules/next-sitemap": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@tailwindcss/typography": "^0.5.13",
     "@vercel/speed-insights": "^1.0.12",
     "next": "14.2.4",
-    "next-seo": "^6.5.0",
     "next-sitemap": "^4.2.3",
     "react": "^18",
     "react-dom": "^18",

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,8 +1,11 @@
-import type { Metadata } from "next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Footer } from "../components/Footer";
 import localFont from "next/font/local";
 import "./globals.css";
+import { Metadata } from "next";
+import { SEO_Config } from "./seo-config";
+
+export const metadata: Metadata = SEO_Config;
 
 const DMSans = localFont({
   variable: "--font-dm-sans",
@@ -11,11 +14,6 @@ const DMSans = localFont({
     { path: "../fonts/DMSans.ttf", weight: "100 400 900", style: "normal" },
   ],
 });
-
-export const metadata: Metadata = {
-  title: "Brewww Studio",
-  description: "We craft unbounded brands.",
-};
 
 export default function RootLayout({
   children,

--- a/src/app/(app)/seo-config.ts
+++ b/src/app/(app)/seo-config.ts
@@ -1,0 +1,31 @@
+export const SEO_Config = {
+  titleTemplate: "%s | Brewww Studio",
+  defaultTitle: "Brewww Studio",
+  description: "Brewww Studio - We craft unbounded brands",
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    url: "https://brewww.studio",
+    siteName: "Brewww Studio",
+    images: [
+      {
+        url: "https://brewww.studio/oh-image.jpg",
+        width: 1200,
+        height: 630,
+        alt: "Brewww Studio",
+      },
+    ],
+  },
+  additionalMetaTags: [
+    { name: "viewport", content: "width=device-width, initial-scale=1" },
+    { name: "author", content: "Brewww Studio" },
+  ],
+  additionalLinkTags: [
+    {
+      rel: "icon",
+      href: "/favicon.ico",
+    },
+    { rel: "me", href: "https://www.facebook.com/brewwwstudio" },
+    { rel: "me", href: "https://www.instagram.com/brewwwstudio" },
+  ],
+};


### PR DESCRIPTION
### TL;DR

Set up SEO configuration directly in the project and removed next-seo dependency.

### What changed?

- Removed `next-seo` dependency from `package.json` and `package-lock.json`.
- Updated `layout.tsx` to use the new SEO configuration from `seo-config.ts` file.
- Introduced `seo-config.ts` with SEO settings such as title templates, default title, description, OpenGraph data, additional meta tags, and additional link tags.

### How to test?

1. Verify that the `next-seo` dependency is no longer present in both `package.json` and `package-lock.json`.
2. Check `layout.tsx` to ensure it references and correctly applies the new SEO configuration from `seo-config.ts`.
3. Confirm that SEO meta tags are correctly rendered on the frontend as per the settings in `seo-config.ts`.

### Why make this change?

To create a centralized SEO configuration that is easily manageable within the project code, removing the need for an external dependency (`next-seo`).

---

