### PR TITLE
feat(ui): add initial structure to play page

### DIFF
--- a/src/app/(frontend)/(new)/new/play/individual/page.tsx
+++ b/src/app/(frontend)/(new)/new/play/individual/page.tsx
@@ -1,0 +1,3 @@
+export default function IndividualPlayPage() {
+  return <div>Individual Play</div>;
+}

--- a/src/app/(frontend)/(new)/new/play/page.tsx
+++ b/src/app/(frontend)/(new)/new/play/page.tsx
@@ -1,0 +1,229 @@
+export default function PlayPage() {
+  return (
+    <>
+      <div className="py-16">
+        <div>
+          <div className="w-full px-20 text-lg text-white">
+            <div>
+              <div className="-ml-0 flex max-w-[18ch] items-center text-[4.25rem] leading-none">
+                <span className="mr-2 text-[2rem]">●</span>
+                Play
+              </div>
+              <div className="mb-4 mt-6 h-0.5 bg-zinc-900" />
+              <div className="mb-4 text-xs uppercase">Selected Projects</div>
+            </div>
+            <div className="flex flex-col gap-y-[7.38rem]">
+              <a
+                className="col-span-2 row-span-1 inline-block w-full max-w-full"
+                href="#"
+              >
+                <div className="relative flex w-full cursor-pointer overflow-hidden rounded-md">
+                  <div className="relative w-full pt-[56.25%]">
+                    <img
+                      className="absolute inset-0 h-full w-full object-cover"
+                      src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10ccaad8365d669c95e70_63c91a92dc0c340932978b8f_image-ueno-template-04-p-3200.jpeg"
+                    />
+                  </div>
+                </div>
+                <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1">
+                  <div>
+                    <div className="inline-block font-semibold uppercase">
+                      Evano Everyday
+                    </div>
+                    <div className="m-1 inline-block">·</div>
+                    The new norm of life
+                  </div>
+                  <div className="text-neutral-400">
+                    Brand identity, Website, Packaging
+                  </div>
+                </div>
+              </a>
+              <div className="grid w-full auto-cols-fr grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr] grid-rows-[auto] items-start gap-y-[7.38rem]">
+                <div
+                  className="col-start-4 col-end-9 row-start-1 row-end-2"
+                  style={{
+                    gridArea: "1/4/2/9",
+                  }}
+                >
+                  <a
+                    className="col-span-2 row-span-1 inline-block w-full max-w-full"
+                    href=""
+                  >
+                    <div className="flex w-full cursor-pointer overflow-hidden rounded-md">
+                      <img
+                        className="inline-block h-full w-full max-w-full object-contain align-middle"
+                        src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10dcd8842ec2b57b28cb6_63c9187126433a43129cc944_image-ueno-template-02.jpeg"
+                      />
+                    </div>
+                    <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1">
+                      <div>
+                        <div className="inline-block font-semibold uppercase">
+                          Square
+                        </div>
+                        <div className="m-1 inline-block">·</div>
+                        The new norm of life
+                      </div>
+                      <div className="text-neutral-400">
+                        Brand identity, Website
+                      </div>
+                    </div>
+                  </a>
+                </div>
+                <div
+                  className="col-start-9 col-end-13 row-start-1 row-end-2 flex-grow pl-28"
+                  style={{
+                    gridArea: "1/9/2/13",
+                  }}
+                >
+                  <a
+                    className="col-span-2 row-span-1 inline-block w-full max-w-full"
+                    href=""
+                  >
+                    <div className="flex w-full cursor-pointer overflow-hidden rounded-md">
+                      <img
+                        className="inline-block h-full w-full max-w-full object-contain align-middle"
+                        src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10dfd80f1f22872630cce_63c91c81185e3416e7ba7960_image-ueno-template-06-p-2000.jpeg"
+                      />
+                    </div>
+                    <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1">
+                      <div>
+                        <div className="inline-block font-semibold uppercase">
+                          Castro Capital
+                        </div>
+                        <div className="m-1 inline-block">·</div>
+                        The new norm of life
+                      </div>
+                      <div className="text-neutral-400">
+                        Digital design system, Website, Print
+                      </div>
+                    </div>
+                  </a>
+                </div>
+              </div>
+              <div className="grid w-full auto-cols-fr grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr] grid-rows-[auto] items-start gap-y-[7.38rem]">
+                <div className="col-span-9 row-span-1 w-full">
+                  <a
+                    className="col-span-2 row-span-1 inline-block w-full max-w-full"
+                    href=""
+                  >
+                    <div className="relative flex w-full cursor-pointer overflow-hidden rounded-md">
+                      <div className="relative w-full pt-[56.25%]">
+                        <img
+                          className="absolute bottom-0 left-0 top-0 inline-block h-full w-full max-w-full object-cover align-middle"
+                          src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10e2f8842ec5dcab29324_63c91907a7ce6182b053ba02_image-ueno-template-03.jpeg"
+                        />
+                      </div>
+                    </div>
+                    <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1">
+                      <div>
+                        <div className="inline-block font-semibold uppercase">
+                          Rucksack Magazine
+                        </div>
+                        <div className="m-1 inline-block">·</div>
+                        All about photography
+                      </div>
+                      <div className="text-neutral-400">
+                        Brand identity, Website, Print
+                      </div>
+                    </div>
+                  </a>
+                </div>
+              </div>
+              <div className="grid w-full auto-cols-fr grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr] grid-rows-[auto] items-start gap-y-[7.38rem]">
+                <div
+                  className="col-start-7 col-end-13 row-start-1 row-end-2 flex-grow pl-28"
+                  style={{
+                    gridArea: "1/7/2/13",
+                  }}
+                >
+                  <a
+                    className="col-span-2 row-span-1 inline-block w-full max-w-full"
+                    href=""
+                  >
+                    <div className="flex w-full cursor-pointer overflow-hidden rounded-md">
+                      <img
+                        className="inline-block h-full w-full max-w-full object-contain align-middle"
+                        src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10e81559654d00360030b_63c91be70da88459ac7b5a3a_image-ueno-template-05.jpeg"
+                      />
+                    </div>
+                    <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1">
+                      <div>
+                        <div className="inline-block font-semibold uppercase">
+                          Romans
+                        </div>
+                        <div className="m-1 inline-block">·</div>
+                        All about photography
+                      </div>
+                      <div className="text-neutral-400">
+                        Brand identity, Website, Packaging
+                      </div>
+                    </div>
+                  </a>
+                </div>
+                <div
+                  className="col-start-4 col-end-7 row-start-1 row-end-2"
+                  style={{
+                    gridArea: "1/4/2/7",
+                  }}
+                >
+                  <a
+                    className="col-span-2 row-span-1 inline-block w-full max-w-full"
+                    href=""
+                  >
+                    <div className="flex w-full cursor-pointer overflow-hidden rounded-md">
+                      <img
+                        className="inline-block h-full w-full max-w-full object-contain align-middle"
+                        src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d1162e150c60446a56cadd_63c91d6bd8d50020d6d274c0_image-ueno-template-07-p-2000.jpeg"
+                      />
+                    </div>
+                    <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1">
+                      <div>
+                        <div className="inline-block font-semibold uppercase">
+                          Hakuha
+                        </div>
+                        <div className="m-1 inline-block">·</div>
+                        All about photography
+                      </div>
+                      <div className="text-neutral-400">
+                        Digital product, Packaging
+                      </div>
+                    </div>
+                  </a>
+                </div>
+              </div>
+              <div className="grid w-full auto-cols-fr grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr] grid-rows-[auto] items-start gap-y-[7.38rem]">
+                <div className="col-span-8 row-span-1">
+                  <a
+                    className="col-span-2 row-span-1 inline-block w-full max-w-full"
+                    href=""
+                  >
+                    <div className="relative flex w-full cursor-pointer overflow-hidden rounded-md">
+                      <div className="relative w-full pt-[56.25%]">
+                        <img
+                          className="absolute bottom-0 left-0 top-0 inline-block h-full w-full max-w-full object-cover align-middle"
+                          src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10ee4ad83658d2bc97c5a_63c91ec109d76d3e7e34327f_image-ueno-template-08-p-2000.jpeg"
+                        />
+                      </div>
+                    </div>
+                    <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1">
+                      <div>
+                        <div className="inline-block font-semibold uppercase">
+                          Café de especialidad
+                        </div>
+                        <div className="m-1 inline-block">·</div>
+                        All about photography
+                      </div>
+                      <div className="text-neutral-400">
+                        Brand identity, Website
+                      </div>
+                    </div>
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
### TL;DR

Added new Play and Individual Play pages with content for showcasing selected projects.

### What changed?

- Created a new `play` page with a grid layout displaying various projects
- Added an `individual` play page as a placeholder
- Implemented responsive design for different screen sizes
- Included project images, titles, and brief descriptions for each showcase item

### How to test?

1. Navigate to the `/new/play` route to view the main Play page
2. Verify that the project grid displays correctly with images and descriptions
3. Check responsiveness by resizing the browser window
4. Navigate to `/new/play/individual` to confirm the placeholder page is present

### Why make this change?

This change introduces a dedicated section for showcasing selected projects, allowing visitors to browse through the portfolio easily. It enhances the user experience by providing a visually appealing and organized display of work, which can help attract potential clients or collaborators.