### PR TITLE
feat(cms): add draft status to collections in Payload

### DIFF
--- a/src/collections/BlogCategories.ts
+++ b/src/collections/BlogCategories.ts
@@ -2,6 +2,9 @@ import { CollectionConfig } from "payload";
 
 export const BlogCategories: CollectionConfig = {
   slug: "categories",
+  versions: {
+    drafts: true,
+  },
   admin: {
     useAsTitle: "name",
   },

--- a/src/collections/BlogPosts.ts
+++ b/src/collections/BlogPosts.ts
@@ -3,6 +3,9 @@ import type { CollectionConfig } from "payload";
 
 export const BlogPosts: CollectionConfig = {
   slug: "posts",
+  versions: {
+    drafts: true,
+  },
   admin: {
     useAsTitle: "name",
   },
@@ -77,9 +80,6 @@ export const BlogPosts: CollectionConfig = {
       type: "richText",
       label: "Main Content",
       required: false,
-      admin: {
-        description: "Add some cool content here.",
-      },
     },
   ],
 };

--- a/src/collections/Clients.ts
+++ b/src/collections/Clients.ts
@@ -1,13 +1,18 @@
 import type { CollectionConfig } from "payload";
 
 export const Clients: CollectionConfig = {
-  slug: "clients", 
-  admin: {
-    useAsTitle: "name"
+  slug: "clients",
+  versions: {
+    drafts: true,
   },
-  fields: [{
-    name: "name", 
-    type: "text",
-    label: "Name"
-  }]
-}
+  admin: {
+    useAsTitle: "name",
+  },
+  fields: [
+    {
+      name: "name",
+      type: "text",
+      label: "Name",
+    },
+  ],
+};

--- a/src/collections/Work.ts
+++ b/src/collections/Work.ts
@@ -2,6 +2,9 @@ import type { CollectionConfig } from "payload";
 
 export const Work: CollectionConfig = {
   slug: "work",
+  versions: {
+    drafts: true,
+  },
   admin: {
     useAsTitle: "name",
   },
@@ -14,6 +17,15 @@ export const Work: CollectionConfig = {
       required: true,
       admin: { position: "sidebar" },
     },
-    {name: "thumbnail", type: "upload", label: "Thumbnail", required: true, relationTo: "media", admin: {description: "This image appears on the WorkCard thumbnail images."}}
+    {
+      name: "thumbnail",
+      type: "upload",
+      label: "Thumbnail",
+      required: true,
+      relationTo: "media",
+      admin: {
+        description: "This image appears on the WorkCard thumbnail images.",
+      },
+    },
   ],
 };

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -96,6 +96,7 @@ export interface Work {
   thumbnail: string | Media;
   updatedAt: string;
   createdAt: string;
+  _status?: ('draft' | 'published') | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -106,6 +107,7 @@ export interface Client {
   name?: string | null;
   updatedAt: string;
   createdAt: string;
+  _status?: ('draft' | 'published') | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -137,6 +139,7 @@ export interface Post {
   } | null;
   updatedAt: string;
   createdAt: string;
+  _status?: ('draft' | 'published') | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -148,6 +151,7 @@ export interface Category {
   slug?: string | null;
   updatedAt: string;
   createdAt: string;
+  _status?: ('draft' | 'published') | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
### TL;DR

Enable drafts versioning across multiple collections in Payload CMS.

### What changed?

- Added `versions.drafts` configuration to `BlogCategories`, `BlogPosts`, `Clients`, and `Work` collections
- Removed redundant admin description from `Main Content` field in `BlogPosts`
- Added `_status` field to TypeScript interfaces for `Work`, `Client`, `Post`, and `Category` to handle draft and published states

### How to test?
1. Implement the changes in Payload CMS
2. Verify that drafts can be created and managed in the specified collections (BlogCategories, BlogPosts, Clients, Work)
3. Confirm that the `_status` field correctly reflects the draft or published state in the TypeScript interfaces

### Why make this change?

This change enhances the CMS by enabling draft versioning for key collections. It allows content editors to create, save, and review drafts before publishing, improving workflow and content management flexibility.


---

