### PR TITLE
feat(ui): add scrolling highlights section to individual work page

### DIFF
--- a/src/app/(frontend)/(new)/new/work/individual/page.tsx
+++ b/src/app/(frontend)/(new)/new/work/individual/page.tsx
@@ -189,6 +189,29 @@ export default function WorkIndividual() {
           </div>
         </div>
       </section>
+      <section className="overflow-hidden bg-zinc-950">
+        <div className="relative flex whitespace-nowrap">
+          <div className="animate-marquee-reverse flex items-center">
+            <span className="mx-4 text-[45.00rem] font-bold leading-none text-neutral-400">
+              HIGHLIGHTS
+            </span>
+            <span className="mx-4 text-[45.00rem] font-bold leading-none text-neutral-400">
+              &nbsp;&nbsp;&nbsp;&nbsp;HIGHLIGHTS
+            </span>
+          </div>
+          <div
+            className="animate-marquee-reverse flex items-center"
+            aria-hidden="true"
+          >
+            <span className="mx-4 text-[45.00rem] font-bold leading-none text-neutral-400">
+              HIGHLIGHTS
+            </span>
+            <span className="mx-4 text-[45.00rem] font-bold leading-none text-neutral-400">
+              &nbsp;&nbsp;&nbsp;&nbsp;HIGHLIGHTS
+            </span>
+          </div>
+        </div>
+      </section>
     </>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -46,3 +46,16 @@ html {
     scrollbar-color: theme("colors.brand.gold") transparent;
   }
 }
+
+@keyframes marquee-reverse {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-100%);
+  }
+}
+
+.animate-marquee-reverse {
+  animation: marquee-reverse 80s linear infinite;
+}


### PR DESCRIPTION
### TL;DR

Added a new "HIGHLIGHTS" marquee section to the individual work page and implemented a reverse marquee animation.

### What changed?

- Added a new section with a reverse-scrolling marquee effect displaying "HIGHLIGHTS" text in the individual work page.
- Implemented a custom `marquee-reverse` animation in the global CSS file.
- Created a new CSS class `animate-marquee-reverse` to apply the marquee animation.

### How to test?

1. Navigate to the individual work page.
2. Scroll down to find the new "HIGHLIGHTS" section.
3. Verify that the text is scrolling from right to left continuously.
4. Check that the animation is smooth and repeats infinitely.

### Why make this change?

This change adds a visually striking element to the individual work page, drawing attention to the highlights section. The reverse marquee effect creates a dynamic and engaging user experience, potentially increasing user engagement and time spent on the page.