### PR TITLE
feat(cms): add collections to Payload

### DIFF
--- a/src/collections/BlogCategories.ts
+++ b/src/collections/BlogCategories.ts
@@ -1,0 +1,21 @@
+import { CollectionConfig } from "payload";
+
+export const BlogCategories: CollectionConfig = {
+  slug: "categories",
+  admin: {
+    useAsTitle: "name",
+  },
+  fields: [
+    { name: "name", type: "text", label: "Name", required: false },
+    {
+      name: "slug",
+      type: "text",
+      label: "Slug",
+      required: false,
+      admin: {
+        position: "sidebar",
+        description: "Add a cool slug here",
+      },
+    },
+  ],
+};

--- a/src/collections/BlogPosts.ts
+++ b/src/collections/BlogPosts.ts
@@ -2,12 +2,58 @@ import type { CollectionConfig } from "payload";
 
 export const BlogPosts: CollectionConfig = {
   slug: "posts",
+  admin: {
+    useAsTitle: "name",
+  },
   fields: [
     {
       name: "name",
       type: "text",
       label: "Name",
       required: false,
+      admin: {
+        description: "Add a cool name here",
+      },
+    },
+    {
+      name: "description",
+      type: "text",
+      label: "Meta Description",
+      required: false,
+      admin: {
+        description: "Add a cool description here. ",
+      },
+    },
+    {
+      name: "imageMain",
+      type: "upload",
+      relationTo: "media",
+      label: "Main Image",
+      required: false,
+      admin: {
+        description: "Add a cool image here.",
+      },
+    },
+    {
+      name: "slug",
+      type: "text",
+      label: "Slug",
+      required: false,
+      admin: {
+        position: "sidebar",
+        description: "Add the slug here",
+      },
+    },
+    {
+      name: "postedOn",
+      type: "date",
+      admin: {
+        description: "Add a cool date here",
+        position: "sidebar",
+        date: {
+          displayFormat: "dayAndTime",
+        },
+      },
     },
   ],
 };

--- a/src/collections/BlogPosts.ts
+++ b/src/collections/BlogPosts.ts
@@ -1,3 +1,4 @@
+import { relationship } from "node_modules/payload/dist/fields/validations";
 import type { CollectionConfig } from "payload";
 
 export const BlogPosts: CollectionConfig = {
@@ -16,7 +17,7 @@ export const BlogPosts: CollectionConfig = {
       },
     },
     {
-      name: "description",
+      name: "seoDescription",
       type: "text",
       label: "Meta Description",
       required: false,
@@ -53,6 +54,31 @@ export const BlogPosts: CollectionConfig = {
         date: {
           displayFormat: "dayAndTime",
         },
+      },
+    },
+    {
+      name: "seoKeywords",
+      type: "text",
+      label: "Keywords",
+      required: false,
+      admin: {
+        description: "Add some cool keywords here",
+      },
+    },
+    {
+      name: "category",
+      type: "relationship",
+      relationTo: "categories",
+      label: "Category",
+      required: false,
+    },
+    {
+      name: "content",
+      type: "richText",
+      label: "Main Content",
+      required: false,
+      admin: {
+        description: "Add some cool content here.",
       },
     },
   ],

--- a/src/collections/BlogPosts.ts
+++ b/src/collections/BlogPosts.ts
@@ -1,0 +1,13 @@
+import type { CollectionConfig } from "payload";
+
+export const BlogPosts: CollectionConfig = {
+  slug: "posts",
+  fields: [
+    {
+      name: "name",
+      type: "text",
+      label: "Name",
+      required: false,
+    },
+  ],
+};

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -15,6 +15,7 @@ export interface Config {
     media: Media;
     work: Work;
     clients: Client;
+    posts: Post;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
@@ -102,6 +103,20 @@ export interface Work {
 export interface Client {
   id: string;
   name?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts".
+ */
+export interface Post {
+  id: string;
+  name?: string | null;
+  description?: string | null;
+  imageMain?: string | Media | null;
+  slug?: string | null;
+  postedOn?: string | null;
   updatedAt: string;
   createdAt: string;
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -16,6 +16,7 @@ export interface Config {
     work: Work;
     clients: Client;
     posts: Post;
+    categories: Category;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
@@ -113,10 +114,38 @@ export interface Client {
 export interface Post {
   id: string;
   name?: string | null;
-  description?: string | null;
+  seoDescription?: string | null;
   imageMain?: string | Media | null;
   slug?: string | null;
   postedOn?: string | null;
+  seoKeywords?: string | null;
+  category?: (string | null) | Category;
+  content?: {
+    root: {
+      type: string;
+      children: {
+        type: string;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "categories".
+ */
+export interface Category {
+  id: string;
+  name?: string | null;
+  slug?: string | null;
   updatedAt: string;
   createdAt: string;
 }

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -9,6 +9,8 @@ import { Users } from "./collections/Users";
 import { Media } from "./collections/Media";
 import { Work } from "./collections/Work";
 import { Clients } from "./collections/Clients";
+import { BlogPosts } from "./collections/BlogPosts";
+import { BlogCategories } from "./collections/BlogCategories";
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
@@ -52,7 +54,7 @@ export default buildConfig({
   admin: {
     user: Users.slug,
   },
-  collections: [Users, Media, Work, Clients],
+  collections: [Users, Media, Work, Clients, BlogPosts, BlogCategories],
   editor: lexicalEditor(),
   secret: PAYLOAD_SECRET || "",
   typescript: {


### PR DESCRIPTION
### TL;DR

Add new collections BlogPosts and BlogCategories to the Payload CMS.

### What changed?

- Added new collection `BlogCategories` to `src/collections/BlogCategories.ts` with fields: `name`, `slug` (with admin options).
- Added new collection `BlogPosts` to `src/collections/BlogPosts.ts` with fields: `name`, `seoDescription`, `imageMain` (with relation to `media`), `slug`, `postedOn` (with admin options for date format), `seoKeywords`, `category` (with relation to `categories`), and `content`.
- Updated `src/payload-types.ts` to include interfaces for `Post` and `Category`.
- Modified `src/payload.config.ts` to include the new collections `BlogPosts` and `BlogCategories` in the collections array.

### How to test?

1. Start the Payload CMS.
2. Navigate to the admin dashboard.
3. Verify that new collections `BlogPosts` and `BlogCategories` are available.
4. Test creating, reading, updating, and deleting entries in these collections to ensure functionality.

### Why make this change?

This change adds foundational structures for blog content management in the CMS, facilitating the creation and management of blog posts and their categories.

---

