### PR TITLE
feat(cms): add helper functions and RichText component to display RichText from CMS

### DIFF
--- a/src/app/components/RichText/RichText.tsx
+++ b/src/app/components/RichText/RichText.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { serializeLexical } from "./serializeLexical";
+import { LexicalNode } from "./lexicalNodeFormat";
+
+type Props = {
+  className?: string;
+  content: Record<string, any>;
+  enableGutter?: boolean;
+  enableProse?: boolean;
+};
+
+const RichText: React.FC<Props> = ({
+  className,
+  content,
+  enableGutter = true,
+  enableProse = true,
+}) => {
+  console.log("RichText content:", content); // Debug log
+
+  if (!content || !content.root || !content.root.children) {
+    console.log("Invalid content structure"); // Debug log
+    return null;
+  }
+
+  return (
+    <div
+      className={` ${enableGutter ? "container" : "max-w-none"} ${enableProse ? "prose mx-auto dark:prose-invert" : ""} ${className || ""} `.trim()}
+    >
+      {serializeLexical({ nodes: content.root.children as LexicalNode[] })}
+    </div>
+  );
+};
+
+export default RichText;

--- a/src/app/components/RichText/lexicalNodeFormat.tsx
+++ b/src/app/components/RichText/lexicalNodeFormat.tsx
@@ -1,0 +1,40 @@
+// Constants for text formatting
+// These use bitwise flags for efficient storage and checking of multiple formats
+export const IS_BOLD = 1;
+export const IS_ITALIC = 1 << 1;
+export const IS_STRIKETHROUGH = 1 << 2;
+export const IS_UNDERLINE = 1 << 3;
+export const IS_CODE = 1 << 4;
+export const IS_SUBSCRIPT = 1 << 5;
+export const IS_SUPERSCRIPT = 1 << 6;
+
+// Type definition for a text node in the Lexical structure
+export type TextNode = {
+  type: "text";
+  text: string;
+  format: number; // Bitwise combination of formatting constants
+  version: number;
+};
+
+// Type definition for an element node in the Lexical structure
+export type ElementNode = {
+  type:
+    | "root"
+    | "paragraph"
+    | "heading"
+    | "quote"
+    | "list"
+    | "listitem"
+    | "link";
+  children: LexicalNode[];
+  direction?: "ltr" | "rtl";
+  format?: number;
+  indent?: number;
+  version: number;
+  tag?: string; // Used for heading levels (h1, h2, etc.)
+  listType?: "bullet" | "number";
+  url?: string; // Used for links
+};
+
+// Union type for all possible Lexical nodes
+export type LexicalNode = TextNode | ElementNode;

--- a/src/app/components/RichText/serializeLexical.tsx
+++ b/src/app/components/RichText/serializeLexical.tsx
@@ -1,0 +1,108 @@
+import React, { Fragment } from "react";
+import escapeHTML from "escape-html";
+import {
+  LexicalNode,
+  TextNode,
+  ElementNode,
+  IS_BOLD,
+  IS_ITALIC,
+  IS_STRIKETHROUGH,
+  IS_UNDERLINE,
+  IS_CODE,
+  IS_SUBSCRIPT,
+  IS_SUPERSCRIPT,
+} from "./lexicalNodeFormat";
+
+// Main function to serialize Lexical nodes into React elements
+export const serializeLexical = ({
+  nodes,
+}: {
+  nodes: LexicalNode[];
+}): React.ReactNode => {
+  return nodes.map((node, i) => {
+    // Handle text nodes
+    if (node.type === "text") {
+      const textNode = node as TextNode;
+      let text = <Fragment key={i}>{escapeHTML(textNode.text)}</Fragment>;
+
+      // Apply text formatting based on the format bitfield
+      if (textNode.format & IS_BOLD) {
+        text = <strong key={i}>{text}</strong>;
+      }
+      if (textNode.format & IS_ITALIC) {
+        text = <em key={i}>{text}</em>;
+      }
+      if (textNode.format & IS_STRIKETHROUGH) {
+        text = <s key={i}>{text}</s>;
+      }
+      if (textNode.format & IS_UNDERLINE) {
+        text = <u key={i}>{text}</u>;
+      }
+      if (textNode.format & IS_CODE) {
+        text = <code key={i}>{text}</code>;
+      }
+      if (textNode.format & IS_SUBSCRIPT) {
+        text = <sub key={i}>{text}</sub>;
+      }
+      if (textNode.format & IS_SUPERSCRIPT) {
+        text = <sup key={i}>{text}</sup>;
+      }
+
+      return text;
+    }
+
+    // Return null for undefined nodes
+    if (!node) {
+      return null;
+    }
+
+    const elementNode = node as ElementNode;
+
+    // Handle different types of element nodes
+    switch (elementNode.type) {
+      case "root":
+        return (
+          <Fragment key={i}>
+            {serializeLexical({ nodes: elementNode.children })}
+          </Fragment>
+        );
+      case "paragraph":
+        return (
+          <p key={i}>{serializeLexical({ nodes: elementNode.children })}</p>
+        );
+      case "heading":
+        const Tag = `h${elementNode.tag}` as keyof JSX.IntrinsicElements;
+        return (
+          <Tag key={i}>{serializeLexical({ nodes: elementNode.children })}</Tag>
+        );
+      case "quote":
+        return (
+          <blockquote key={i}>
+            {serializeLexical({ nodes: elementNode.children })}
+          </blockquote>
+        );
+      case "list":
+        const ListTag = elementNode.listType === "number" ? "ol" : "ul";
+        return (
+          <ListTag key={i}>
+            {serializeLexical({ nodes: elementNode.children })}
+          </ListTag>
+        );
+      case "listitem":
+        return (
+          <li key={i}>{serializeLexical({ nodes: elementNode.children })}</li>
+        );
+      case "link":
+        return (
+          <a href={escapeHTML(elementNode.url || "")} key={i}>
+            {serializeLexical({ nodes: elementNode.children })}
+          </a>
+        );
+      default:
+        // Default to a paragraph if the element type is not recognized
+        return (
+          <p key={i}>{serializeLexical({ nodes: elementNode.children })}</p>
+        );
+    }
+  });
+};


### PR DESCRIPTION
### TL;DR

Implemented a new RichText component for rendering Lexical-formatted content.

### What changed?

- Added a new `RichText` component that renders content in Lexical format.
- Created `lexicalNodeFormat.tsx` to define types and constants for Lexical nodes.
- Implemented `serializeLexical` function to convert Lexical nodes into React elements.

### How to test?

1. Import the `RichText` component in a React file.
2. Pass Lexical-formatted content to the component:
   ```jsx
   <RichText content={lexicalContent} />
   ```
3. Verify that the content renders correctly with proper formatting (bold, italic, lists, headings, etc.).
4. Test with different content structures to ensure robustness.

### Why make this change?

This change introduces a flexible and efficient way to render rich text content using the Lexical format. It allows for easy integration of formatted text, headings, lists, and links in React applications, improving the overall content presentation capabilities.

---

