### PR TITLE
feat(ui): update challenge section styling on work page

### DIFF
--- a/src/app/(app)/work/WorkGrid.tsx
+++ b/src/app/(app)/work/WorkGrid.tsx
@@ -7,7 +7,7 @@ export function WorkGrid() {
     <>
       <div className="container mx-auto px-4 py-12">
         <h2 className="my-8 text-4xl font-bold">Our Work</h2>
-        <div className="lg: grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <div className="lg: grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2">
           {workProjects.map((project) => (
             <WorkCard
               id={project.id}

--- a/src/app/(app)/work/[slug]/page.tsx
+++ b/src/app/(app)/work/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { getWorkProjects } from "@/app/lib/workProjects";
 import { notFound } from "next/navigation";
+import Image from "next/image";
 
 export async function generateStaticParams() {
   const projects = getWorkProjects();
@@ -19,24 +20,68 @@ export default function WorkProjectPage({
     notFound();
   }
 
+  const firstSection = project.sections[0];
+
   return (
     <>
       <div className="container mx-auto px-4 py-8">
-        <h1 className="mb-4 text-4xl font-bold">{project.title}</h1>
-        <div className="mb-4">
-          <span className="font-semibold">client:</span> {project.client}
+        <div className="min-[620px]:mb-20 min-[900px]:mb-28 min-[900px]:pr-60">
+          <div className="mb-6 uppercase">{project.client}</div>
+
+          <h1 className="text-[3.38rem] leading-none">{project.title}</h1>
         </div>
-        <div className="mb-4">
-          <span className="font-semibold">location:</span> {project.location}
+        <div>
+          <div className="relative h-[500px] w-full">
+            <Image
+              src={project.heroImage}
+              alt={project.title}
+              fill
+              style={{ objectFit: "cover" }}
+            />
+          </div>
         </div>
-        <div className="mb-4">
-          <span className="font-semibold">year:</span> {project.year}
+        <div className="min-[900px]:flex">
+          <div className="w-full uppercase text-red-500 min-[900px]:w-60">
+            <div className="mb-6 mt-2 min-[900px]:mb-0 min-[900px]:pr-8">
+              The Challenge
+            </div>
+          </div>
+
+          <div className="w-full min-[900px]:w-[59.098vw]">
+            <h2 className="mb-12 text-[2.38rem] leading-none">
+              {firstSection.title}
+            </h2>
+
+            <div className="w-full text-lg font-light">
+              <p>{firstSection.content}</p>
+            </div>
+
+            <div className="mt-12 text-lg min-[900px]:mt-10">
+              <div className="mb-6 min-[900px]:mb-0">
+                <div className="mb-1 font-bold min-[900px]:mr-8 min-[900px]:inline">
+                  Services Provided
+                </div>
+
+                <p className="mr-4 mt-10 font-light">Experience Design</p>
+
+                <p className="mr-4 mt-10 font-light">Visual Design</p>
+
+                <p className="mr-4 mt-10 font-light">User Research</p>
+
+                <p className="mr-4 mt-10 font-light">Front End Development</p>
+              </div>
+
+              <div className="mb-6 min-[900px]:mb-0">
+                <div className="mb-1 font-bold min-[900px]:mr-8 min-[900px]:inline">
+                  Industry
+                </div>
+
+                <p className="mr-4 mt-10 font-light">Customer Experience</p>
+              </div>
+            </div>
+          </div>
         </div>
-        <img
-          src={project.heroImage}
-          alt={project.title}
-          className="mb-4 h-64 w-full object-cover"
-        />
+
         <div>
           <span className="font-semibold">Services:</span>{" "}
           {project.services.join(", ")}

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -15,16 +15,6 @@ export function Footer() {
             className="m-auto grid auto-cols-fr grid-cols-[1fr_1fr_1fr] grid-rows-[auto_auto] gap-4 px-12 pb-8"
             id="div-1"
           >
-            <a
-              className="col-start-1 col-end-4 row-start-1 row-end-2 m-auto inline-block max-w-full self-center justify-self-center text-[4.38rem] font-bold leading-none"
-              href="/hire-us"
-            >
-              <div className="m-auto h-full w-full overflow-hidden py-3">
-                <h4 className="mx-auto mb-8 min-h-[0vw] max-w-[43.75rem] text-center">
-                  Creative That Just Works.
-                </h4>
-              </div>
-            </a>
             <div
               className="col-start-1 col-end-2 row-start-2 row-end-3 justify-self-center font-bold"
               id="div-2"
@@ -504,7 +494,9 @@ export function Footer() {
                 className="flex items-center justify-around text-white/[0.6]"
                 id="div-9"
               >
-                <div>© {getCurrentYear()} Brewww Studio. All Rights Reserved. </div>
+                <div>
+                  © {getCurrentYear()} Brewww Studio. All Rights Reserved.{" "}
+                </div>
               </div>
             </div>
           </div>

--- a/src/app/data/work/azle-storage.json
+++ b/src/app/data/work/azle-storage.json
@@ -4,7 +4,7 @@
   "client": "Azle Storage",
   "location": "Dallas, TX",
   "year": "2020",
-  "title": "Securing Your Life, Safely Stored",
+  "title": "A safe haven for what matters most.",
   "slug": "azle-storage-secure-self-storage",
   "category": ["strategy", "branding", "website", "design"],
   "services": ["branding", "web design", "content strategy", "photography"],

--- a/src/app/data/work/concrete-catholic.json
+++ b/src/app/data/work/concrete-catholic.json
@@ -4,7 +4,7 @@
   "client": "Concrete Catholic",
   "location": "Atlanta, GA",
   "year": "2020",
-  "title": "Encountering Christ in the Everyday",
+  "title": "Branding a podcast worth listening to.",
   "slug": "concrete-catholic-faith-media",
   "category": ["strategy", "branding", "website", "design"],
   "services": ["branding", "web design", "content strategy"],

--- a/src/app/data/work/custom-texas-living.json
+++ b/src/app/data/work/custom-texas-living.json
@@ -4,7 +4,7 @@
   "client": "Custom Texas Living",
   "location": "San Antonio, TX",
   "year": "2019",
-  "title": "Custom Living on Any Budget",
+  "title": "Custom construction built for any budget.",
   "slug": "custom-home-design-san-antonio",
   "category": ["strategy", "branding", "website", "design"],
   "services": ["branding", "web design", "content strategy", "photography"],

--- a/src/app/data/work/ies-national.json
+++ b/src/app/data/work/ies-national.json
@@ -4,7 +4,7 @@
   "client": "IES National",
   "location": "Pensacola, FL",
   "year": "2021",
-  "title": "Lighting the Way for Energy Efficiency",
+  "title": "Rebranding America's trusted LED lighting partner.",
   "slug": "led-lighting-solutions",
   "category": ["strategy", "branding", "website", "design"],
   "services": ["branding", "web design", "content strategy", "photography"],

--- a/src/app/data/work/kevin-and-christine-2019.json
+++ b/src/app/data/work/kevin-and-christine-2019.json
@@ -4,7 +4,7 @@
   "client": "Kevin and Christine",
   "location": "Nashville, TN",
   "year": "2019",
-  "title": "A Joyful Wedding Celebration",
+  "title": "Creating a new kind of wedding website.",
   "slug": "joyful-wedding-celebration",
   "category": ["strategy", "branding", "website", "design"],
   "services": ["branding", "web design", "content strategy", "photography"],


### PR DESCRIPTION
### TL;DR
This PR updates the `WorkGrid`, `WorkProjectPage` components, enhances the `Footer`, and modifies project data titles.

### What changed?
- Changed `lg:grid-cols-3` to `lg:grid-cols-2` in `WorkGrid` component
- Added `next/image` for optimized images in `WorkProjectPage`
- Improved layout and styles for project details in `WorkProjectPage`
- Removed the 'Creative That Just Works' section from `Footer`
- Updated project titles in JSON data files

### How to test?
1. Check the `WorkGrid` component to see if it displays two columns on large screens.
2. Verify image optimization and layout changes in `WorkProjectPage`.
3. Ensure the `Footer` no longer contains the removed section and looks visually correct.
4. Validate the updated titles in JSON project data files.

### Why make this change?
This change improves visual consistency, optimizes image loading, and updates outdated project details.

---

