### PR TITLE
feat(cms): add tabs and SEO to Playground collection in Payload

### DIFF
--- a/src/collections/BlogPosts.ts
+++ b/src/collections/BlogPosts.ts
@@ -109,7 +109,13 @@ export const BlogPosts: CollectionConfig = {
   },
   admin: {
     useAsTitle: "name",
-    defaultColumns: ["name"],
+    defaultColumns: ["name", "postedOn", "updatedAt"],
+
+    pagination: {
+      defaultLimit: 25,
+      limits: [10, 25, 50, 100],
+    },
+    description: "Writing brings clarity.",
   },
   labels: {
     singular: "Post",

--- a/src/collections/Playground.ts
+++ b/src/collections/Playground.ts
@@ -1,25 +1,68 @@
 import type { CollectionConfig } from "payload";
 
+import {
+  MetaDescriptionField,
+  MetaImageField,
+  MetaTitleField,
+  OverviewField,
+  PreviewField,
+} from "@payloadcms/plugin-seo/fields";
+
 export const Playground: CollectionConfig = {
   slug: "play",
   fields: [
-    { name: "name", type: "text", label: "Name", required: true },
     {
-      name: "slug",
-      type: "text",
-      label: "Slug",
-      required: false,
-      admin: { position: "sidebar" },
-    },
-    {
-      name: "thumbnail",
-      type: "upload",
-      label: "Thumbnail",
-      required: false,
-      relationTo: "media",
-      admin: {
-        description: "This image appears on the PlayCard thumbnail images.",
-      },
+      type: "tabs",
+      tabs: [
+        {
+          label: "Content",
+          fields: [
+            { name: "name", type: "text", label: "Name", required: true },
+            {
+              name: "slug",
+              type: "text",
+              label: "Slug",
+              required: false,
+              admin: { position: "sidebar" },
+            },
+            {
+              name: "thumbnail",
+              type: "upload",
+              label: "Thumbnail",
+              required: false,
+              relationTo: "media",
+              admin: {
+                description:
+                  "This image appears on the PlayCard thumbnail images.",
+              },
+            },
+          ],
+        },
+        {
+          label: "SEO",
+          fields: [
+            OverviewField({
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+              imagePath: "meta.image",
+            }),
+            MetaImageField({
+              relationTo: "media",
+            }),
+            MetaTitleField({
+              hasGenerateFn: true,
+            }),
+            MetaDescriptionField({}),
+            PreviewField({
+              // if the `generateUrl` function is configured
+              hasGenerateFn: true,
+              // field paths to match the target field for data
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+            }),
+          ],
+        },
+      ],
     },
   ],
   versions: {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -208,6 +208,9 @@ export interface Play {
   name: string;
   slug?: string | null;
   thumbnail?: string | Media | null;
+  image?: string | Media | null;
+  title?: string | null;
+  description?: string | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;


### PR DESCRIPTION
### TL;DR

Enhanced BlogPosts and Playground collections with improved admin interface and SEO capabilities.

### What changed?

- BlogPosts:
  - Added "postedOn" and "updatedAt" to default columns in admin view
  - Implemented pagination with customizable limits
  - Added a description for the collection

- Playground:
  - Restructured fields into Content and SEO tabs
  - Integrated SEO plugin fields for meta title, description, and image
  - Added preview functionality for SEO data

### How to test?

1. Access the admin interface for BlogPosts:
   - Verify new default columns are visible
   - Test pagination functionality
   - Confirm the new description is displayed

2. Create or edit a Playground item:
   - Check for Content and SEO tabs
   - Fill in SEO fields and ensure they generate correctly
   - Test the preview functionality for SEO data

3. Verify that the Playground collection now includes new fields for SEO in the payload-types.ts file

### Why make this change?

This change improves the admin experience for managing BlogPosts and enhances SEO capabilities for the Playground collection. The additions to BlogPosts make it easier to manage and navigate posts, while the SEO integration for Playground items allows for better optimization of content for search engines and social media sharing.

---

