### PR TITLE
feat(ui): add initial ServicesImpact section to Services page

### DIFF
--- a/src/app/(app)/services/ServicesImpact.tsx
+++ b/src/app/(app)/services/ServicesImpact.tsx
@@ -1,0 +1,56 @@
+export function ServicesImpact() {
+  return (
+    <>
+      <div className="bg-white text-stone-950">
+        <div className="mx-auto w-full max-w-6xl px-8 py-12">
+          <div className="m-auto w-full max-w-[90.00rem]" id="div-1">
+            <div className="text-2xl font-medium">Impact & Results</div>
+            <div className="grid grid-cols-3 gap-8 pt-12">
+              <div className="">
+                <div className="flex items-start text-6xl">
+                  3<span className="ml-3 mt-6 text-xl">M</span>
+                </div>
+                <div className="mb-12 text-lg">
+                  Brand strategy and site development of The Merry Beggars led
+                  to 3 million downloads of their original audio entertainment
+                  podcast.
+                </div>
+
+                <a className="text-lg font-medium text-blue-700" href="">
+                  View Case Study
+                </a>
+              </div>
+              <div className="">
+                <div className="flex items-start text-6xl">
+                  10<span className="ml-3 mt-6 text-xl">X</span>
+                </div>
+                <div className="mb-12 text-lg">
+                  Brand strategy and development of Fem Catholic led to a grant
+                  for their initiative, ten times their original site
+                  investment.
+                </div>
+
+                <a className="text-lg font-medium text-blue-700" href="">
+                  View Case Study
+                </a>
+              </div>
+              <div className="">
+                <div className="flex items-start text-6xl">
+                  760<span className="ml-3 mt-6 text-xl">%</span>
+                </div>
+                <div className="mb-12 text-lg">
+                  Increase in online donations within 90 days after Joseph House
+                  site rebrand and website launch.
+                </div>
+
+                <a className="text-lg font-medium text-blue-700" href="">
+                  View Case Study
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/(app)/services/page.tsx
+++ b/src/app/(app)/services/page.tsx
@@ -1,6 +1,7 @@
 import { ServicesHero } from "./ServicesHero";
 import { ServicesIntro } from "./ServicesIntro";
 import { ServicesSpecialty } from "./ServicesSpeciality";
+import { ServicesImpact } from "./ServicesImpact";
 import { ServicesTestimonial } from "./ServicesTestimonial";
 
 export default function Page() {
@@ -9,6 +10,7 @@ export default function Page() {
       <ServicesHero />
       <ServicesIntro />
       <ServicesSpecialty />
+      <ServicesImpact />
       <ServicesTestimonial />
     </>
   );


### PR DESCRIPTION
### TL;DR

Added a new `ServicesImpact` component to the services section of the site, displaying various impacts and results.

### What changed?

1. Created a `ServicesImpact` component that displays achievements and case studies in a grid format.
2. Incorporated the `ServicesImpact` component within the services section's main page.

### How to test?

1. Pull the branch and start the development server.
2. Navigate to the services section of the site.
3. Ensure the `ServicesImpact` component is rendering correctly with all details.
4. Verify the links to case studies are functional.

### Why make this change?

To provide potential clients with tangible results and success stories, demonstrating the impact and effectiveness of the services.

---

