### PR TITLE
feat(cms): add limit to saved documents

### DIFF
--- a/src/collections/BlogCategories.ts
+++ b/src/collections/BlogCategories.ts
@@ -4,7 +4,9 @@ export const BlogCategories: CollectionConfig = {
   slug: "categories",
   versions: {
     drafts: true,
+    maxPerDoc: 25,
   },
+
   admin: {
     useAsTitle: "name",
   },

--- a/src/collections/BlogPosts.ts
+++ b/src/collections/BlogPosts.ts
@@ -4,6 +4,7 @@ export const BlogPosts: CollectionConfig = {
   slug: "posts",
   versions: {
     drafts: true,
+    maxPerDoc: 25,
   },
   admin: {
     useAsTitle: "name",

--- a/src/collections/Clients.ts
+++ b/src/collections/Clients.ts
@@ -4,6 +4,7 @@ export const Clients: CollectionConfig = {
   slug: "clients",
   versions: {
     drafts: true,
+    maxPerDoc: 25,
   },
   admin: {
     useAsTitle: "name",

--- a/src/collections/Locations.ts
+++ b/src/collections/Locations.ts
@@ -2,5 +2,8 @@ import type { CollectionConfig } from "payload";
 
 export const Location: CollectionConfig = {
   slug: "in",
+  admin: {
+    useAsTitle: "name",
+  },
   fields: [{ name: "name", type: "text", label: "Name" }],
 };

--- a/src/collections/Pages.ts
+++ b/src/collections/Pages.ts
@@ -4,6 +4,7 @@ export const Pages: CollectionConfig = {
   slug: "pages",
   versions: {
     drafts: true,
+    maxPerDoc: 25,
   },
   admin: {
     useAsTitle: "name",

--- a/src/collections/Results.ts
+++ b/src/collections/Results.ts
@@ -2,6 +2,13 @@ import type { CollectionConfig } from "payload";
 
 export const Results: CollectionConfig = {
   slug: "results",
+  versions: {
+    drafts: true,
+    maxPerDoc: 25,
+  },
+  admin: {
+    useAsTitle: "name",
+  },
   fields: [
     {
       name: "name",

--- a/src/collections/Services.ts
+++ b/src/collections/Services.ts
@@ -4,6 +4,7 @@ export const Services: CollectionConfig = {
   slug: "services",
   versions: {
     drafts: true,
+    maxPerDoc: 25,
   },
   admin: {
     useAsTitle: "name",

--- a/src/collections/Testimonials.ts
+++ b/src/collections/Testimonials.ts
@@ -4,6 +4,7 @@ export const Testimonials: CollectionConfig = {
   slug: "testimonials",
   versions: {
     drafts: true,
+    maxPerDoc: 25,
   },
   admin: {
     useAsTitle: "name",

--- a/src/collections/Work.ts
+++ b/src/collections/Work.ts
@@ -4,6 +4,7 @@ export const Work: CollectionConfig = {
   slug: "work",
   versions: {
     drafts: true,
+    maxPerDoc: 25,
   },
   admin: {
     useAsTitle: "name",


### PR DESCRIPTION
### TL;DR

Added version control and improved admin settings for various collections.

### What changed?

- Added `maxPerDoc: 25` to version control settings for BlogCategories, BlogPosts, Clients, Pages, Services, Testimonials, and Work collections.
- Added version control with drafts and `maxPerDoc: 25` for the Results collection.
- Added `useAsTitle: "name"` to the admin settings for the Location and Results collections.

### How to test?

1. Access the admin panel for each modified collection.
2. Verify that version control is working correctly, allowing up to 25 versions per document.
3. Check that drafts can be created and managed for the Results collection.
4. Confirm that the "name" field is used as the title in the admin interface for Location and Results collections.

### Why make this change?

These changes improve version control and admin usability across multiple collections:

1. Setting `maxPerDoc: 25` limits the number of versions stored per document, preventing excessive storage usage while maintaining a reasonable version history.
2. Adding version control to the Results collection allows for draft creation and management, improving content workflow.
3. Using the "name" field as the title in the admin interface for Location and Results collections enhances readability and navigation for content managers.

---

