### PR TITLE
feat(cms): add RichText features to Payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@types/escape-html": "^1.0.4",
     "@types/node": "^20.16.2",
     "@types/react": "npm:types-react@19.0.0-rc.0",
     "@types/react-dom": "npm:types-react-dom@19.0.0-rc.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.10)
     devDependencies:
+      '@types/escape-html':
+        specifier: ^1.0.4
+        version: 1.0.4
       '@types/node':
         specifier: ^20.16.2
         version: 20.16.2
@@ -1597,6 +1600,9 @@ packages:
 
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
+  '@types/escape-html@1.0.4':
+    resolution: {integrity: sha512-qZ72SFTgUAZ5a7Tj6kf2SHLetiH5S6f8G5frB2SPQ3EyF02kxdyBFf4Tz4banE3xCgGnKgWLt//a6VuYHKYJTg==}
 
   '@types/glob@7.2.0':
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
@@ -6219,6 +6225,8 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@types/escape-html@1.0.4': {}
+
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 5.1.2
@@ -6983,7 +6991,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
       eslint-plugin-react: 7.35.0(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -7014,7 +7022,7 @@ snapshots:
       is-bun-module: 1.1.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -7032,7 +7040,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5

--- a/src/app/(frontend)/(inner)/posts/page.tsx
+++ b/src/app/(frontend)/(inner)/posts/page.tsx
@@ -10,15 +10,8 @@ export default async function Page() {
   const posts = await payload.find({
     collection: "posts",
     limit: 1000,
-    depth: 1,
     sort: "-publishedDate",
-    where: {
-      slug: {
-        exists: true,
-      },
-    },
   });
-
   return (
     <div className="pb-24 pt-24">
       <div className="container mx-auto mb-16">

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -117,7 +117,7 @@ export interface Post {
   title?: string | null;
   description?: string | null;
   slug?: string | null;
-  postedOn: string;
+  publishedDate: string;
   category: string | Category;
   updatedAt: string;
   createdAt: string;

--- a/src/payload/collections/BlogPosts.ts
+++ b/src/payload/collections/BlogPosts.ts
@@ -85,7 +85,7 @@ export const BlogPosts: CollectionConfig = {
       },
     },
     {
-      name: "postedOn",
+      name: "publishedDate",
       type: "date",
       required: true,
       label: "Published Date",
@@ -119,16 +119,16 @@ export const BlogPosts: CollectionConfig = {
   },
   admin: {
     description: "Writing brings clarity.",
-    defaultColumns: ["name", "postedOn", "updatedAt"],
+    defaultColumns: ["name", "publishedDate", "updatedAt"],
     group: "Blog Posts",
     listSearchableFields: ["name"],
     pagination: {
-      defaultLimit: 25,
+      defaultLimit: 100,
       limits: [10, 25, 50, 100],
     },
     useAsTitle: "name",
   },
-  defaultSort: "postedOn",
+  defaultSort: "publishedDate",
   labels: {
     singular: "Post",
     plural: "Posts",


### PR DESCRIPTION
### TL;DR

Updated blog post collection structure and improved post retrieval efficiency.

### What changed?

- Renamed `postedOn` field to `publishedDate` in BlogPosts collection and payload types
- Removed unnecessary query parameters in post retrieval
- Increased default pagination limit for blog posts in admin panel
- Updated default sort field to `publishedDate`

### How to test?

1. Navigate to the blog posts page
2. Verify that posts are displayed correctly and sorted by publish date
3. Check the admin panel to ensure the new `publishedDate` field is visible and functioning
4. Create a new blog post and confirm the `publishedDate` field works as expected

### Why make this change?

This change improves consistency in field naming and optimizes post retrieval. The increased pagination limit in the admin panel allows for easier management of larger numbers of blog posts. These updates enhance the overall efficiency and usability of the blog post management system.

---

