### PR TITLE
feat(ui): add dynamic initial Services page

### DIFF
--- a/src/app/(app)/services/ServicesIntro.tsx
+++ b/src/app/(app)/services/ServicesIntro.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 
 export function ServicesIntro() {
   return (
@@ -32,6 +33,9 @@ export function ServicesIntro() {
                 color palettes—we create a kinetic brand experience that
                 resonates with your audience and propels your business forward.
               </p>
+              <Link href="/services/branding" className="font-bold">
+                Learn More
+              </Link>
             </div>
             <div>
               <h2 className="mb-3 text-4xl font-bold uppercase">Websites</h2>
@@ -51,6 +55,9 @@ export function ServicesIntro() {
                 interfaces; theyre strategic tools designed to engage your
                 audience and drive meaningful action.
               </p>
+              <Link href="/services/websites" className="font-bold">
+                Learn More
+              </Link>
             </div>
             <div>
               <h2 className="mb-3 text-4xl font-bold uppercase">Content</h2>
@@ -70,6 +77,9 @@ export function ServicesIntro() {
                 create content that not only speaks to your audience but moves
                 them to action.
               </p>
+              <Link href="/services/content" className="font-bold">
+                Learn More
+              </Link>
             </div>
           </div>
         </div>

--- a/src/app/(app)/services/[slug]/page.tsx
+++ b/src/app/(app)/services/[slug]/page.tsx
@@ -1,0 +1,22 @@
+import { getServiceData } from "@/app/lib/serviceData";
+import { notFound } from "next/navigation";
+
+export async function generateStaticParams() {
+  const services = getServiceData();
+  return services.map((service) => ({ slug: service.slug }));
+}
+
+export default function ServicePage({ params }: { params: { slug: string } }) {
+  const services = getServiceData();
+  const service = services.find((s) => s.slug === params.slug);
+  if (!service) {
+    console.error(`Service with slug ${params.slug} not found`);
+    return notFound();
+  }
+
+  return (
+    <>
+      <h1>{service.pageTitle}</h1>
+    </>
+  );
+}

--- a/src/app/data/services/branding.json
+++ b/src/app/data/services/branding.json
@@ -1,0 +1,28 @@
+{
+  "id": "branding",
+  "pageTitle": "Branding & System Design",
+  "slug": "branding",
+  "featuredImg": "/images/branding-books.1920.jpg",
+  "heroSection": {
+    "headline": "Your business values visualized through brand storytelling",
+    "description": "A bold, strategic brand identity is what lies behind a strong first impression. There are two parts to a strong brand: strategy and identity. Your brand strategy personifies your business, and your brand identity visualizes it."
+  },
+  "services": {
+    "brandStrategy": [
+      "Brand Consulting",
+      "User Personas",
+      "Competitive Analysis",
+      "Brand Messaging",
+      "Positioning & Differentiation",
+      "Journey Mapping"
+    ],
+    "brandIdentity": [
+      "Art Direction",
+      "Logo Design",
+      "Design System",
+      "Brand Naming",
+      "Brand Guidelines",
+      "Collateral Design"
+    ]
+  }
+}

--- a/src/app/lib/serviceData.ts
+++ b/src/app/lib/serviceData.ts
@@ -1,0 +1,24 @@
+import fs from "fs";
+import path from "path";
+
+export interface ServiceData {
+  id: string;
+  pageTitle: string;
+  slug: string;
+}
+
+export function getServiceData(): ServiceData[] {
+  const serviceDataDirectory = path.join(
+    process.cwd(),
+    "src/app/data/services",
+  );
+  const fileNames = fs.readdirSync(serviceDataDirectory);
+
+  const allServicePages = fileNames.map((fileName) => {
+    const filePath = path.join(serviceDataDirectory, fileName);
+    const fileContents = fs.readFileSync(filePath, "utf-8");
+    return JSON.parse(fileContents) as ServiceData;
+  });
+
+  return allServicePages;
+}


### PR DESCRIPTION
### TL;DR

Added dynamic routing for the services pages and loaded service data from JSON files to improve scalability and maintainability.

### What changed?

- Introduced `next/link` for better navigation within the `ServicesIntro` component.
- Created dynamic routes for service pages using `[slug]` in the URL.
- Added new JSON data files for each service to populate the service pages.
- Implemented `getServiceData` function to fetch and parse JSON data files.
- Updated `ServicesIntro` to include navigational links for each service using `next/link`.

### How to test?

1. Navigate to the `/services` page.
2. Click on any 

---

