### PR TITLE
feat(cms): add labels to collections for clarity

### DIFF
--- a/src/collections/BlogCategories.ts
+++ b/src/collections/BlogCategories.ts
@@ -6,9 +6,12 @@ export const BlogCategories: CollectionConfig = {
     drafts: true,
     maxPerDoc: 25,
   },
-
   admin: {
     useAsTitle: "name",
+  },
+  labels: {
+    singular: "Category",
+    plural: "Categories",
   },
   fields: [
     { name: "name", type: "text", label: "Category Name", required: true },

--- a/src/collections/BlogPosts.ts
+++ b/src/collections/BlogPosts.ts
@@ -9,6 +9,10 @@ export const BlogPosts: CollectionConfig = {
   admin: {
     useAsTitle: "name",
   },
+  labels: {
+    singular: "Post",
+    plural: "Posts",
+  },
   fields: [
     {
       name: "name",

--- a/src/collections/Clients.ts
+++ b/src/collections/Clients.ts
@@ -9,6 +9,10 @@ export const Clients: CollectionConfig = {
   admin: {
     useAsTitle: "name",
   },
+  labels: {
+    singular: "Client",
+    plural: "Clients",
+  },
   fields: [
     {
       name: "name",

--- a/src/collections/Locations.ts
+++ b/src/collections/Locations.ts
@@ -5,5 +5,13 @@ export const Location: CollectionConfig = {
   admin: {
     useAsTitle: "name",
   },
+  versions: {
+    drafts: true,
+    maxPerDoc: 25,
+  },
+  labels: {
+    singular: "Location",
+    plural: "Locations",
+  },
   fields: [{ name: "name", type: "text", label: "Name" }],
 };

--- a/src/collections/Results.ts
+++ b/src/collections/Results.ts
@@ -9,6 +9,10 @@ export const Results: CollectionConfig = {
   admin: {
     useAsTitle: "name",
   },
+  labels: {
+    singular: "Result",
+    plural: "Results",
+  },
   fields: [
     {
       name: "name",

--- a/src/collections/Services.ts
+++ b/src/collections/Services.ts
@@ -9,6 +9,10 @@ export const Services: CollectionConfig = {
   admin: {
     useAsTitle: "name",
   },
+  labels: {
+    singular: "Service",
+    plural: "Services",
+  },
   fields: [
     {
       name: "name",

--- a/src/collections/Testimonials.ts
+++ b/src/collections/Testimonials.ts
@@ -9,6 +9,10 @@ export const Testimonials: CollectionConfig = {
   admin: {
     useAsTitle: "name",
   },
+  labels: {
+    singular: "Testimonial",
+    plural: "Testimonials",
+  },
   fields: [
     {
       name: "name",

--- a/src/collections/Work.ts
+++ b/src/collections/Work.ts
@@ -9,6 +9,10 @@ export const Work: CollectionConfig = {
   admin: {
     useAsTitle: "name",
   },
+  labels: {
+    singular: "Work",
+    plural: "Works",
+  },
   fields: [
     { name: "name", type: "text", label: "Name", required: true },
     {


### PR DESCRIPTION
### TL;DR

Added labels and version control to collection configurations.

### What changed?

- Added `labels` property to all collection configurations, specifying singular and plural forms.
- Implemented version control for the Location collection by adding the `versions` property.

### How to test?

1. Navigate to the admin panel and verify that the correct singular and plural labels are displayed for each collection.
2. Create and edit entries in the Location collection to ensure that version control is working as expected, with drafts and a maximum of 25 versions per document.

### Why make this change?

This change improves the user experience in the admin panel by providing clear and consistent labeling for collections. It also enhances content management for the Location collection by enabling version control, allowing for better tracking of changes and the ability to revert to previous versions if needed.

---

