### PR TITLE
feat(cms): add initial Header and Footer blocks

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -1,5 +1,4 @@
 import { SpeedInsights } from "@vercel/speed-insights/next";
-import { Footer } from "../components/Footer";
 import localFont from "next/font/local";
 import "@/styles/globals.css";
 import { Metadata } from "next";
@@ -24,7 +23,6 @@ export default function RootLayout({
     <html lang="en" className={`${DMSans.variable}`}>
       <body className="bg-gray-950 text-gray-50 antialiased">
         <main className="flex min-h-svh flex-col">{children}</main>
-        <Footer />
         <SpeedInsights />
       </body>
     </html>

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -2,8 +2,8 @@ import { Landing } from "../components/Landing";
 
 export default function Page() {
   return (
-    <main>
+    <>
       <Landing />
-    </main>
+    </>
   );
 }

--- a/src/app/blocks/global/Footer/Server.tsx
+++ b/src/app/blocks/global/Footer/Server.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function FooterServer() {
+  return <footer>Footer</footer>;
+}

--- a/src/app/blocks/global/Header/Server.tsx
+++ b/src/app/blocks/global/Header/Server.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { getPayloadHMR } from "@payloadcms/next/utilities";
+import config from "@payload-config";
+import Image from "next/image";
+
+interface HeaderData {
+  logo: {
+    url: string;
+  };
+}
+export default async function HeaderServer() {
+  const payload = await getPayloadHMR({ config });
+  const header = (await payload.findGlobal({ slug: "header" })) as HeaderData;
+
+  return (
+    <header>
+      <div className="relative h-20 w-44">
+        <Image
+          src={header.logo.url}
+          alt="logo"
+          fill
+          className="object-contain"
+        />
+      </div>
+    </header>
+  );
+}

--- a/src/collections/Playground.ts
+++ b/src/collections/Playground.ts
@@ -18,13 +18,7 @@ export const Playground: CollectionConfig = {
           label: "Content",
           fields: [
             { name: "name", type: "text", label: "Name", required: true },
-            {
-              name: "slug",
-              type: "text",
-              label: "Slug",
-              required: false,
-              admin: { position: "sidebar" },
-            },
+
             {
               name: "thumbnail",
               type: "upload",
@@ -63,6 +57,13 @@ export const Playground: CollectionConfig = {
           ],
         },
       ],
+    },
+    {
+      name: "slug",
+      type: "text",
+      label: "Slug",
+      required: false,
+      admin: { position: "sidebar" },
     },
   ],
   versions: {

--- a/src/globals/Footer.tsx
+++ b/src/globals/Footer.tsx
@@ -15,9 +15,18 @@ export const Footer: GlobalConfig = {
       type: "array",
       label: "Navigation",
       fields: [
-        { name: "label", label: "Label", type: "text" },
-        { name: "link", label: "Link", type: "text" },
+        { name: "label", label: "Label", type: "text", required: false },
+        { name: "link", label: "Link", type: "text", required: false },
       ],
+    },
+    {
+      name: "copyrightNotice",
+      label: "Copyright Notice",
+      type: "text",
+      required: false,
+      admin: {
+        description: "Appears in the footer",
+      },
     },
   ],
 };

--- a/src/globals/Header.tsx
+++ b/src/globals/Header.tsx
@@ -8,7 +8,7 @@ export const Header: GlobalConfig = {
       type: "upload",
       relationTo: "media",
       label: "logo",
-      required: false,
+      required: true,
     },
     {
       name: "nav",

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -206,11 +206,11 @@ export interface Client {
 export interface Play {
   id: string;
   name: string;
-  slug?: string | null;
   thumbnail?: string | Media | null;
   image?: string | Media | null;
   title?: string | null;
   description?: string | null;
+  slug?: string | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -311,7 +311,7 @@ export interface PayloadMigration {
  */
 export interface Header {
   id: string;
-  logo?: string | Media | null;
+  logo: string | Media;
   nav?:
     | {
         label?: string | null;
@@ -336,6 +336,7 @@ export interface Footer {
         id?: string | null;
       }[]
     | null;
+  copyrightNotice?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
 }


### PR DESCRIPTION
### TL;DR

Restructured layout components and updated global configurations for Header and Footer.

### What changed?

- Removed Footer component from the root layout
- Relocated Header and Footer components to new server-side blocks
- Updated Playground collection by moving the slug field
- Modified Header and Footer global configurations
- Adjusted the Landing page structure

### How to test?

1. Verify that the Header appears correctly with the logo from the global configuration
2. Check that the Footer is no longer present in the root layout
3. Ensure the Playground collection's slug field is accessible in the sidebar
4. Confirm that the Landing page renders without errors

### Why make this change?

This restructuring improves the application's layout organization and enhances the flexibility of global components. By moving Header and Footer to server-side blocks, we can leverage server-side rendering for these components, potentially improving performance and SEO. The updates to global configurations provide more customization options for the site's header and footer content.

---

