### PR TITLE
feat(ui): add initial hero design to individual Services page

### DIFF
--- a/src/app/(app)/services/[slug]/page.tsx
+++ b/src/app/(app)/services/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { getServiceData } from "@/app/lib/serviceData";
 import { notFound } from "next/navigation";
+import Image from "next/image";
 
 export async function generateStaticParams() {
   const services = getServiceData();
@@ -16,7 +17,31 @@ export default function ServicePage({ params }: { params: { slug: string } }) {
 
   return (
     <>
-      <h1>{service.pageTitle}</h1>
+      <section className="flex items-end bg-stone-950 px-16 pt-44 text-center text-white">
+        <div className="flex flex-wrap justify-center">
+          <h1 className="flex flex-col justify-center text-[5.13rem] leading-none">
+            <div className="table pr-1">
+              <div>
+                <h1>{service.pageTitle}</h1>
+              </div>
+            </div>
+          </h1>
+
+          <div className="flex w-full justify-between pb-4 pt-16 text-4xl font-bold uppercase">
+            <h2>Service</h2>
+            <h2>Contact Us</h2>
+          </div>
+
+          <div className="relative flex h-0 w-full items-end pb-[66%]">
+            <Image
+              src={service.featuredImg}
+              alt="text"
+              fill
+              style={{ objectFit: "cover" }}
+            />
+          </div>
+        </div>
+      </section>
     </>
   );
 }

--- a/src/app/lib/serviceData.ts
+++ b/src/app/lib/serviceData.ts
@@ -5,6 +5,7 @@ export interface ServiceData {
   id: string;
   pageTitle: string;
   slug: string;
+  featuredImg: string;
 }
 
 export function getServiceData(): ServiceData[] {


### PR DESCRIPTION
### TL;DR
Enhanced the service page to include a responsive hero section featuring the page title and a featured image.

### What changed?
- Imported `Image` component from 'next/image'.
- Added a new hero section in the `ServicePage` component that includes the page title and a featured image.
- Updated service data interface to include `featuredImg` field.

### How to test?
1. Navigate to the service page.
2. Verify the presence of the hero section with the page title, a 'Contact Us' area, and a featured image.
3. Ensure the styles are responsive and adapt to different screen sizes.

### Why make this change?
To improve the visual appeal and user experience of the service pages by adding a hero section that highlights key information and includes a featured image.

---

