### PR TITLE
feat(cms): add Locations collection to Payload

### DIFF
--- a/src/collections/Locations.ts
+++ b/src/collections/Locations.ts
@@ -1,0 +1,6 @@
+import { CollectionConfig } from "payload";
+
+export const Location: CollectionConfig = {
+  slug: "in",
+  fields: [{ name: "name", type: "text", label: "Name" }],
+};

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -14,6 +14,7 @@ import { BlogPosts } from "./collections/BlogPosts";
 import { BlogCategories } from "./collections/BlogCategories";
 import { Services } from "./collections/Services";
 import { Testimonials } from "./collections/Testimonials";
+import { Location } from "./collections/Locations";
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
@@ -66,6 +67,7 @@ export default buildConfig({
     BlogPosts,
     BlogCategories,
     Testimonials,
+    Location,
   ],
   editor: lexicalEditor(),
   secret: PAYLOAD_SECRET || "",


### PR DESCRIPTION
### TL;DR
This PR adds a new `Location` collection to the Payload CMS, allowing users to manage location-specific data.

### What changed?
- Introduced a new file `src/collections/Locations.ts` which defines the `Location` collection.
- Updated `src/payload.config.ts` to include the `Location` collection.

### How to test?
1. Run the CMS and navigate to the collections dashboard.
2. Verify that the `Location` collection appears in the list of collections.
3. Try adding, editing, and deleting entries in the `Location` collection.

### Why make this change?
This change is part of a series of updates aimed at enhancing the CMS with more versatile content management capabilities. The `Location` collection is intended to store and manage geographical data, which could be useful for various applications such as displaying store locations, events, or any location-based content.

---

