### PR TITLE
feat(ui): add hero for individual project template

### DIFF
--- a/src/app/(frontend)/(new)/new/about/page.tsx
+++ b/src/app/(frontend)/(new)/new/about/page.tsx
@@ -3,13 +3,13 @@ import AboutImageEight from "/public/images/brewww-eight.jpeg";
 export default function About() {
   return (
     <>
-      <div className="flex h-screen w-full items-center justify-center bg-zinc-950 bg-[linear-gradient(rgba(8,_8,_8,_0.75),_rgba(8,_8,_8,_0.75))] font-mono text-[20.25rem] font-bold uppercase leading-none text-neutral-400">
+      <section className="flex h-screen w-full items-center justify-center bg-zinc-950 bg-[linear-gradient(rgba(8,_8,_8,_0.75),_rgba(8,_8,_8,_0.75))] font-mono text-[20.25rem] font-bold uppercase leading-none text-neutral-400">
         <h1 className="text-center text-white">
-          <span className="text-outline inline-block">All</span>
-          <span className="block">About</span>
-          <span className="text-brand-gold block">Brewww</span>
+          <span className="text-outline block">All</span>
+          <span className="-mt-16 block">About</span>
+          <span className="text-brand-gold -mt-16 block">Brewww</span>
         </h1>
-      </div>
+      </section>
 
       <section className="relative overflow-hidden bg-white pb-48 pt-24 font-medium text-black">
         <div className="relative m-auto w-full max-w-[120.00rem] flex-col px-8">

--- a/src/app/(frontend)/(new)/new/work/individual/page.tsx
+++ b/src/app/(frontend)/(new)/new/work/individual/page.tsx
@@ -1,0 +1,93 @@
+import Image from "next/image";
+import AboutImageEight from "/public/images/brewww-eight.jpeg";
+
+export default function WorkIndividual() {
+  return (
+    <>
+      <section className="bg-zinc-950 py-40 text-center text-[11.00rem] font-bold uppercase leading-none text-neutral-400">
+        <h1 className="text-white">The Merry Beggars</h1>
+      </section>
+      <section className="mx-auto flex max-w-7xl items-center justify-between bg-zinc-950 px-4 py-2 text-sm text-white">
+        <div className="uppercase">
+          <span>Branding, Design, Development</span>
+        </div>
+        <div>
+          <span>/ 2022</span>
+        </div>
+      </section>
+      <section className="bg-zinc-950">
+        <div className="mx-auto max-w-7xl px-4 py-16">
+          <div className="relative aspect-video w-full overflow-hidden rounded-lg">
+            <Image
+              src={AboutImageEight}
+              alt="Project image"
+              layout="fill"
+              objectFit="cover"
+              className="cursor-pointer"
+            />
+          </div>
+        </div>
+      </section>
+      <section className="bg-zinc-950 py-16">
+        <h1 className="text-center text-[7rem] font-bold uppercase leading-none text-white">
+          Original Audio Entertainment for the Whole Family
+        </h1>
+      </section>
+      <section className="grid grid-rows-[332px_192px] gap-5 bg-zinc-950 text-neutral-400">
+        <div>
+          <span className="text-sm uppercase text-stone-500">
+            <sub>#AUDIOENTERTAINER</sub>
+          </span>
+          <div className="text-[1.75rem] leading-8 text-white">
+            Ready to elevate its digital presence, The Merry Beggars turned to
+            Brewww for help with consolidating their full range of audio
+            entertainment into a single platform. Today, it's the go-to
+            destination for original stories and top-shelf audio productions,
+            captivating millions of listeners worldwide and earning multiple
+            industry accolades.
+          </div>
+        </div>
+        <div>
+          After a thorough partner selection process, Brewww was chosen to help
+          The Merry Beggars become a leader in the audio entertainment industry.
+          We developed a comprehensive digital platform that replaced several
+          fragmented services, becoming the sole practical access point to The
+          Merry Beggars' world of storytelling. We've since tackled multiple
+          projects together, with our partnership continuing to flourish.
+        </div>
+        <div className="row-start-1">
+          <div>
+            <h4 className="text-xs font-bold uppercase text-stone-500">
+              <span>Quick Links</span>
+            </h4>
+
+            <p>
+              <span>
+                <a
+                  className="text-red-700 underline"
+                  href="https://www.brewww.com/#what-we-did"
+                >
+                  What we did
+                </a>
+                <br />
+                <a
+                  className="text-red-700 underline"
+                  href="https://www.brewww.com/#highlights"
+                >
+                  Highlights
+                </a>
+                <br />
+                <a
+                  className="text-red-700 underline"
+                  href="https://www.brewww.com/#key-insights"
+                >
+                  Key insights
+                </a>
+              </span>
+            </p>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -198,8 +198,8 @@ export interface Testimonial {
     };
     [k: string]: unknown;
   };
-  author: string;
   client: string | Client;
+  author: string;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;

--- a/src/payload/collections/Testimonials.ts
+++ b/src/payload/collections/Testimonials.ts
@@ -17,38 +17,60 @@ export const Testimonials: CollectionConfig = {
       },
     },
     {
-      name: "callout",
-      type: "textarea",
-      label: "Callout",
-      required: true,
-      admin: {
-        description: "Add a short excerpt of the testimonial here.",
-      },
-    },
-    {
-      name: "testimonial",
-      type: "richText",
-      label: "Testimonial",
-      required: true,
-      admin: {
-        description: "Add the full testimonial content here. ",
-      },
-    },
-    {
-      name: "author",
-      type: "text",
-      label: "Testimonial Author",
-      required: true,
-      admin: {
-        description: "Add the name of the person that left the testimonial",
-      },
-    },
-    {
-      name: "client",
-      type: "relationship",
-      relationTo: "clients",
-      hasMany: false,
-      required: true,
+      type: "tabs",
+      tabs: [
+        {
+          label: "Content",
+          fields: [
+            {
+              name: "callout",
+              type: "textarea",
+              label: "Callout",
+              required: true,
+              admin: {
+                description: "Add a short excerpt of the testimonial here.",
+              },
+            },
+            {
+              name: "testimonial",
+              type: "richText",
+              label: "Full Testimonial",
+              required: true,
+              admin: {
+                description: "Add the full testimonial content here. ",
+              },
+            },
+          ],
+        },
+        {
+          label: "Meta",
+          fields: [
+            {
+              name: "client",
+              type: "relationship",
+              relationTo: "clients",
+              required: true,
+              hasMany: false,
+              unique: true,
+              admin: {
+                position: "sidebar",
+                description: "Select the client that left the testimonial.",
+              },
+            },
+            {
+              name: "author",
+              type: "text",
+              label: "Testimonial Author",
+              unique: true,
+              required: true,
+              admin: {
+                description:
+                  "Add the name of the person that left the testimonial",
+              },
+            },
+          ],
+        },
+      ],
     },
   ],
 


### PR DESCRIPTION
### TL;DR

Updated the About page layout and added a new Work Individual page. Restructured the Testimonials collection in Payload CMS.

### What changed?

- About page: Adjusted the layout of the hero section, changing `div` to `section` and modifying the spacing of text elements.
- Added a new Work Individual page with sections for project details, images, and description.
- Testimonials collection: Reorganized fields into tabs (Content and Meta), made the client relationship unique, and adjusted field positions and descriptions.

### How to test?

1. Check the About page (/new/about) to ensure the hero section layout is correct.
2. Navigate to the new Work Individual page (/new/work/individual) and verify all sections are displayed properly.
3. In the Payload CMS admin panel, create or edit a Testimonial to confirm the new tab structure and field arrangements.

### Why make this change?

- The About page layout changes improve the visual hierarchy and responsiveness of the hero section.
- The new Work Individual page provides a detailed view for showcasing specific projects.
- Restructuring the Testimonials collection in Payload CMS enhances the content management experience by organizing fields more logically and ensuring unique client-author combinations.