### PR TITLE
feat(cms): add tabs and SEO to Work collection in Payload

### DIFF
--- a/src/collections/BlogCategories.ts
+++ b/src/collections/BlogCategories.ts
@@ -68,6 +68,7 @@ export const BlogCategories: CollectionConfig = {
   },
   admin: {
     useAsTitle: "name",
+    defaultColumns: ["name"],
   },
   labels: {
     singular: "Category",

--- a/src/collections/Clients.ts
+++ b/src/collections/Clients.ts
@@ -2,17 +2,6 @@ import type { CollectionConfig } from "payload";
 
 export const Clients: CollectionConfig = {
   slug: "clients",
-  versions: {
-    drafts: true,
-    maxPerDoc: 25,
-  },
-  admin: {
-    useAsTitle: "name",
-  },
-  labels: {
-    singular: "Client",
-    plural: "Clients",
-  },
   fields: [
     {
       name: "name",
@@ -64,4 +53,15 @@ export const Clients: CollectionConfig = {
       },
     },
   ],
+  versions: {
+    drafts: true,
+    maxPerDoc: 25,
+  },
+  admin: {
+    useAsTitle: "name",
+  },
+  labels: {
+    singular: "Client",
+    plural: "Clients",
+  },
 };

--- a/src/collections/Locations.ts
+++ b/src/collections/Locations.ts
@@ -2,6 +2,7 @@ import type { CollectionConfig } from "payload";
 
 export const Location: CollectionConfig = {
   slug: "in",
+  fields: [{ name: "name", type: "text", label: "Name" }],
   admin: {
     useAsTitle: "name",
   },
@@ -13,5 +14,4 @@ export const Location: CollectionConfig = {
     singular: "Location",
     plural: "Locations",
   },
-  fields: [{ name: "name", type: "text", label: "Name" }],
 };

--- a/src/collections/Pages.ts
+++ b/src/collections/Pages.ts
@@ -2,13 +2,6 @@ import type { CollectionConfig } from "payload";
 
 export const Pages: CollectionConfig = {
   slug: "pages",
-  versions: {
-    drafts: true,
-    maxPerDoc: 25,
-  },
-  admin: {
-    useAsTitle: "name",
-  },
   fields: [
     {
       name: "name",
@@ -37,4 +30,11 @@ export const Pages: CollectionConfig = {
       blocks: [],
     },
   ],
+  versions: {
+    drafts: true,
+    maxPerDoc: 25,
+  },
+  admin: {
+    useAsTitle: "name",
+  },
 };

--- a/src/collections/Playground.ts
+++ b/src/collections/Playground.ts
@@ -2,17 +2,6 @@ import type { CollectionConfig } from "payload";
 
 export const Playground: CollectionConfig = {
   slug: "play",
-  versions: {
-    drafts: true,
-    maxPerDoc: 25,
-  },
-  admin: {
-    useAsTitle: "name",
-  },
-  labels: {
-    singular: "Playground",
-    plural: "Playgrounds",
-  },
   fields: [
     { name: "name", type: "text", label: "Name", required: true },
     {
@@ -33,4 +22,15 @@ export const Playground: CollectionConfig = {
       },
     },
   ],
+  versions: {
+    drafts: true,
+    maxPerDoc: 25,
+  },
+  admin: {
+    useAsTitle: "name",
+  },
+  labels: {
+    singular: "Playground",
+    plural: "Playgrounds",
+  },
 };

--- a/src/collections/Results.ts
+++ b/src/collections/Results.ts
@@ -2,17 +2,6 @@ import type { CollectionConfig } from "payload";
 
 export const Results: CollectionConfig = {
   slug: "results",
-  versions: {
-    drafts: true,
-    maxPerDoc: 25,
-  },
-  admin: {
-    useAsTitle: "name",
-  },
-  labels: {
-    singular: "Result",
-    plural: "Results",
-  },
   fields: [
     {
       name: "name",
@@ -35,4 +24,15 @@ export const Results: CollectionConfig = {
       required: false,
     },
   ],
+  versions: {
+    drafts: true,
+    maxPerDoc: 25,
+  },
+  admin: {
+    useAsTitle: "name",
+  },
+  labels: {
+    singular: "Result",
+    plural: "Results",
+  },
 };

--- a/src/collections/Services.ts
+++ b/src/collections/Services.ts
@@ -2,17 +2,7 @@ import type { CollectionConfig } from "payload";
 
 export const Services: CollectionConfig = {
   slug: "services",
-  versions: {
-    drafts: true,
-    maxPerDoc: 25,
-  },
-  admin: {
-    useAsTitle: "name",
-  },
-  labels: {
-    singular: "Service",
-    plural: "Services",
-  },
+
   fields: [
     {
       name: "name",
@@ -34,4 +24,15 @@ export const Services: CollectionConfig = {
       },
     },
   ],
+  versions: {
+    drafts: true,
+    maxPerDoc: 25,
+  },
+  admin: {
+    useAsTitle: "name",
+  },
+  labels: {
+    singular: "Service",
+    plural: "Services",
+  },
 };

--- a/src/collections/Testimonials.ts
+++ b/src/collections/Testimonials.ts
@@ -2,17 +2,6 @@ import type { CollectionConfig } from "payload";
 
 export const Testimonials: CollectionConfig = {
   slug: "testimonials",
-  versions: {
-    drafts: true,
-    maxPerDoc: 25,
-  },
-  admin: {
-    useAsTitle: "name",
-  },
-  labels: {
-    singular: "Testimonial",
-    plural: "Testimonials",
-  },
   fields: [
     {
       name: "name",
@@ -58,4 +47,15 @@ export const Testimonials: CollectionConfig = {
       required: true,
     },
   ],
+  versions: {
+    drafts: true,
+    maxPerDoc: 25,
+  },
+  admin: {
+    useAsTitle: "name",
+  },
+  labels: {
+    singular: "Testimonial",
+    plural: "Testimonials",
+  },
 };

--- a/src/collections/Users.ts
+++ b/src/collections/Users.ts
@@ -2,9 +2,9 @@ import type { CollectionConfig } from "payload";
 
 export const Users: CollectionConfig = {
   slug: "users",
+  fields: [{ name: "name", type: "text", label: "Full Name" }],
   admin: {
     useAsTitle: "name",
   },
-  fields: [{ name: "name", type: "text", label: "Full Name" }],
   auth: true,
 };

--- a/src/collections/Work.ts
+++ b/src/collections/Work.ts
@@ -1,7 +1,92 @@
 import type { CollectionConfig } from "payload";
 
+import {
+  MetaDescriptionField,
+  MetaImageField,
+  MetaTitleField,
+  OverviewField,
+  PreviewField,
+} from "@payloadcms/plugin-seo/fields";
+
 export const Work: CollectionConfig = {
   slug: "work",
+
+  fields: [
+    {
+      type: "tabs",
+      tabs: [
+        {
+          label: "Content",
+          fields: [
+            { name: "name", type: "text", label: "Name", required: true },
+            {
+              name: "thumbnail",
+              type: "upload",
+              label: "Thumbnail",
+              required: false,
+              relationTo: "media",
+              admin: {
+                description:
+                  "This image appears on the WorkCard thumbnail images.",
+              },
+            },
+            {
+              name: "testimonial",
+              type: "relationship",
+              relationTo: "testimonials",
+              hasMany: false,
+              required: false,
+              admin: {
+                description: "If a testimonial exists, add it here.",
+              },
+            },
+            {
+              name: "client",
+              type: "relationship",
+              relationTo: "clients",
+              hasMany: false,
+              required: true,
+              admin: {
+                description: "Add the connected client here. ",
+              },
+            },
+          ],
+        },
+        {
+          label: "SEO",
+          fields: [
+            OverviewField({
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+              imagePath: "meta.image",
+            }),
+            MetaImageField({
+              relationTo: "media",
+            }),
+            MetaTitleField({
+              hasGenerateFn: true,
+            }),
+            MetaDescriptionField({}),
+            PreviewField({
+              // if the `generateUrl` function is configured
+              hasGenerateFn: true,
+              // field paths to match the target field for data
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+            }),
+          ],
+        },
+      ],
+    },
+
+    {
+      name: "slug",
+      type: "text",
+      label: "Slug",
+      required: false,
+      admin: { position: "sidebar" },
+    },
+  ],
   versions: {
     drafts: true,
     maxPerDoc: 25,
@@ -13,44 +98,4 @@ export const Work: CollectionConfig = {
     singular: "Work",
     plural: "Works",
   },
-  fields: [
-    { name: "name", type: "text", label: "Name", required: true },
-    {
-      name: "slug",
-      type: "text",
-      label: "Slug",
-      required: false,
-      admin: { position: "sidebar" },
-    },
-    {
-      name: "thumbnail",
-      type: "upload",
-      label: "Thumbnail",
-      required: false,
-      relationTo: "media",
-      admin: {
-        description: "This image appears on the WorkCard thumbnail images.",
-      },
-    },
-    {
-      name: "testimonial",
-      type: "relationship",
-      relationTo: "testimonials",
-      hasMany: false,
-      required: false,
-      admin: {
-        description: "If a testimonial exists, add it here.",
-      },
-    },
-    {
-      name: "client",
-      type: "relationship",
-      relationTo: "clients",
-      hasMany: false,
-      required: true,
-      admin: {
-        description: "Add the connected client here. ",
-      },
-    },
-  ],
 };

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -144,15 +144,13 @@ export interface Category {
 export interface Work {
   id: string;
   name: string;
-  slug?: string | null;
   thumbnail?: string | Media | null;
   testimonial?: (string | null) | Testimonial;
   client: string | Client;
-  meta?: {
-    title?: string | null;
-    description?: string | null;
-    image?: string | Media | null;
-  };
+  image?: string | Media | null;
+  title?: string | null;
+  description?: string | null;
+  slug?: string | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -106,7 +106,6 @@ export default buildConfig({
       },
     }),
     seoPlugin({
-      collections: ["work"],
       uploadsCollection: "media",
       fieldOverrides: {
         title: { required: false },


### PR DESCRIPTION
### TL;DR

Restructured collection configurations and added SEO fields to the Work collection.

### What changed?

- Reordered fields in multiple collection configurations for consistency
- Added defaultColumns to BlogCategories admin configuration
- Implemented SEO fields for the Work collection using @payloadcms/plugin-seo
- Restructured Work collection fields into Content and SEO tabs
- Updated payload-types.ts to reflect changes in the Work interface

### How to test?

1. Navigate to the admin panel and verify the following:
   - BlogCategories collection displays the "name" column by default
   - Work collection has new Content and SEO tabs
   - SEO fields are present in the Work collection's SEO tab
2. Create or edit a Work item to ensure SEO fields are functioning correctly
3. Check that other collections (Clients, Pages, Playground, Results, Services, Testimonials) still work as expected despite field reordering

### Why make this change?

- To improve consistency across collection configurations
- To enhance SEO capabilities for the Work collection
- To provide a more organized and user-friendly interface for managing Work items in the admin panel

---

