### PR TITLE
feat(ui): add initial intro section to individual Series page

### DIFF
--- a/src/app/(app)/services/[slug]/page.tsx
+++ b/src/app/(app)/services/[slug]/page.tsx
@@ -17,31 +17,53 @@ export default function ServicePage({ params }: { params: { slug: string } }) {
 
   return (
     <>
-      <section className="flex items-end bg-stone-950 px-16 pt-44 text-center text-white">
-        <div className="flex flex-wrap justify-center">
-          <h1 className="flex flex-col justify-center text-[5.13rem] leading-none">
-            <div className="table pr-1">
-              <div>
-                <h1>{service.pageTitle}</h1>
+      <div className="bg-stone-950 text-white">
+        <section className="flex items-end px-16 pt-44 text-center">
+          <div className="flex flex-wrap justify-center">
+            <h1 className="flex flex-col justify-center text-[5.13rem] leading-none">
+              <div className="table pr-1">
+                <div>
+                  <h1>{service.pageTitle}</h1>
+                </div>
+              </div>
+            </h1>
+
+            <div className="flex w-full justify-between pb-4 pt-16 text-4xl font-bold uppercase">
+              <h2>Service</h2>
+              <h2>Contact Us</h2>
+            </div>
+
+            <div className="relative flex h-0 w-full items-end pb-[66%]">
+              <Image
+                src={service.featuredImg}
+                alt="text"
+                fill
+                style={{ objectFit: "cover" }}
+              />
+            </div>
+          </div>
+        </section>
+        <section className="px-16 pt-20">
+          <div className="m-auto w-full max-w-[120.00rem]">
+            <div className="flex" id="div-1">
+              <div
+                className="flex w-[55%] flex-col pr-[calc(min(6vw,_115px)_*_2)] text-3xl font-bold uppercase"
+                id="div-2"
+              >
+                <h2 className="overflow-hidden">
+                  <div className="">
+                    <h2>{service.heroSection.headline}</h2>
+                  </div>
+                </h2>
+              </div>
+
+              <div className="flex w-[45%] flex-col" id="div-3">
+                <p>{service.heroSection.description}</p>
               </div>
             </div>
-          </h1>
-
-          <div className="flex w-full justify-between pb-4 pt-16 text-4xl font-bold uppercase">
-            <h2>Service</h2>
-            <h2>Contact Us</h2>
           </div>
-
-          <div className="relative flex h-0 w-full items-end pb-[66%]">
-            <Image
-              src={service.featuredImg}
-              alt="text"
-              fill
-              style={{ objectFit: "cover" }}
-            />
-          </div>
-        </div>
-      </section>
+        </section>
+      </div>
     </>
   );
 }

--- a/src/app/data/services/branding.json
+++ b/src/app/data/services/branding.json
@@ -4,11 +4,11 @@
   "slug": "branding",
   "featuredImg": "/images/branding-books.1920.jpg",
   "heroSection": {
-    "headline": "Your business values visualized through brand storytelling",
+    "headline": "Your brand tells the story of your company values",
     "description": "A bold, strategic brand identity is what lies behind a strong first impression. There are two parts to a strong brand: strategy and identity. Your brand strategy personifies your business, and your brand identity visualizes it."
   },
   "services": {
-    "brandStrategy": [
+    "serviceOne": [
       "Brand Consulting",
       "User Personas",
       "Competitive Analysis",
@@ -16,7 +16,7 @@
       "Positioning & Differentiation",
       "Journey Mapping"
     ],
-    "brandIdentity": [
+    "serviceTwo": [
       "Art Direction",
       "Logo Design",
       "Design System",

--- a/src/app/lib/serviceData.ts
+++ b/src/app/lib/serviceData.ts
@@ -1,11 +1,22 @@
 import fs from "fs";
 import path from "path";
 
+export interface HeroSection {
+  headline: string;
+  description: string;
+}
+
+export interface Services {
+  serviceOne: string[];
+  serviceTwo: string[];
+}
+
 export interface ServiceData {
   id: string;
   pageTitle: string;
   slug: string;
   featuredImg: string;
+  heroSection: HeroSection;
 }
 
 export function getServiceData(): ServiceData[] {


### PR DESCRIPTION
### TL;DR

The pull request includes significant changes to the `ServicePage` component in `page.tsx` and updates to the JSON data structure in `branding.json` and `serviceData.ts`.

### What changed?

- **Component Update**: Modified the JSX structure in `src/app/(app)/services/[slug]/page.tsx` to enhance layout and styling.
- **JSON Data Structure**: Changed the keys in `branding.json` from `brandStrategy` and `brandIdentity` to `serviceOne` and `serviceTwo`. Also updated the `headline` and `description` for the hero section.
- **TypeScript Interface Update**: Extended the `ServiceData` interface in `serviceData.ts` to include the `heroSection` object which contains `headline` and `description`.

### How to test?

1. **Run the Application**: Start the application and navigate to the service pages to ensure that the layout renders correctly with updated data.
2. **Check Data Rendering**: Verify that the hero section’s headline and description are displayed correctly.
3. **Inspect JSON Data**: Ensure the updated keys `serviceOne` and `serviceTwo` are being read and rendered as expected.

### Why make this change?

To improve the readability and structure of the Service page while aligning the JSON data and TypeScript interfaces for better maintainability.


---

