### PR TITLE
chore(code): add keep-alive cron job to keep admin route warm

### DIFF
--- a/src/app/keep-alive.ts/route.ts
+++ b/src/app/keep-alive.ts/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  await fetch(`https://${process.env.VERCEL_URL}/admin`);
+  return NextResponse.json({ ok: true });
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron",
+      "schedule": "*/5 * * * *"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "crons": [
     {
-      "path": "/api/cron",
+      "path": "/keep-alive",
       "schedule": "*/5 * * * *"
     }
   ]


### PR DESCRIPTION
### TL;DR

Add a new keep-alive endpoint to ensure the server stays active by hitting the `/admin` route periodically. A cron job is scheduled to run every 5 minutes.

### What changed?

1. Created a new `GET` endpoint in `src/app/keep-alive.ts/route.ts` that performs a fetch request to the `/admin` route.
2. Added a `vercel.json` file to schedule a cron job that hits the `/keep-alive` endpoint every 5 minutes.

### How to test?

1. Deploy the changes to Vercel.
2. Check if the cron job is listed under the Settings > Cron Jobs tab in the Vercel dashboard.
3. Monitor the logs to verify that the `/admin` route is being hit every 5 minutes.

### Why make this change?

This change is introduced to keep the server alive by periodically hitting the `/admin` route, preventing it from going idle due to inactivity.

---

