### PR TITLE
feat(cms): add tabs and SEO to BlogPosts collection in Payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "postbuild": "node generate-sitemap.js",
     "start": "next start",
     "lint": "next lint",
+    "generate:importmap": "payload generate:importmap",
     "clean": "rm -rf .next/ && rm -rf node_modules/ && pnpm install"
   },
   "dependencies": {
@@ -36,7 +37,7 @@
     "react": "19.0.0-rc-06d0b89e-20240801",
     "react-dom": "19.0.0-rc-06d0b89e-20240801",
     "react-hook-form": "7.45.4",
-    "sharp": "0.32.6",
+    "sharp": "^0.33.4",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/src/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/src/app/(payload)/admin/[[...segments]]/page.tsx
@@ -1,24 +1,27 @@
 /* THIS FILE WAS GENERATED AUTOMATICALLY BY PAYLOAD. */
-import type { Metadata } from 'next'
+import type { Metadata } from "next";
 
-import config from '@payload-config'
+import config from "@payload-config";
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
-import { RootPage, generatePageMetadata } from '@payloadcms/next/views'
-import { importMap } from '../importMap'
+import { RootPage, generatePageMetadata } from "@payloadcms/next/views";
+import { importMap } from "../importMap";
 
 type Args = {
   params: {
-    segments: string[]
-  }
+    segments: string[];
+  };
   searchParams: {
-    [key: string]: string | string[]
-  }
-}
+    [key: string]: string | string[];
+  };
+};
 
-export const generateMetadata = ({ params, searchParams }: Args): Promise<Metadata> =>
-  generatePageMetadata({ config, params, searchParams })
+export const generateMetadata = ({
+  params,
+  searchParams,
+}: Args): Promise<Metadata> =>
+  generatePageMetadata({ config, params, searchParams });
 
 const Page = ({ params, searchParams }: Args) =>
-  RootPage({ config, params, searchParams, importMap })
+  RootPage({ config, params, searchParams, importMap });
 
-export default Page
+export default Page;

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -1,1 +1,59 @@
-export const importMap = {}
+import { RichTextCell as RichTextCell_0 } from '@payloadcms/richtext-lexical/client'
+import { RichTextField as RichTextField_1 } from '@payloadcms/richtext-lexical/client'
+import { getGenerateComponentMap as getGenerateComponentMap_2 } from '@payloadcms/richtext-lexical/generateComponentMap'
+import { InlineToolbarFeatureClient as InlineToolbarFeatureClient_3 } from '@payloadcms/richtext-lexical/client'
+import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_4 } from '@payloadcms/richtext-lexical/client'
+import { UploadFeatureClient as UploadFeatureClient_5 } from '@payloadcms/richtext-lexical/client'
+import { BlockquoteFeatureClient as BlockquoteFeatureClient_6 } from '@payloadcms/richtext-lexical/client'
+import { RelationshipFeatureClient as RelationshipFeatureClient_7 } from '@payloadcms/richtext-lexical/client'
+import { LinkFeatureClient as LinkFeatureClient_8 } from '@payloadcms/richtext-lexical/client'
+import { ChecklistFeatureClient as ChecklistFeatureClient_9 } from '@payloadcms/richtext-lexical/client'
+import { OrderedListFeatureClient as OrderedListFeatureClient_10 } from '@payloadcms/richtext-lexical/client'
+import { UnorderedListFeatureClient as UnorderedListFeatureClient_11 } from '@payloadcms/richtext-lexical/client'
+import { IndentFeatureClient as IndentFeatureClient_12 } from '@payloadcms/richtext-lexical/client'
+import { AlignFeatureClient as AlignFeatureClient_13 } from '@payloadcms/richtext-lexical/client'
+import { HeadingFeatureClient as HeadingFeatureClient_14 } from '@payloadcms/richtext-lexical/client'
+import { ParagraphFeatureClient as ParagraphFeatureClient_15 } from '@payloadcms/richtext-lexical/client'
+import { InlineCodeFeatureClient as InlineCodeFeatureClient_16 } from '@payloadcms/richtext-lexical/client'
+import { SuperscriptFeatureClient as SuperscriptFeatureClient_17 } from '@payloadcms/richtext-lexical/client'
+import { SubscriptFeatureClient as SubscriptFeatureClient_18 } from '@payloadcms/richtext-lexical/client'
+import { StrikethroughFeatureClient as StrikethroughFeatureClient_19 } from '@payloadcms/richtext-lexical/client'
+import { UnderlineFeatureClient as UnderlineFeatureClient_20 } from '@payloadcms/richtext-lexical/client'
+import { BoldFeatureClient as BoldFeatureClient_21 } from '@payloadcms/richtext-lexical/client'
+import { ItalicFeatureClient as ItalicFeatureClient_22 } from '@payloadcms/richtext-lexical/client'
+import { OverviewComponent as OverviewComponent_23 } from '@payloadcms/plugin-seo/client'
+import { MetaImageComponent as MetaImageComponent_24 } from '@payloadcms/plugin-seo/client'
+import { MetaTitleComponent as MetaTitleComponent_25 } from '@payloadcms/plugin-seo/client'
+import { MetaDescriptionComponent as MetaDescriptionComponent_26 } from '@payloadcms/plugin-seo/client'
+import { PreviewComponent as PreviewComponent_27 } from '@payloadcms/plugin-seo/client'
+
+export const importMap = {
+  "@payloadcms/richtext-lexical/client#RichTextCell": RichTextCell_0,
+  "@payloadcms/richtext-lexical/client#RichTextField": RichTextField_1,
+  "@payloadcms/richtext-lexical/generateComponentMap#getGenerateComponentMap": getGenerateComponentMap_2,
+  "@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient": InlineToolbarFeatureClient_3,
+  "@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient": HorizontalRuleFeatureClient_4,
+  "@payloadcms/richtext-lexical/client#UploadFeatureClient": UploadFeatureClient_5,
+  "@payloadcms/richtext-lexical/client#BlockquoteFeatureClient": BlockquoteFeatureClient_6,
+  "@payloadcms/richtext-lexical/client#RelationshipFeatureClient": RelationshipFeatureClient_7,
+  "@payloadcms/richtext-lexical/client#LinkFeatureClient": LinkFeatureClient_8,
+  "@payloadcms/richtext-lexical/client#ChecklistFeatureClient": ChecklistFeatureClient_9,
+  "@payloadcms/richtext-lexical/client#OrderedListFeatureClient": OrderedListFeatureClient_10,
+  "@payloadcms/richtext-lexical/client#UnorderedListFeatureClient": UnorderedListFeatureClient_11,
+  "@payloadcms/richtext-lexical/client#IndentFeatureClient": IndentFeatureClient_12,
+  "@payloadcms/richtext-lexical/client#AlignFeatureClient": AlignFeatureClient_13,
+  "@payloadcms/richtext-lexical/client#HeadingFeatureClient": HeadingFeatureClient_14,
+  "@payloadcms/richtext-lexical/client#ParagraphFeatureClient": ParagraphFeatureClient_15,
+  "@payloadcms/richtext-lexical/client#InlineCodeFeatureClient": InlineCodeFeatureClient_16,
+  "@payloadcms/richtext-lexical/client#SuperscriptFeatureClient": SuperscriptFeatureClient_17,
+  "@payloadcms/richtext-lexical/client#SubscriptFeatureClient": SubscriptFeatureClient_18,
+  "@payloadcms/richtext-lexical/client#StrikethroughFeatureClient": StrikethroughFeatureClient_19,
+  "@payloadcms/richtext-lexical/client#UnderlineFeatureClient": UnderlineFeatureClient_20,
+  "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_21,
+  "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_22,
+  "@payloadcms/plugin-seo/client#OverviewComponent": OverviewComponent_23,
+  "@payloadcms/plugin-seo/client#MetaImageComponent": MetaImageComponent_24,
+  "@payloadcms/plugin-seo/client#MetaTitleComponent": MetaTitleComponent_25,
+  "@payloadcms/plugin-seo/client#MetaDescriptionComponent": MetaDescriptionComponent_26,
+  "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_27
+}

--- a/src/collections/BlogPosts.ts
+++ b/src/collections/BlogPosts.ts
@@ -1,36 +1,84 @@
 import type { CollectionConfig } from "payload";
+import {
+  MetaDescriptionField,
+  MetaImageField,
+  MetaTitleField,
+  OverviewField,
+  PreviewField,
+} from "@payloadcms/plugin-seo/fields";
 
 export const BlogPosts: CollectionConfig = {
   slug: "posts",
-  versions: {
-    drafts: true,
-    maxPerDoc: 25,
-  },
-  admin: {
-    useAsTitle: "name",
-  },
-  labels: {
-    singular: "Post",
-    plural: "Posts",
-  },
+
   fields: [
     {
-      name: "name",
-      type: "text",
-      label: "Name",
-      required: true,
-      admin: {
-        description: "Add a cool name here",
-      },
+      type: "tabs",
+      tabs: [
+        {
+          fields: [
+            {
+              name: "name",
+              type: "text",
+              label: "Post Title",
+              required: true,
+              admin: {
+                description: "Add a cool name here",
+              },
+            },
+            {
+              name: "imageMain",
+              type: "upload",
+              relationTo: "media",
+              label: "Main Image",
+              required: false,
+              admin: {
+                description: "Add a cool image here.",
+              },
+            },
+            {
+              name: "content",
+              type: "richText",
+              label: "Main Content",
+              required: false,
+            },
+          ],
+          label: "Content",
+        },
+        {
+          name: "meta",
+          label: "SEO",
+          fields: [
+            OverviewField({
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+              imagePath: "meta.image",
+            }),
+            MetaImageField({
+              relationTo: "media",
+            }),
+            MetaTitleField({
+              hasGenerateFn: true,
+            }),
+            MetaDescriptionField({}),
+            PreviewField({
+              // if the `generateUrl` function is configured
+              hasGenerateFn: true,
+              // field paths to match the target field for data
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+            }),
+          ],
+        },
+      ],
     },
     {
-      name: "imageMain",
-      type: "upload",
-      relationTo: "media",
-      label: "Main Image",
+      name: "slug",
+      type: "text",
+      label: "Slug",
       required: false,
       admin: {
-        description: "Add a cool image here.",
+        position: "sidebar",
+        description: "Add the slug here",
       },
     },
     {
@@ -46,16 +94,6 @@ export const BlogPosts: CollectionConfig = {
       },
     },
     {
-      name: "slug",
-      type: "text",
-      label: "Slug",
-      required: false,
-      admin: {
-        position: "sidebar",
-        description: "Add the slug here",
-      },
-    },
-    {
       name: "category",
       type: "relationship",
       relationTo: "categories",
@@ -66,11 +104,16 @@ export const BlogPosts: CollectionConfig = {
         description: "Add the post category here. ",
       },
     },
-    {
-      name: "content",
-      type: "richText",
-      label: "Main Content",
-      required: false,
-    },
   ],
+  versions: {
+    drafts: true,
+    maxPerDoc: 25,
+  },
+  admin: {
+    useAsTitle: "name",
+  },
+  labels: {
+    singular: "Post",
+    plural: "Posts",
+  },
 };

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -97,9 +97,6 @@ export interface Post {
   id: string;
   name: string;
   imageMain?: string | Media | null;
-  postedOn: string;
-  slug?: string | null;
-  category: string | Category;
   content?: {
     root: {
       type: string;
@@ -116,10 +113,13 @@ export interface Post {
     [k: string]: unknown;
   } | null;
   meta?: {
+    image?: string | Media | null;
     title?: string | null;
     description?: string | null;
-    image?: string | Media | null;
   };
+  slug?: string | null;
+  postedOn: string;
+  category: string | Category;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -106,7 +106,7 @@ export default buildConfig({
       },
     }),
     seoPlugin({
-      collections: ["work", "posts"],
+      collections: ["work"],
       uploadsCollection: "media",
       fieldOverrides: {
         title: { required: false },


### PR DESCRIPTION
### TL;DR

Added SEO functionality to blog posts and updated the admin interface.

### What changed?

- Added a new "generate:importmap" script in package.json
- Updated the sharp dependency to version ^0.33.4
- Implemented SEO fields for blog posts, including meta title, description, and image
- Restructured the BlogPosts collection to use tabs for better organization
- Updated the admin interface to include SEO preview and overview components
- Modified the importMap to include necessary SEO and rich text components

### How to test?

1. Run `pnpm generate:importmap` to generate the updated import map
2. Start the development server and navigate to the admin panel
3. Create or edit a blog post
4. Verify that the new SEO tab is present and functional
5. Test the SEO preview functionality
6. Ensure that rich text editing still works as expected

### Why make this change?

This change enhances the SEO capabilities of blog posts, allowing for better control over meta information and improving search engine visibility. The updated admin interface provides a more user-friendly experience for content creators to manage SEO-related fields and preview how their content will appear in search results.

---

