### PR TITLE
feat(ui): sort blog posts on think page by order published

### DIFF
--- a/src/app/(app)/think/ThinkBody.tsx
+++ b/src/app/(app)/think/ThinkBody.tsx
@@ -2,6 +2,10 @@ import { allPosts } from "content-collections";
 import { BlogCard } from "@/app/components/BlogCard";
 
 export function ThinkBody() {
+  const sortedPosts = allPosts.sort(
+    (a, b) =>
+      new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime(),
+  );
   return (
     <>
       <section>
@@ -11,7 +15,7 @@ export function ThinkBody() {
           </div>
           <div className="relative">
             <div className="grid grid-cols-2 gap-4">
-              {allPosts.map((post) => (
+              {sortedPosts.map((post) => (
                 <BlogCard
                   key={post.title}
                   title={post.title}


### PR DESCRIPTION
### TL;DR
Sorts the blog posts displayed in the ThinkBody component by their published date.

### What changed?
In the `ThinkBody` component, the blog posts (`allPosts`) are now sorted by their `publishedAt` date in descending order before being passed to the `BlogCard` component.

### How to test?
Ensure that the `ThinkBody` component displays blog posts sorted by the published date, with the most recent posts appearing first.

### Why make this change?
This change ensures that the most recent blog posts appear first, providing users with the latest content at a glance.

---

