### PR TITLE
feat(ui): expand about Brewww section on about page

### DIFF
--- a/src/app/(frontend)/(new)/new/about/page.tsx
+++ b/src/app/(frontend)/(new)/new/about/page.tsx
@@ -1,3 +1,5 @@
+import AboutImageEight from "/public/images/brewww-eight.jpeg";
+
 export default function About() {
   return (
     <>
@@ -51,6 +53,207 @@ export default function About() {
             </div>
           </div>
         </div>
+      </section>
+
+      <section className="bg-zinc-950 text-white">
+        <article className="grid grid-cols-[103.906px_103.906px_103.906px_103.906px_103.906px_103.906px_103.906px_103.922px_103.906px_103.906px_103.906px_103.906px] grid-rows-[192px_auto_auto_auto_auto_76px] gap-x-10 gap-y-6">
+          <div
+            className="col-start-3 text-4xl"
+            style={{
+              gridColumnEnd: "span 8",
+            }}
+          >
+            <p>
+              <span className="inline-block pr-9 text-sm uppercase text-stone-500">
+                Hello!
+              </span>
+              Brewww is a branding and web design team. We've crafted custom
+              solutions for leaders and dreamers like The Merry Beggars, IES
+              National, Pietra Fitness,
+              <a className="inline-block underline" href="">
+                and more.
+                <span className="cursor-pointer text-sm uppercase text-stone-500">
+                  <span className="inline-block align-top">(our work)</span>
+                </span>
+              </a>
+            </p>
+          </div>
+          <div
+            className="col-start-3 text-4xl"
+            style={{
+              gridColumnEnd: "span 5",
+            }}
+          >
+            <p>
+              Here since 2017, we believe in taking on challenges. In turn, we
+              challenge ourselves and our partners, molding every idea into
+              something exceptional.
+            </p>
+          </div>
+          <div
+            className="col-start-9"
+            style={{
+              gridColumnEnd: "span 2",
+            }}
+          >
+            <figure>
+              <span className="relative inline-block h-36 w-60 overflow-hidden">
+                <img
+                  className="h-full w-full object-cover"
+                  src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%27440%27%20height=%27248%27/%3e"
+                />
+                <img
+                  className="absolute inset-0 h-full w-full object-cover"
+                  src={AboutImageEight.src}
+                  alt="Kevin Wessa"
+                />
+              </span>
+              <div className="text-sm uppercase text-stone-500">
+                <span className="text-white">Kevin Wessa,</span> Founder and CEO
+                of Brewwww
+              </div>
+            </figure>
+          </div>
+          <div
+            className="col-start-3 text-4xl"
+            style={{
+              gridColumnEnd: "span 8",
+            }}
+          >
+            <p>
+              Our vision is not a convoluted puzzle. It's simple and honest:{" "}
+              <span className="text-rose-600">We want to do top work.</span>{" "}
+              Every strategy, every px in every design, every line of code, is
+              something Brewww proudly{" "}
+              <a className="inline-block underline" href="">
+                stands behind.
+                <span className="cursor-pointer text-sm uppercase text-stone-500">
+                  <span className="inline-block align-top">
+                    (Here's why{" "}
+                    <svg
+                      className="inline-block h-3 w-3 rotate-90"
+                      fill="none"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M11.2396 6.99425 6.58589 2.34052 7.99896.92517l7.06694 7.06695-.0005.00056.0044.00446-7.06126 7.07266-1.41421-1.4142 4.65307-4.66055-9.02388.00363-.0445.00002-.00081-2.00081.0445-.00002.00041 1.00041-.0004-1.00041 9.01688-.00362Z"
+                        fill="rgb(102, 102, 102)"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                    )
+                  </span>
+                </span>
+              </a>{" "}
+              And this is possible only thanks to our deep partnerships with our
+              clients.
+            </p>
+          </div>
+          <div
+            className="col-start-3 text-4xl"
+            style={{
+              gridColumnEnd: "span 8",
+            }}
+          >
+            <p>
+              We are{" "}
+              <a className="inline-block underline" href="">
+                curious individuals
+                <span className="cursor-pointer text-sm uppercase text-stone-500">
+                  <span className="inline-block align-top">
+                    (Meet us{" "}
+                    <svg
+                      className="inline-block h-3 w-3 rotate-90"
+                      fill="none"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M11.2396 6.99425 6.58589 2.34052 7.99896.92517l7.06694 7.06695-.0005.00056.0044.00446-7.06126 7.07266-1.41421-1.4142 4.65307-4.66055-9.02388.00363-.0445.00002-.00081-2.00081.0445-.00002.00041 1.00041-.0004-1.00041 9.01688-.00362Z"
+                        fill="rgb(102, 102, 102)"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                    )
+                  </span>
+                </span>
+              </a>{" "}
+              that stay busy, and we like it that way. Transform a crazy idea
+              into a product impossible to ignore? We're in. Provide guidance
+              and structure while we're at it? That's what we do.
+            </p>
+          </div>
+          <div
+            className="col-start-3 text-4xl"
+            style={{
+              gridColumnEnd: "span 8",
+            }}
+          >
+            <p>
+              Fearlessly going all in is what Brewww was built on. Our feet may
+              be firmly on the ground today, but our restless resolve isn't
+              going anywhere.
+            </p>
+          </div>
+          <div
+            className="col-start-3 text-sm font-bold uppercase"
+            style={{
+              gridColumnEnd: "span 8",
+            }}
+          >
+            <div className="grid grid-flow-col grid-cols-[220px_220px] grid-rows-[3.75rem] justify-start gap-10">
+              <a
+                className="bg-brand-gold flex items-center justify-center rounded-sm px-5 text-black"
+                href=""
+              >
+                <span className="flex cursor-pointer items-center justify-between">
+                  Meet the team
+                  <svg
+                    className="ml-2 h-3 w-3 rotate-90"
+                    fill="none"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clipRule="evenodd"
+                      d="M11.2396 6.99425 6.58589 2.34052 7.99896.92517l7.06694 7.06695-.0005.00056.0044.00446-7.06126 7.07266-1.41421-1.4142 4.65307-4.66055-9.02388.00363-.0445.00002-.00081-2.00081.0445-.00002.00041 1.00041-.0004-1.00041 9.01688-.00362Z"
+                      fill="currentColor"
+                      fillRule="evenodd"
+                    />
+                  </svg>
+                </span>
+              </a>
+              <a
+                className="flex items-center justify-center rounded-sm border-2 border-solid border-zinc-800 px-5"
+                href=""
+              >
+                <span className="flex cursor-pointer items-center justify-between">
+                  What you can expect
+                  <svg
+                    className="ml-2 h-3 w-3 rotate-90"
+                    fill="none"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clipRule="evenodd"
+                      d="M11.2396 6.99425 6.58589 2.34052 7.99896.92517l7.06694 7.06695-.0005.00056.0044.00446-7.06126 7.07266-1.41421-1.4142 4.65307-4.66055-9.02388.00363-.0445.00002-.00081-2.00081.0445-.00002.00041 1.00041-.0004-1.00041 9.01688-.00362Z"
+                      fill="currentColor"
+                      fillRule="evenodd"
+                    />
+                  </svg>
+                </span>
+              </a>
+            </div>
+          </div>
+        </article>
       </section>
     </>
   );

--- a/src/app/(frontend)/(new)/new/page.tsx
+++ b/src/app/(frontend)/(new)/new/page.tsx
@@ -1,0 +1,3 @@
+export default function New() {
+  return <div>New</div>;
+}

--- a/src/app/(frontend)/(new)/new/services/page.tsx
+++ b/src/app/(frontend)/(new)/new/services/page.tsx
@@ -2,7 +2,6 @@ export default function ServicesPage() {
   return (
     <>
       <div>
-
         <section className="relative grid grid-cols-[105.50rem] grid-rows-[1155px_104px] items-center justify-items-center bg-zinc-950 text-center uppercase text-neutral-400">
           <span className="text-[13.00rem] font-bold leading-none text-white">
             <span>
@@ -95,7 +94,6 @@ export default function ServicesPage() {
       </div>
 
       <div>
-
         <div className="w-full text-neutral-900">
           <div className="m-auto flex min-h-screen w-full flex-col overflow-clip">
             <section className="bg-neutral-900 uppercase text-white min-[1000px]:pt-20 min-[1001px]:pt-28">
@@ -736,11 +734,7 @@ export default function ServicesPage() {
                     </li>
 
                     <li
-
                       className="relative list-item md:mt-12 min-[769px]:ml-auto min-[769px]:w-[48.2105%]"
-
-                    
-
                       id="li-7"
                     >
                       <span
@@ -760,9 +754,7 @@ export default function ServicesPage() {
                           <img
                             className="h-auto w-full max-w-full"
                             src="https://www.fhoke.com/wp-content/uploads/2022/10/Xpert-Header-916x1100.jpg"
-
                             alt="Xpert Workwear"
-
                           />
                           {"        "}
                         </picture>
@@ -1176,11 +1168,7 @@ export default function ServicesPage() {
                     </li>
 
                     <li
-
                       className="relative list-item md:mt-12 min-[769px]:ml-auto min-[769px]:w-[48.2105%]"
-
-                   
-
                       id="li-8"
                     >
                       <span
@@ -1203,10 +1191,7 @@ export default function ServicesPage() {
                           <img
                             className="h-auto w-full max-w-full"
                             src="https://www.fhoke.com/wp-content/uploads/2018/09/NL4x4-Banner-916x1100.jpg"
-
                             alt="New Legend 4x4"
-
-
                           />
                           {"        "}
                         </picture>
@@ -1229,16 +1214,11 @@ export default function ServicesPage() {
                           <p className="opacity-50">True legends never die.</p>
                         </div>
 
-
                         <div className="ml-5 text-lg uppercase">
-
-                 
-
                           <a
                             className="relative inline-block overflow-hidden rounded-full bg-gray-200 text-center"
                             href="https://www.fhoke.com/projects/new-legend/"
                           >
-
                             <span
                               className="relative cursor-pointer lg:pb-1.5 lg:pl-3.5 lg:pr-3.5 lg:pt-1.5 min-[1025px]:pb-1.5 min-[1025px]:pl-3.5 min-[1025px]:pr-3.5 min-[1025px]:pt-1.5"
                               id="span-32"
@@ -1248,7 +1228,6 @@ export default function ServicesPage() {
                                 className="absolute left-0 top-full w-full rounded-tl-full rounded-tr-full bg-white lg:pb-1.5 lg:pl-3.5 lg:pr-3.5 lg:pt-1.5 min-[1025px]:pb-1.5 min-[1025px]:pl-3.5 min-[1025px]:pr-3.5 min-[1025px]:pt-1.5"
                                 id="span-33"
                               />
-
                             </span>
                           </a>
                           {"        "}
@@ -1260,12 +1239,10 @@ export default function ServicesPage() {
               </div>
             </section>
 
-
             <section
               className="relative bg-neutral-900 text-white min-[1600px]:pb-20 min-[1600px]:pt-20 min-[1920px]:pb-28 min-[1920px]:pt-28 min-[1921px]:pb-28 min-[1921px]:pt-28"
               id="section-9"
             >
-
               <div
                 className="m-auto w-[92%] min-[769px]:flex min-[1921px]:max-w-[118.75rem]"
                 id="div-36"
@@ -1606,265 +1583,6 @@ export default function ServicesPage() {
                 </div>
               </div>
             </section>
-
-            <footer className="mt-auto bg-white">
-              <div
-                className="m-auto w-[92%] min-[1600px]:pb-5 min-[1600px]:pt-16 min-[1920px]:pb-5 min-[1920px]:pt-24 min-[1921px]:max-w-[118.75rem] min-[1921px]:pb-5 min-[1921px]:pt-24"
-                id="div-45"
-              >
-                <div className="gap-x-[3.57895%] min-[769px]:flex min-[769px]:items-start">
-                  <div className="uppercase lg:w-[48.2105%] min-[1025px]:w-[56.8421%]">
-                    <h6
-                      className="inline-block text-lg min-[671px]:pl-6"
-                      id="h6-1"
-                    >
-                      Let’s Collaborate
-                    </h6>
-                    <h2
-                      className="text-[8.75rem] leading-none lg:mt-10 min-[1025px]:mt-16"
-                      id="h2-2"
-                    >
-                      <span className="text-[6.25rem] leading-none">
-                        We love working with ambitious brands, across every
-                        sector
-                      </span>
-                    </h2>
-
-                    <p
-                      className="text-[1.38rem] leading-7 lg:mt-8 min-[1025px]:mt-12"
-                      id="p-9"
-                    >
-                      <a
-                        className="relative inline-block overflow-hidden rounded-full bg-gray-200 text-center text-lg"
-                        href="https://www.fhoke.com/contact/"
-                      >
-                        <span
-                          className="relative cursor-pointer lg:pb-4 lg:pl-8 lg:pr-8 lg:pt-4 min-[1025px]:pb-5 min-[1025px]:pl-8 min-[1025px]:pr-8 min-[1025px]:pt-5"
-                          id="span-45"
-                        >
-                          Let’s Work Together
-                          <span
-                            className="absolute left-0 top-full w-full rounded-tl-full rounded-tr-full bg-white lg:pb-4 lg:pl-8 lg:pr-8 lg:pt-4 min-[1025px]:pb-5 min-[1025px]:pl-8 min-[1025px]:pr-8 min-[1025px]:pt-5"
-                            id="span-46"
-                          />
-                        </span>
-                      </a>{" "}
-                      <a
-                        className="relative inline-block overflow-hidden rounded-full bg-neutral-900 text-center text-lg text-white lg:mt-8 min-[1025px]:mt-9"
-                        href="https://calendly.com/fhoke/15-minute-chat"
-                        id="a-28"
-                      >
-                        <span
-                          className="relative cursor-pointer lg:pb-4 lg:pl-8 lg:pr-8 lg:pt-4 min-[1025px]:pb-5 min-[1025px]:pl-8 min-[1025px]:pr-8 min-[1025px]:pt-5"
-                          id="span-47"
-                        >
-                          Book a Call
-                          <span
-                            className="absolute left-0 top-full w-full rounded-tl-full rounded-tr-full bg-white lg:pb-4 lg:pl-8 lg:pr-8 lg:pt-4 min-[1025px]:pb-5 min-[1025px]:pl-8 min-[1025px]:pr-8 min-[1025px]:pt-5"
-                            id="span-48"
-                          />
-                        </span>
-                      </a>
-                    </p>
-                  </div>
-
-                  <div
-                    className="ml-auto md:mt-16 md:mt-24 lg:w-[48.2105%] min-[1025px]:w-[30.9474%]"
-                    id="div-46"
-                  >
-                    <div className="flex justify-between">
-                      <div
-                        className="flex w-[44.2177%] flex-col min-[769px]:w-[44.2177%]"
-                        id="div-47"
-                      >
-                        <h6
-                          className="inline-block text-lg uppercase min-[671px]:pl-6 min-[1600px]:mb-10 min-[1920px]:mb-12 min-[1921px]:mb-12"
-                          id="h6-2"
-                        >
-                          London
-                        </h6>
-
-                        <div className="text-[1.38rem] leading-7">
-                          <a href="https://www.google.com/maps/dir//Fhoke+Limited/data=!4m6!4m5!1m1!4e2!1m2!1m1!1s0x48760531aa1f60c7:0xde0764dccb3817ff?sa=X&hl=en-GB&ved=2ahUKEwjx84WpmNT_AhUKT8AKHWZAAbEQ9Rd6BAhNEAU">
-                            107-111 Fleet Street,
-                            <br className="cursor-pointer" />
-                            Ludgate House,
-                            <br className="cursor-pointer" />
-                            London, EC4A 2AB
-                          </a>
-                        </div>
-
-                        <p className="text-[1.38rem] leading-7">
-                          020 7936 9450
-                        </p>
-
-                        <p
-                          className="mt-auto text-[1.38rem] leading-7 min-[1600px]:pt-10 min-[1920px]:pt-16 min-[1921px]:pt-16"
-                          id="p-10"
-                        >
-                          hello@fhoke.com
-                        </p>
-                      </div>
-
-                      <div
-                        className="flex w-[44.2177%] flex-col min-[769px]:w-[44.2177%]"
-                        id="div-48"
-                      >
-                        <h6
-                          className="inline-block text-lg uppercase min-[671px]:pl-6 min-[1600px]:mb-10 min-[1920px]:mb-12 min-[1921px]:mb-12"
-                          id="h6-3"
-                        >
-                          Salisbury
-                        </h6>
-
-                        <div className="text-[1.38rem] leading-7">
-                          <a href="https://www.google.com/maps/dir//fhoke/data=!4m6!4m5!1m1!4e2!1m2!1m1!1s0x4873f73af0550763:0x4ff58d49938218ba?sa=X&ved=2ahUKEwi-soLUmNT_AhXSa8AKHQrsBbIQ9Rd6BAg6EAU">
-                            7 The Beeches,
-                            <br className="cursor-pointer" />
-                            Dean Hill Park,
-                            <br className="cursor-pointer" />
-                            Salisbury, SP5 1EZ
-                          </a>
-                        </div>
-
-                        <p className="text-[1.38rem] leading-7">
-                          01794 342 113
-                        </p>
-
-                        <div
-                          className="mt-auto min-[1600px]:pt-10 min-[1920px]:pt-16 min-[1921px]:pt-16"
-                          id="div-49"
-                        >
-                          <ul className="flex list-disc items-center gap-[1.13rem] pb-2">
-                            <li className="list-item pt-1">
-                              <a
-                                className="flex items-center justify-center"
-                                href="https://www.awwwards.com/fhoke/"
-                              >
-                                <svg
-                                  className="h-auto max-h-[1.13rem] w-full max-w-[1.13rem] cursor-pointer"
-                                  fill="rgb(0, 0, 0)"
-                                  viewBox="0 0 18 11.08"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="m12.74,0l-1.94,7.51-1.83-7.51h-2.5l-1.83,7.51L2.69,0H0l3.47,10.95h2.37l1.87-7.08,1.88,7.08h2.37L15.43,0h-2.69,0Zm1.64,9.25c0,1.04.78,1.82,1.81,1.82s1.81-.78,1.81-1.82-.78-1.82-1.81-1.82-1.81.78-1.81,1.82Z"
-                                    fill="rgb(18, 18, 18)"
-                                  />
-                                </svg>
-                              </a>
-                            </li>
-                            <li className="list-item">
-                              <a
-                                className="flex items-center justify-center"
-                                href="https://www.linkedin.com/company/fhoke/"
-                              >
-                                <svg
-                                  className="h-auto max-h-[1.13rem] w-full max-w-[1.13rem] cursor-pointer"
-                                  fill="rgb(0, 0, 0)"
-                                  viewBox="0 0 18 18"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="m16.67,0H1.33C.6,0,0,.58,0,1.3v15.4c0,.72.6,1.3,1.33,1.3h15.34c.73,0,1.33-.58,1.33-1.3V1.3c0-.72-.6-1.3-1.33-1.3ZM5.34,15.34h-2.67V6.75h2.67v8.59Zm-1.34-9.76c-.86,0-1.55-.69-1.55-1.55s.69-1.55,1.55-1.55,1.55.69,1.55,1.55-.69,1.55-1.55,1.55Zm11.33,9.76h-2.67v-4.18c0-1-.02-2.28-1.39-2.28s-1.6,1.09-1.6,2.21v4.25h-2.67V6.75h2.56v1.17h.04c.36-.68,1.23-1.39,2.53-1.39,2.7,0,3.2,1.78,3.2,4.09v4.71Z"
-                                    fill="rgb(18, 18, 18)"
-                                  />
-                                </svg>
-                              </a>
-                            </li>
-                            <li className="list-item">
-                              <a
-                                className="flex items-center justify-center"
-                                href="https://www.instagram.com/fhoke/"
-                              >
-                                <svg
-                                  className="h-auto max-h-[1.13rem] w-full max-w-[1.13rem] cursor-pointer"
-                                  fill="rgb(0, 0, 0)"
-                                  viewBox="0 0 28 28"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M21 3a4 4 0 0 1 4 4v14a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4V7a4 4 0 0 1 4-4h14m0-3H7a7 7 0 0 0-7 7v14a7 7 0 0 0 7 7h14a7 7 0 0 0 7-7V7a7 7 0 0 0-7-7z"
-                                    fill="rgb(18, 18, 18)"
-                                  />
-                                  <path
-                                    d="M14 9.91A4.09 4.09 0 1 1 9.91 14 4.09 4.09 0 0 1 14 9.91m0-3A7.09 7.09 0 1 0 21.09 14 7.1 7.1 0 0 0 14 6.91z"
-                                    fill="rgb(18, 18, 18)"
-                                  />
-                                  <circle
-                                    cx="21.5"
-                                    cy="6.5"
-                                    fill="rgb(18, 18, 18)"
-                                    r="1.5"
-                                  />
-                                </svg>
-                              </a>
-                            </li>
-                            <li className="list-item">
-                              <a
-                                className="flex items-center justify-center"
-                                href="https://www.facebook.com/FhokeAgency"
-                              >
-                                <svg
-                                  className="h-auto max-h-[1.13rem] w-full max-w-[1.13rem] cursor-pointer"
-                                  fill="rgb(0, 0, 0)"
-                                  viewBox="0 0 18 18"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="m18,9.06C18,4.05,13.97,0,9,0S0,4.05,0,9.06c0,4.52,3.29,8.27,7.59,8.94v-6.33h-2.29v-2.62h2.29v-1.99c0-2.27,1.34-3.52,3.4-3.52.98,0,2.01.18,2.01.18v2.23h-1.13c-1.12,0-1.47.7-1.47,1.41v1.7h2.5l-.4,2.62h-2.1v6.33c4.3-.68,7.59-4.43,7.59-8.94Z"
-                                    fill="rgb(18, 18, 18)"
-                                  />
-                                </svg>
-                              </a>
-                            </li>
-                            <li className="list-item">
-                              <a
-                                className="flex items-center justify-center"
-                                href="https://twitter.com/fhoke"
-                              >
-                                <svg
-                                  className="h-auto max-h-[1.13rem] w-full max-w-[1.13rem] cursor-pointer"
-                                  fill="rgb(0, 0, 0)"
-                                  viewBox="0 0 29.95 24.34"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M26.88 6.06v.79c.02 8.13-6.16 17.49-17.43 17.49a17.39 17.39 0 0 1-9.42-2.76 12.46 12.46 0 0 0 1.47.09 12.33 12.33 0 0 0 7.63-2.63 6.15 6.15 0 0 1-5.74-4.27 6.16 6.16 0 0 0 2.77-.11 6.15 6.15 0 0 1-4.93-6v-.08a6.12 6.12 0 0 0 2.78.77 6.15 6.15 0 0 1-1.9-8.2 17.44 17.44 0 0 0 12.66 6.42 6.15 6.15 0 0 1 10.47-5.6 12.3 12.3 0 0 0 3.9-1.49 6.16 6.16 0 0 1-2.7 3.4 12.28 12.28 0 0 0 3.53-1 12.48 12.48 0 0 1-3.09 3.18z"
-                                    fill="rgb(18, 18, 18)"
-                                  />
-                                </svg>
-                              </a>
-                            </li>
-                          </ul>
-                          {"                    "}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                <div
-                  className="gap-x-[3.57895%] uppercase min-[769px]:flex min-[769px]:items-start min-[1600px]:mt-16 min-[1920px]:mt-24 min-[1921px]:mt-24"
-                  id="div-50"
-                >
-                  <ul className="list-none lg:w-[48.2105%] min-[1025px]:w-[56.8421%]">
-                    <li className="inline-block">Privacy</li>
-
-                    <li className="ml-8 inline-block">Careers</li>
-
-                    <li className="ml-8 inline-block">Working With Us</li>
-                  </ul>
-
-                  <div
-                    className="ml-auto lg:w-[48.2105%] min-[1025px]:w-[30.9474%]"
-                    id="div-51"
-                  >
-                    <p>© Fhoke 2024</p>
-                  </div>
-                </div>
-              </div>
-            </footer>
           </div>
         </div>
       </div>

--- a/src/app/components/HeaderNew/index.tsx
+++ b/src/app/components/HeaderNew/index.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import BrewwwLogo from "/public/images/brewww-logotype-gold.png";
 export function HeaderNew() {
   return (
-    <header className="w-full bg-zinc-950 text-sm text-neutral-400">
+    <header className="bg-brand-black w-full text-sm text-neutral-400">
       <div className="mx-auto max-w-[120rem] px-12">
         <div className="grid grid-cols-3 items-center py-4">
           <nav className="flex items-center space-x-10 font-semibold uppercase text-white">
@@ -27,34 +27,42 @@ export function HeaderNew() {
             </Link>
             <Link
               className="relative inline-block min-w-max after:absolute after:bottom-0 after:left-0 after:h-[1px] after:w-0 after:bg-white after:transition-all after:duration-300 hover:after:w-full"
+              href="/new/about"
+            >
+              About
+            </Link>
+            <Link
+              className="relative inline-block min-w-max after:absolute after:bottom-0 after:left-0 after:h-[1px] after:w-0 after:bg-white after:transition-all after:duration-300 hover:after:w-full"
               href="/new/blog"
             >
               Blog
             </Link>
           </nav>
           <div className="flex justify-center">
-            <img
-              className="w-36 max-w-full cursor-pointer"
-              src={BrewwwLogo.src}
-              alt="Brewww Logo"
-            />
+            <Link href="/new">
+              <img
+                className="w-36 max-w-full cursor-pointer"
+                src={BrewwwLogo.src}
+                alt="Brewww Logo"
+              />
+            </Link>
           </div>
           <div className="flex items-center justify-end space-x-4 text-white">
             <div className="flex items-center space-x-4 uppercase">
-              <a
+              <Link
                 className="relative inline-block min-w-max font-semibold after:absolute after:bottom-0 after:left-0 after:h-[1px] after:w-0 after:bg-white after:transition-all after:duration-300 hover:after:w-full"
                 href="mailto:hello@brewww.studio"
               >
                 hello@brewww.studio
-              </a>
-              <a
-                className="bg-brand-gold inline-block h-12 min-w-[9.88rem] px-5 font-bold text-black md:min-w-[10.63rem] min-[1680px]:h-16 min-[1680px]:min-w-[13.75rem]"
+              </Link>
+              <Link
+                className="bg-brand-gold inline-block h-12 min-w-[9.88rem] rounded-sm px-5 font-bold text-black md:min-w-[10.63rem] min-[1680px]:h-16 min-[1680px]:min-w-[13.75rem]"
                 href="/new/contact"
               >
                 <span className="flex h-full w-full cursor-pointer items-center justify-center">
                   Let's talk
                 </span>
-              </a>
+              </Link>
             </div>
             <button className="h-12 min-w-8 cursor-pointer">
               <span className="flex h-full w-full items-center justify-center">


### PR DESCRIPTION
### TL;DR

Enhanced the About page and updated the HeaderNew component with improved navigation and styling.

### What changed?

- Added a new section to the About page with detailed content about Brewww, including company information, mission statement, and team details.
- Updated the HeaderNew component:
  - Added an "About" link in the navigation menu.
  - Improved the logo by making it a clickable link to the new homepage.
  - Styled the "Let's talk" button with rounded corners.
- Created a new homepage component (New).

### How to test?

1. Navigate to the About page (/new/about) and verify the new content is displayed correctly.
2. Check the header navigation:
   - Ensure the "About" link is present and leads to the correct page.
   - Click the Brewww logo and confirm it redirects to the new homepage.
   - Verify the "Let's talk" button has rounded corners.
3. Visit the new homepage (/new) and confirm it renders properly.

### Why make this change?

These changes aim to improve the user experience by providing more comprehensive information about Brewww on the About page and enhancing navigation throughout the site. The updated header offers easier access to key pages, while the new homepage sets the foundation for a refreshed site structure.