### PR TITLE
feat(cms): add initial Playground collection to Payload

### DIFF
--- a/src/collections/Playground.ts
+++ b/src/collections/Playground.ts
@@ -1,0 +1,36 @@
+import type { CollectionConfig } from "payload";
+
+export const Playground: CollectionConfig = {
+  slug: "play",
+  versions: {
+    drafts: true,
+    maxPerDoc: 25,
+  },
+  admin: {
+    useAsTitle: "name",
+  },
+  labels: {
+    singular: "Playground",
+    plural: "Playgrounds",
+  },
+  fields: [
+    { name: "name", type: "text", label: "Name", required: true },
+    {
+      name: "slug",
+      type: "text",
+      label: "Slug",
+      required: false,
+      admin: { position: "sidebar" },
+    },
+    {
+      name: "thumbnail",
+      type: "upload",
+      label: "Thumbnail",
+      required: false,
+      relationTo: "media",
+      admin: {
+        description: "This image appears on the PlayCard thumbnail images.",
+      },
+    },
+  ],
+};

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -19,6 +19,7 @@ import { Results } from "./collections/Results";
 import { Pages } from "./collections/Pages";
 import { Header } from "./globals/Header";
 import { Footer } from "./globals/Footer";
+import { Playground } from "./collections/Playground";
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
@@ -63,17 +64,18 @@ export default buildConfig({
     user: Users.slug,
   },
   collections: [
-    Users,
     Media,
     Pages,
-    Work,
-    Services,
-    Clients,
     BlogPosts,
     BlogCategories,
+    Work,
+    Playground,
+    Services,
+    Clients,
     Testimonials,
     Location,
     Results,
+    Users,
   ],
   globals: [Header, Footer],
   editor: lexicalEditor(),


### PR DESCRIPTION
### TL;DR

Added a new Playground collection and updated the collection order in the payload configuration.

### What changed?

- Created a new `Playground` collection with fields for name, slug, and thumbnail.
- Added the `Playground` collection to the payload configuration.
- Reordered the collections in the payload configuration, moving `Users` to the end of the list.

### How to test?

1. Navigate to the admin panel.
2. Verify that the new Playground collection is visible and accessible.
3. Create a new Playground entry and ensure all fields (name, slug, thumbnail) are working correctly.
4. Check that the collection order in the admin panel matches the updated order in the payload configuration.

### Why make this change?

This change introduces a new Playground collection, a feature to showcase interior creative projects. Reordering collections in the payload configuration improves the organization and usability of the admin panel.

---

