### PR TITLE
feat(ui): update schema for BlogPosts and BlogCategories

### DIFF
--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -107,7 +107,7 @@ export interface Page {
  */
 export interface Post {
   id: string;
-  name: string;
+  title: string;
   imageMain?: (string | null) | Media;
   content?: {
     root: {
@@ -124,13 +124,16 @@ export interface Post {
     };
     [k: string]: unknown;
   } | null;
-  title?: string | null;
-  image?: (string | null) | Media;
-  description?: string | null;
-  slug?: string | null;
+  relatedPosts?: (string | Post)[] | null;
+  categories: (string | Category)[];
+  readTime: number;
+  metadata?: {
+    title?: string | null;
+    image?: (string | null) | Media;
+    description?: string | null;
+  };
+  slug: string;
   publishedDate: string;
-  readTime?: number | null;
-  category: string | Category;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -141,25 +144,7 @@ export interface Post {
  */
 export interface Category {
   id: string;
-  name: string;
-  content?: {
-    root: {
-      type: string;
-      children: {
-        type: string;
-        version: number;
-        [k: string]: unknown;
-      }[];
-      direction: ('ltr' | 'rtl') | null;
-      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
-      indent: number;
-      version: number;
-    };
-    [k: string]: unknown;
-  } | null;
-  image?: (string | null) | Media;
-  title?: string | null;
-  description?: string | null;
+  title: string;
   slug: string;
   updatedAt: string;
   createdAt: string;

--- a/src/payload/collections/BlogCategories.ts
+++ b/src/payload/collections/BlogCategories.ts
@@ -17,48 +17,14 @@ export const BlogCategories: CollectionConfig = {
   //* Collection Fields
   fields: [
     {
-      type: "tabs",
-      tabs: [
-        {
-          label: "Content",
-          fields: [
-            {
-              name: "name",
-              type: "text",
-              label: "Category Name",
-              required: true,
-            },
-            {
-              name: "content",
-              type: "richText",
-            },
-          ],
-        },
-        {
-          label: "SEO",
-          fields: [
-            OverviewField({
-              titlePath: "meta.title",
-              descriptionPath: "meta.description",
-              imagePath: "meta.image",
-            }),
-            MetaImageField({
-              relationTo: "media",
-            }),
-            MetaTitleField({
-              hasGenerateFn: true,
-            }),
-            MetaDescriptionField({}),
-            PreviewField({
-              // if the `generateUrl` function is configured
-              hasGenerateFn: true,
-              // field paths to match the target field for data
-              titlePath: "meta.title",
-              descriptionPath: "meta.description",
-            }),
-          ],
-        },
-      ],
+      name: "title",
+      type: "text",
+      label: "Category Title",
+      unique: true,
+      admin: {
+        description: "The title of the category as it appears around the site.",
+      },
+      required: true,
     },
     {
       name: "slug",
@@ -81,16 +47,16 @@ export const BlogCategories: CollectionConfig = {
   },
   admin: {
     description: "Categories for blog posts.",
-    defaultColumns: ["name"],
+    defaultColumns: ["title"],
     group: "Blog Posts",
-    listSearchableFields: ["name"],
+    listSearchableFields: ["title"],
     pagination: {
       defaultLimit: 25,
       limits: [10, 25, 50, 100],
     },
-    useAsTitle: "name",
+    useAsTitle: "title",
   },
-  defaultSort: "name",
+  defaultSort: "title",
   labels: {
     singular: "Category",
     plural: "Categories",

--- a/src/payload/collections/BlogPosts.ts
+++ b/src/payload/collections/BlogPosts.ts
@@ -16,21 +16,21 @@ export const BlogPosts: CollectionConfig = {
   //* Collection Fields
   fields: [
     {
+      name: "title",
+      type: "text",
+      label: "Post Title",
+      unique: true,
+      required: true,
+      admin: {
+        description: "The title of the article as it appears around the site.",
+      },
+    },
+    {
       type: "tabs",
       tabs: [
         {
           label: "Content",
           fields: [
-            {
-              name: "name",
-              type: "text",
-              label: "Post Title",
-              required: true,
-              admin: {
-                description:
-                  "The name of the article as it appears around the site.",
-              },
-            },
             {
               name: "imageMain",
               type: "upload",
@@ -51,6 +51,51 @@ export const BlogPosts: CollectionConfig = {
           ],
         },
         {
+          label: "Meta",
+          fields: [
+            {
+              name: "relatedPosts",
+              type: "relationship",
+              admin: {
+                position: "sidebar",
+              },
+              filterOptions: ({ id }) => {
+                return {
+                  id: {
+                    not_in: [id],
+                  },
+                };
+              },
+              hasMany: true,
+              relationTo: "posts",
+            },
+            {
+              name: "categories",
+              type: "relationship",
+              admin: {
+                position: "sidebar",
+                description:
+                  "Add the post categories here. This is used to group the articles.",
+              },
+              hasMany: true,
+              relationTo: "categories",
+              required: true,
+            },
+            {
+              name: "readTime",
+              type: "number",
+              required: true,
+              label: "Read Time",
+              admin: {
+                description:
+                  "The estimated time it takes to read the article in minutes. Every 200 words is approximately one minute.",
+                position: "sidebar",
+              },
+            },
+          ],
+        },
+        {
+          name: "metadata",
           label: "SEO",
           fields: [
             OverviewField({
@@ -80,7 +125,8 @@ export const BlogPosts: CollectionConfig = {
       name: "slug",
       type: "text",
       label: "Slug",
-      required: false,
+      required: true,
+      unique: true,
       admin: {
         position: "sidebar",
         description: "Add the slug here",
@@ -100,29 +146,6 @@ export const BlogPosts: CollectionConfig = {
         },
       },
     },
-    {
-      name: "readTime",
-      type: "number",
-      required: false,
-      label: "Read Time",
-      admin: {
-        description:
-          "The estimated time it takes to read the article in minutes.",
-        position: "sidebar",
-      },
-    },
-    {
-      name: "category",
-      type: "relationship",
-      relationTo: "categories",
-      label: "Category",
-      required: true,
-      admin: {
-        position: "sidebar",
-        description:
-          "Add the post category here. This is used to group the articles.",
-      },
-    },
   ],
 
   //* Admin Settings
@@ -135,14 +158,14 @@ export const BlogPosts: CollectionConfig = {
   admin: {
     description:
       "Writing brings clarity. Writing is a way to make sense of the world.",
-    defaultColumns: ["name", "publishedDate", "updatedAt"],
+    defaultColumns: ["title", "publishedDate", "updatedAt"],
     group: "Blog Posts",
-    listSearchableFields: ["name"],
+    listSearchableFields: ["title"],
     pagination: {
       defaultLimit: 100,
       limits: [25, 50, 100],
     },
-    useAsTitle: "name",
+    useAsTitle: "title",
   },
   defaultSort: "-publishedDate",
   labels: {


### PR DESCRIPTION
### TL;DR

Refactored the Post and Category interfaces and updated corresponding collection configurations.

### What changed?

- Updated `Post` interface:
  - Renamed `name` to `title`
  - Added `relatedPosts`, `categories`, and `readTime` fields
  - Moved SEO-related fields into a `metadata` object
  - Made `slug` required
  - Removed `category` field

- Simplified `Category` interface:
  - Removed `name`, `content`, `image`, and SEO-related fields
  - Renamed `name` to `title`

- Updated `BlogCategories` collection:
  - Simplified fields to only include `title` and `slug`
  - Made `title` unique and required

- Updated `BlogPosts` collection:
  - Moved `title` field out of tabs
  - Added `relatedPosts`, `categories`, and `readTime` fields
  - Moved SEO fields into a `metadata` tab
  - Made `slug` required and unique
  - Removed `category` field

### How to test?

1. Create a new blog post and verify that all new fields are present and functioning correctly
2. Create a new category and ensure only `title` and `slug` fields are available
3. Test the relationship between posts and categories
4. Verify that related posts can be added to a blog post
5. Check that the SEO fields are now under the `metadata` tab for blog posts

### Why make this change?

This refactoring improves the structure and relationships between blog posts and categories. It allows for multiple categories per post, adds related posts functionality, and simplifies the category model. The changes also enhance SEO management by grouping related fields under a `metadata` object for posts.