### PR TITLE
chore(deps): remove Vercel speed insights

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@radix-ui/react-select": "^2.1.1",
     "@radix-ui/react-slot": "^1.1.0",
     "@tailwindcss/typography": "^0.5.14",
-    "@vercel/speed-insights": "^1.0.12",
     "babel-plugin-react-compiler": "0.0.0-experimental-de2cfda-20240912",
     "eslint-plugin-react-compiler": "0.0.0-experimental-75b9fd4-20240912",
     "graphql": "^16.9.0",

--- a/src/app/(frontend)/(home)/layout.tsx
+++ b/src/app/(frontend)/(home)/layout.tsx
@@ -1,4 +1,3 @@
-import { SpeedInsights } from "@vercel/speed-insights/next";
 import localFont from "next/font/local";
 import "@/styles/globals.css";
 import { Metadata } from "next";
@@ -23,7 +22,6 @@ export default function RootLayout({
     <html lang="en" className={`${DMSans.variable}`}>
       <body className="bg-gray-950 text-gray-50 antialiased">
         <main className="flex min-h-svh flex-col">{children}</main>
-        <SpeedInsights />
       </body>
     </html>
   );

--- a/src/app/(frontend)/(inner)/layout.tsx
+++ b/src/app/(frontend)/(inner)/layout.tsx
@@ -1,4 +1,3 @@
-import { SpeedInsights } from "@vercel/speed-insights/next";
 import localFont from "next/font/local";
 import "@/styles/globals.css";
 import { Metadata } from "next";
@@ -28,7 +27,6 @@ export default function InnerLayout({
         <Header />
         <div className="">{children}</div>
         <Footer />
-        <SpeedInsights />
       </body>
     </html>
   );

--- a/src/app/(frontend)/(new)/layout.tsx
+++ b/src/app/(frontend)/(new)/layout.tsx
@@ -1,4 +1,3 @@
-import { SpeedInsights } from "@vercel/speed-insights/next";
 import localFont from "next/font/local";
 import "@/styles/globals.css";
 import { Metadata } from "next";
@@ -40,7 +39,6 @@ export default function InnerLayout({
         <HeaderNew />
         <div className="">{children}</div>
         <FooterNew />
-        <SpeedInsights />
       </body>
     </html>
   );

--- a/src/app/(frontend)/[slug]/layout.tsx
+++ b/src/app/(frontend)/[slug]/layout.tsx
@@ -1,4 +1,3 @@
-import { SpeedInsights } from "@vercel/speed-insights/next";
 import localFont from "next/font/local";
 import "@/styles/globals.css";
 import { Metadata } from "next";
@@ -28,7 +27,6 @@ export default function InnerLayout({
         <Header />
         <div className="">{children}</div>
         <Footer />
-        <SpeedInsights />
       </body>
     </html>
   );


### PR DESCRIPTION
### TL;DR

Removed Vercel Speed Insights from the project.

### What changed?

- Removed `@vercel/speed-insights` dependency from `package.json`
- Removed `SpeedInsights` component import and usage from various layout files:
  - `src/app/(frontend)/(home)/layout.tsx`
  - `src/app/(frontend)/(inner)/layout.tsx`
  - `src/app/(frontend)/(new)/layout.tsx`
  - `src/app/(frontend)/[slug]/layout.tsx`

### How to test?

1. Run the application locally
2. Navigate through different pages and ensure they load correctly
3. Check the browser's network tab to confirm that no Speed Insights related requests are being made
4. Verify that the application's performance and functionality remain unaffected

### Why make this change?

The removal of Vercel Speed Insights could be due to:
- Opting for alternative performance monitoring tools
- Simplifying the application's codebase

This change aims to streamline the project while maintaining its core functionality.