### PR TITLE
feat(ui): add results section to individual work page

### DIFF
--- a/src/app/(frontend)/(new)/new/work/individual/page.tsx
+++ b/src/app/(frontend)/(new)/new/work/individual/page.tsx
@@ -212,6 +212,42 @@ export default function WorkIndividual() {
           </div>
         </div>
       </section>
+      <section className="bg-zinc-950">
+        <div className="container mx-auto px-4">
+          <ul className="grid list-none grid-cols-[630.922px_374.844px_481.234px] grid-rows-[19.75rem] gap-5 text-neutral-400">
+            <li className="list-item">
+              <div>
+                <h3 className="text-[11.75rem] font-bold leading-none text-white">
+                  150K+
+                </h3>
+                <span className="text-[1.38rem] leading-7 text-zinc-500">
+                  Active app users in a few months post-release
+                </span>
+              </div>
+            </li>
+            <li className="list-item">
+              <div>
+                <h3 className="text-[11.75rem] font-bold leading-none text-white">
+                  47
+                </h3>
+                <span className="text-[1.38rem] leading-7 text-zinc-500">
+                  Countries using app
+                </span>
+              </div>
+            </li>
+            <li className="list-item">
+              <div>
+                <h3 className="text-[11.75rem] font-bold leading-none text-white">
+                  2x
+                </h3>
+                <span className="text-[1.38rem] leading-7 text-zinc-500">
+                  Winner of eMobility Excellence
+                </span>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </section>
     </>
   );
 }


### PR DESCRIPTION
### TL;DR

Added a new statistics section to the WorkIndividual page.

### What changed?

- Introduced a new `<section>` with a dark background (bg-zinc-950)
- Added a grid layout containing three statistics:
- Each statistic is displayed with a large number and a descriptive text

### How to test?

1. Navigate to the WorkIndividual page
2. Scroll down to the newly added section
3. Verify that the statistics are displayed correctly:
4. Check that the layout and styling match the intended design

### Why make this change?

This addition provides key performance indicators and achievements, highlighting the success and reach of the app. It helps to build credibility and showcase the app's impact to potential users or stakeholders.