### PR TITLE
feat(impact): improve styling of services impact section

### DIFF
--- a/src/app/(app)/services/ServiceCard.tsx
+++ b/src/app/(app)/services/ServiceCard.tsx
@@ -24,7 +24,7 @@ export function ServiceCard({
       </div>
       <p className="py-3 text-base">{description}</p>
 
-      <LinkMain text="Learn More" href={`/services/${slug}`} size="medium" />
+      <LinkMain text="Learn More" link={`/services/${slug}`} size="medium" />
     </div>
   );
 }

--- a/src/app/(app)/services/ServicesImpact.tsx
+++ b/src/app/(app)/services/ServicesImpact.tsx
@@ -5,51 +5,29 @@ export function ServicesImpact() {
     <>
       <div className="bg-white text-stone-950">
         <div className="mx-auto w-full max-w-6xl px-8 py-12">
-          <div className="m-auto w-full max-w-[90.00rem]" id="div-1">
-            <div className="text-2xl font-medium">Impact & Results</div>
-            <div className="grid grid-cols-3 gap-8 pt-12">
-              <div className="">
-                <div className="flex items-start text-6xl">
-                  3<span className="ml-3 mt-6 text-xl">M</span>
-                </div>
-                <div className="mb-12 text-lg">
-                  Brand strategy and site development of The Merry Beggars led
-                  to 3 million downloads of their original audio entertainment
-                  podcast.
-                </div>
-
-                <a className="text-lg font-medium text-blue-700" href="">
-                  View Case Study
-                </a>
-              </div>
-              <div className="">
-                <div className="flex items-start text-6xl">
-                  10<span className="ml-3 mt-6 text-xl">X</span>
-                </div>
-                <div className="mb-12 text-lg">
-                  Brand strategy and development of Fem Catholic led to a grant
-                  for their initiative, ten times their original site
-                  investment.
-                </div>
-
-                <a className="text-lg font-medium text-blue-700" href="">
-                  View Case Study
-                </a>
-              </div>
-              <div className="">
-                <div className="flex items-start text-6xl">
-                  760<span className="ml-3 mt-6 text-xl">%</span>
-                </div>
-                <div className="mb-12 text-lg">
-                  Increase in online donations within 90 days after Joseph House
-                  site rebrand and website launch.
-                </div>
-
-                <a className="text-lg font-medium text-blue-700" href="">
-                  View Case Study
-                </a>
-              </div>
-            </div>
+          <div className="text-2xl font-medium">Impact & Results</div>
+          <div className="grid grid-cols-3 gap-8 pt-12">
+            <ImpactCard
+              number={3}
+              letter={"m"}
+              text={
+                "Brand strategy and site development of The Merry Beggars led to 3 million downloads of their original audio entertainment podcast."
+              }
+            />
+            <ImpactCard
+              number={10}
+              letter={"x"}
+              text={
+                " Brand strategy and development of Fem Catholic led to a grant for their initiative, ten times their original site investment."
+              }
+            />
+            <ImpactCard
+              number={760}
+              letter={"%"}
+              text={
+                "Increase in online donations within 90 days after Joseph House site rebrand and website launch."
+              }
+            />
           </div>
         </div>
       </div>

--- a/src/app/(app)/services/ServicesImpact.tsx
+++ b/src/app/(app)/services/ServicesImpact.tsx
@@ -1,3 +1,5 @@
+import { ImpactCard } from "@/app/components/ImpactCard";
+
 export function ServicesImpact() {
   return (
     <>

--- a/src/app/(app)/services/ServicesImpact.tsx
+++ b/src/app/(app)/services/ServicesImpact.tsx
@@ -4,7 +4,7 @@ export function ServicesImpact() {
   return (
     <>
       <div className="bg-white text-stone-950">
-        <div className="mx-auto w-full max-w-6xl px-8 py-12">
+        <div className="mx-auto w-full max-w-6xl px-8 py-24">
           <div className="text-2xl font-medium">Impact & Results</div>
           <div className="grid grid-cols-3 gap-8 pt-12">
             <ImpactCard

--- a/src/app/(app)/services/ServicesIntro.tsx
+++ b/src/app/(app)/services/ServicesIntro.tsx
@@ -4,7 +4,7 @@ import { ServiceCard } from "./ServiceCard";
 export function ServicesIntro() {
   const services = getServiceData();
   return (
-    <section className="bg-white px-8 py-12 text-stone-950">
+    <section className="bg-white px-8 py-20 text-stone-950">
       <div className="max-w-8xl container mx-auto">
         <h2 className="mb-16 text-4xl font-bold uppercase">
           <span className="mr-4 pb-4 text-base">Our Speciality</span>A Cleveland

--- a/src/app/(app)/services/ServicesROI.tsx
+++ b/src/app/(app)/services/ServicesROI.tsx
@@ -1,34 +1,30 @@
 export function ServicesROI() {
   return (
-    <>
-      <div>
-        <div className="flex max-w-6xl items-start justify-between bg-white px-8 py-12 text-stone-950">
-          <div className="w-[calc(42%_-_12px)] text-4xl font-medium">
-            <p>Design that makes a good impression and investment.</p>
-          </div>
-
-          <div className="mt-16 w-[calc(50%_-_12px)] text-xl">
-            At Brewww Studio, ROI isnt optional—its essential. We create brand
-            experiences that not only look good but drive real results. Our
-            superior design nurtures relationships and delivers value, proven
-            across industries like fitness, non-profits, media & entertainment,
-            and e-commerce.
-            <div className="mt-12">
-              <p className="mt-5 font-medium text-neutral-800 opacity-60">
-                {" "}
-                5.0/5.0 Avg. Rating on{" "}
-                <a className="underline" href="">
-                  Facebook
-                </a>
-                {" and "}
-                <a className="underline" href="">
-                  Google
-                </a>
-              </p>
-            </div>
+    <div>
+      <div className="flex max-w-6xl items-start justify-between bg-white px-8 py-12 text-stone-950">
+        <div className="w-[calc(42%_-_12px)] text-4xl font-medium">
+          <p>Design that makes a good impression and investment.</p>
+        </div>
+        <div className="mt-16 w-[calc(50%_-_12px)] text-xl">
+          At Brewww Studio, ROI isnt optional—its essential. We create brand
+          experiences that not only look good but drive real results. Our
+          superior design nurtures relationships and delivers value, proven
+          across industries like fitness, non-profits, media & entertainment,
+          and e-commerce.
+          <div className="mt-12">
+            <p className="mt-5 font-medium text-neutral-800 opacity-60">
+              5.0/5.0 Avg. Rating on{" "}
+              <a className="underline" href="">
+                Facebook
+              </a>
+              {" and "}
+              <a className="underline" href="">
+                Google
+              </a>
+            </p>
           </div>
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/app/(app)/services/ServicesSpeciality.tsx
+++ b/src/app/(app)/services/ServicesSpeciality.tsx
@@ -4,7 +4,7 @@ export function ServicesSpecialty() {
   return (
     <>
       <div className="bg-white text-stone-950">
-        <div className="grid min-h-[40rem] grid-cols-2 border-t-2 border-solid border-stone-950">
+        <div className="grid min-h-[40rem] grid-cols-2">
           <div className="flex flex-col justify-center px-12 py-24">
             <h2 className="pb-4 text-[3.13rem] leading-none">Our Specialty</h2>
             <p>
@@ -23,7 +23,7 @@ export function ServicesSpecialty() {
             />
           </div>
         </div>
-        <div className="grid min-h-[40rem] grid-cols-2 border-t-2 border-solid border-stone-950">
+        <div className="grid min-h-[40rem] grid-cols-2">
           <div className="relative flex flex-col justify-center px-24 py-16 opacity-[0.9501] blur-[0px]">
             <Image
               src="/images/broken-glass-light.1920.jpg"

--- a/src/app/(app)/services/ServicesTestimonial.tsx
+++ b/src/app/(app)/services/ServicesTestimonial.tsx
@@ -9,7 +9,7 @@ export function ServicesTestimonial() {
   }
 
   return (
-    <section className="border-t-2 border-solid border-stone-950 bg-white px-16 py-32 text-center text-stone-950">
+    <section className="bg-white px-16 py-32 text-center text-stone-950">
       <TestimonialCard {...testimonial} />
     </section>
   );

--- a/src/app/(app)/services/page.tsx
+++ b/src/app/(app)/services/page.tsx
@@ -4,15 +4,19 @@ import { ServicesSpecialty } from "./ServicesSpeciality";
 import { ServicesImpact } from "./ServicesImpact";
 import { ServicesROI } from "./ServicesROI";
 import { ServicesTestimonial } from "./ServicesTestimonial";
+import { LineFull } from "@/app/components/LineFull";
 
 export default function Page() {
   return (
     <>
       <ServicesHero />
       <ServicesIntro />
+      <LineFull />
       <ServicesSpecialty />
       <ServicesImpact />
+      <LineFull />
       <ServicesROI />
+      <LineFull />
       <ServicesTestimonial />
     </>
   );

--- a/src/app/(app)/services/page.tsx
+++ b/src/app/(app)/services/page.tsx
@@ -14,7 +14,6 @@ export default function Page() {
       <LineFull />
       <ServicesSpecialty />
       <ServicesImpact />
-      <LineFull />
       <ServicesROI />
       <LineFull />
       <ServicesTestimonial />

--- a/src/app/components/ImpactCard.tsx
+++ b/src/app/components/ImpactCard.tsx
@@ -1,3 +1,5 @@
+import { LinkMain } from "./LinkMain";
+
 interface ImpactCardProps {
   number: number;
   letter: string;
@@ -13,11 +15,7 @@ export function ImpactCard({ number, letter, text, link }: ImpactCardProps) {
         <span className="ml-3 mt-6 text-xl">{letter}</span>
       </div>
       <div className="mb-12 text-lg">{text}</div>
-      {link && (
-        <a className="text-lg font-medium text-blue-700" href="">
-          View Case Study
-        </a>
-      )}
+      {link && <LinkMain text="View Case Study" link={link} />}
     </div>
   );
 }

--- a/src/app/components/ImpactCard.tsx
+++ b/src/app/components/ImpactCard.tsx
@@ -1,3 +1,10 @@
-export function ImpactCard({ number, letter, text, link }) {
+interface ImpactCardProps {
+  number: number;
+  letter: string;
+  text: string;
+  link: string;
+}
+
+export function ImpactCard({ number, letter, text, link }: ImpactCardProps) {
   return <div></div>;
 }

--- a/src/app/components/ImpactCard.tsx
+++ b/src/app/components/ImpactCard.tsx
@@ -1,0 +1,3 @@
+export function ImpactCard({ number, letter, text, link }) {
+  return <div></div>;
+}

--- a/src/app/components/ImpactCard.tsx
+++ b/src/app/components/ImpactCard.tsx
@@ -2,9 +2,22 @@ interface ImpactCardProps {
   number: number;
   letter: string;
   text: string;
-  link: string;
+  link?: string;
 }
 
 export function ImpactCard({ number, letter, text, link }: ImpactCardProps) {
-  return <div></div>;
+  return (
+    <div className="">
+      <div className="flex items-start text-6xl">
+        {number}
+        <span className="ml-3 mt-6 text-xl">{letter}</span>
+      </div>
+      <div className="mb-12 text-lg">{text}</div>
+      {link && (
+        <a className="text-lg font-medium text-blue-700" href="">
+          View Case Study
+        </a>
+      )}
+    </div>
+  );
 }

--- a/src/app/components/LineFull.tsx
+++ b/src/app/components/LineFull.tsx
@@ -1,0 +1,5 @@
+export function LineFull() {
+  return (
+    <div className="w-full border-t-2 border-solid border-stone-950"></div>
+  );
+}

--- a/src/app/components/LinkMain.tsx
+++ b/src/app/components/LinkMain.tsx
@@ -3,13 +3,13 @@ import { twMerge } from "tailwind-merge";
 
 interface LinkMainProps {
   text: string;
-  href: string;
+  link: string;
   showArrow?: boolean;
   size?: "large" | "medium" | "small";
 }
 export function LinkMain({
   text,
-  href,
+  link,
   showArrow = true,
   size = "medium",
 }: LinkMainProps) {
@@ -20,7 +20,7 @@ export function LinkMain({
 
   return (
     <>
-      <Link className={linkClass} href={href}>
+      <Link className={linkClass} href={link}>
         <span className="flex cursor-pointer items-center">
           <span>{text}</span>
           {showArrow && (


### PR DESCRIPTION
### TL;DR

This pull request implements significant refactoring changes to the Services page components and their styling. 

Key changes include:

1. **ServiceCard:** Fixed the prop name from `href` to `link`.
2. **ServicesImpact:** Simplified the component by replacing div elements with the new `ImpactCard` component.
3. **ServicesIntro:** Adjusted padding for better visual alignment.
4. **ServicesROI:** Improved nesting and formatting within the JSX structure.
5. **ServicesSpeciality:** Removed unused border classes for a cleaner design.
6. **ServicesTestimonial:** Removed the top border for a more modern look.
7. **page.tsx:** Included `LineFull` component to add horizontal lines separating sections.
8. **ImpactCard Component:** Introduced a new `ImpactCard` reusable component for displaying impact metrics.
9. **LineFull Component:** Introduced a new `LineFull` component for adding horizontal lines.
10. **LinkMain Component:** Changed the prop name from `href` to `link` for consistency.

---

