### PR TITLE
feat(cms): add initial Services collection to Payload

### DIFF
--- a/src/collections/Services.ts
+++ b/src/collections/Services.ts
@@ -1,0 +1,29 @@
+import { CollectionConfig } from "payload";
+
+export const Services: CollectionConfig = {
+  slug: "services",
+  admin: {
+    useAsTitle: "name",
+  },
+  fields: [
+    {
+      name: "name",
+      type: "text",
+      label: "Name",
+      required: true,
+      admin: {
+        description: "add a cool name here",
+      },
+    },
+    {
+      name: "slug",
+      type: "text",
+      label: "Slug",
+      required: true,
+      admin: {
+        description: "add a cool slug",
+        position: "sidebar",
+      },
+    },
+  ],
+};

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -14,6 +14,7 @@ export interface Config {
     users: User;
     media: Media;
     work: Work;
+    services: Service;
     clients: Client;
     posts: Post;
     categories: Category;
@@ -97,6 +98,17 @@ export interface Work {
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "services".
+ */
+export interface Service {
+  id: string;
+  name: string;
+  slug: string;
+  updatedAt: string;
+  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -11,6 +11,7 @@ import { Work } from "./collections/Work";
 import { Clients } from "./collections/Clients";
 import { BlogPosts } from "./collections/BlogPosts";
 import { BlogCategories } from "./collections/BlogCategories";
+import { Services } from "./collections/Services";
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
@@ -54,7 +55,15 @@ export default buildConfig({
   admin: {
     user: Users.slug,
   },
-  collections: [Users, Media, Work, Clients, BlogPosts, BlogCategories],
+  collections: [
+    Users,
+    Media,
+    Work,
+    Services,
+    Clients,
+    BlogPosts,
+    BlogCategories,
+  ],
   editor: lexicalEditor(),
   secret: PAYLOAD_SECRET || "",
   typescript: {


### PR DESCRIPTION
### TL;DR

Add a new 'Services' collection to the Payload CMS.

### What changed?

- Created a new file `Services.ts` in `src/collections`.
- Added `Services` collection configuration defining fields: `name` and `slug` both set as required.
- Updated `payload-types.ts` to include new `Service` interface.
- Updated `payload.config.ts` to register the new `Services` collection with the Payload CMS configuration.

### How to test?

1. Pull the changes to your local environment.
2. Run the Payload CMS application.
3. Navigate to the CMS admin dashboard.
4. Verify the existence of the 'Services' collection.
5. Create a new service and verify it saves correctly.

### Why make this change?

Adding the 'Services' collection is essential to organize and manage services offered, enhancing content management capabilities.

---

