### PR TITLE
feat(cms): add new slugField to all other CMS collections

### DIFF
--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -3,30 +3,30 @@ import { MetaTitleComponent as MetaTitleComponent_1 } from '@payloadcms/plugin-s
 import { MetaImageComponent as MetaImageComponent_2 } from '@payloadcms/plugin-seo/client'
 import { MetaDescriptionComponent as MetaDescriptionComponent_3 } from '@payloadcms/plugin-seo/client'
 import { PreviewComponent as PreviewComponent_4 } from '@payloadcms/plugin-seo/client'
-import { RichTextCell as RichTextCell_5 } from '@payloadcms/richtext-lexical/client'
-import { RichTextField as RichTextField_6 } from '@payloadcms/richtext-lexical/client'
-import { getGenerateComponentMap as getGenerateComponentMap_7 } from '@payloadcms/richtext-lexical/generateComponentMap'
-import { InlineToolbarFeatureClient as InlineToolbarFeatureClient_8 } from '@payloadcms/richtext-lexical/client'
-import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_9 } from '@payloadcms/richtext-lexical/client'
-import { UploadFeatureClient as UploadFeatureClient_10 } from '@payloadcms/richtext-lexical/client'
-import { BlockquoteFeatureClient as BlockquoteFeatureClient_11 } from '@payloadcms/richtext-lexical/client'
-import { RelationshipFeatureClient as RelationshipFeatureClient_12 } from '@payloadcms/richtext-lexical/client'
-import { LinkFeatureClient as LinkFeatureClient_13 } from '@payloadcms/richtext-lexical/client'
-import { ChecklistFeatureClient as ChecklistFeatureClient_14 } from '@payloadcms/richtext-lexical/client'
-import { OrderedListFeatureClient as OrderedListFeatureClient_15 } from '@payloadcms/richtext-lexical/client'
-import { UnorderedListFeatureClient as UnorderedListFeatureClient_16 } from '@payloadcms/richtext-lexical/client'
-import { IndentFeatureClient as IndentFeatureClient_17 } from '@payloadcms/richtext-lexical/client'
-import { AlignFeatureClient as AlignFeatureClient_18 } from '@payloadcms/richtext-lexical/client'
-import { HeadingFeatureClient as HeadingFeatureClient_19 } from '@payloadcms/richtext-lexical/client'
-import { ParagraphFeatureClient as ParagraphFeatureClient_20 } from '@payloadcms/richtext-lexical/client'
-import { InlineCodeFeatureClient as InlineCodeFeatureClient_21 } from '@payloadcms/richtext-lexical/client'
-import { SuperscriptFeatureClient as SuperscriptFeatureClient_22 } from '@payloadcms/richtext-lexical/client'
-import { SubscriptFeatureClient as SubscriptFeatureClient_23 } from '@payloadcms/richtext-lexical/client'
-import { StrikethroughFeatureClient as StrikethroughFeatureClient_24 } from '@payloadcms/richtext-lexical/client'
-import { UnderlineFeatureClient as UnderlineFeatureClient_25 } from '@payloadcms/richtext-lexical/client'
-import { BoldFeatureClient as BoldFeatureClient_26 } from '@payloadcms/richtext-lexical/client'
-import { ItalicFeatureClient as ItalicFeatureClient_27 } from '@payloadcms/richtext-lexical/client'
-import { SlugComponent as SlugComponent_28 } from '@/fields/slug/SlugComponent'
+import { SlugComponent as SlugComponent_5 } from '@/fields/slug/SlugComponent'
+import { RichTextCell as RichTextCell_6 } from '@payloadcms/richtext-lexical/client'
+import { RichTextField as RichTextField_7 } from '@payloadcms/richtext-lexical/client'
+import { getGenerateComponentMap as getGenerateComponentMap_8 } from '@payloadcms/richtext-lexical/generateComponentMap'
+import { InlineToolbarFeatureClient as InlineToolbarFeatureClient_9 } from '@payloadcms/richtext-lexical/client'
+import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_10 } from '@payloadcms/richtext-lexical/client'
+import { UploadFeatureClient as UploadFeatureClient_11 } from '@payloadcms/richtext-lexical/client'
+import { BlockquoteFeatureClient as BlockquoteFeatureClient_12 } from '@payloadcms/richtext-lexical/client'
+import { RelationshipFeatureClient as RelationshipFeatureClient_13 } from '@payloadcms/richtext-lexical/client'
+import { LinkFeatureClient as LinkFeatureClient_14 } from '@payloadcms/richtext-lexical/client'
+import { ChecklistFeatureClient as ChecklistFeatureClient_15 } from '@payloadcms/richtext-lexical/client'
+import { OrderedListFeatureClient as OrderedListFeatureClient_16 } from '@payloadcms/richtext-lexical/client'
+import { UnorderedListFeatureClient as UnorderedListFeatureClient_17 } from '@payloadcms/richtext-lexical/client'
+import { IndentFeatureClient as IndentFeatureClient_18 } from '@payloadcms/richtext-lexical/client'
+import { AlignFeatureClient as AlignFeatureClient_19 } from '@payloadcms/richtext-lexical/client'
+import { HeadingFeatureClient as HeadingFeatureClient_20 } from '@payloadcms/richtext-lexical/client'
+import { ParagraphFeatureClient as ParagraphFeatureClient_21 } from '@payloadcms/richtext-lexical/client'
+import { InlineCodeFeatureClient as InlineCodeFeatureClient_22 } from '@payloadcms/richtext-lexical/client'
+import { SuperscriptFeatureClient as SuperscriptFeatureClient_23 } from '@payloadcms/richtext-lexical/client'
+import { SubscriptFeatureClient as SubscriptFeatureClient_24 } from '@payloadcms/richtext-lexical/client'
+import { StrikethroughFeatureClient as StrikethroughFeatureClient_25 } from '@payloadcms/richtext-lexical/client'
+import { UnderlineFeatureClient as UnderlineFeatureClient_26 } from '@payloadcms/richtext-lexical/client'
+import { BoldFeatureClient as BoldFeatureClient_27 } from '@payloadcms/richtext-lexical/client'
+import { ItalicFeatureClient as ItalicFeatureClient_28 } from '@payloadcms/richtext-lexical/client'
 
 export const importMap = {
   "@payloadcms/plugin-seo/client#OverviewComponent": OverviewComponent_0,
@@ -34,28 +34,28 @@ export const importMap = {
   "@payloadcms/plugin-seo/client#MetaImageComponent": MetaImageComponent_2,
   "@payloadcms/plugin-seo/client#MetaDescriptionComponent": MetaDescriptionComponent_3,
   "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_4,
-  "@payloadcms/richtext-lexical/client#RichTextCell": RichTextCell_5,
-  "@payloadcms/richtext-lexical/client#RichTextField": RichTextField_6,
-  "@payloadcms/richtext-lexical/generateComponentMap#getGenerateComponentMap": getGenerateComponentMap_7,
-  "@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient": InlineToolbarFeatureClient_8,
-  "@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient": HorizontalRuleFeatureClient_9,
-  "@payloadcms/richtext-lexical/client#UploadFeatureClient": UploadFeatureClient_10,
-  "@payloadcms/richtext-lexical/client#BlockquoteFeatureClient": BlockquoteFeatureClient_11,
-  "@payloadcms/richtext-lexical/client#RelationshipFeatureClient": RelationshipFeatureClient_12,
-  "@payloadcms/richtext-lexical/client#LinkFeatureClient": LinkFeatureClient_13,
-  "@payloadcms/richtext-lexical/client#ChecklistFeatureClient": ChecklistFeatureClient_14,
-  "@payloadcms/richtext-lexical/client#OrderedListFeatureClient": OrderedListFeatureClient_15,
-  "@payloadcms/richtext-lexical/client#UnorderedListFeatureClient": UnorderedListFeatureClient_16,
-  "@payloadcms/richtext-lexical/client#IndentFeatureClient": IndentFeatureClient_17,
-  "@payloadcms/richtext-lexical/client#AlignFeatureClient": AlignFeatureClient_18,
-  "@payloadcms/richtext-lexical/client#HeadingFeatureClient": HeadingFeatureClient_19,
-  "@payloadcms/richtext-lexical/client#ParagraphFeatureClient": ParagraphFeatureClient_20,
-  "@payloadcms/richtext-lexical/client#InlineCodeFeatureClient": InlineCodeFeatureClient_21,
-  "@payloadcms/richtext-lexical/client#SuperscriptFeatureClient": SuperscriptFeatureClient_22,
-  "@payloadcms/richtext-lexical/client#SubscriptFeatureClient": SubscriptFeatureClient_23,
-  "@payloadcms/richtext-lexical/client#StrikethroughFeatureClient": StrikethroughFeatureClient_24,
-  "@payloadcms/richtext-lexical/client#UnderlineFeatureClient": UnderlineFeatureClient_25,
-  "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_26,
-  "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_27,
-  "@/fields/slug/SlugComponent#SlugComponent": SlugComponent_28
+  "@/fields/slug/SlugComponent#SlugComponent": SlugComponent_5,
+  "@payloadcms/richtext-lexical/client#RichTextCell": RichTextCell_6,
+  "@payloadcms/richtext-lexical/client#RichTextField": RichTextField_7,
+  "@payloadcms/richtext-lexical/generateComponentMap#getGenerateComponentMap": getGenerateComponentMap_8,
+  "@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient": InlineToolbarFeatureClient_9,
+  "@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient": HorizontalRuleFeatureClient_10,
+  "@payloadcms/richtext-lexical/client#UploadFeatureClient": UploadFeatureClient_11,
+  "@payloadcms/richtext-lexical/client#BlockquoteFeatureClient": BlockquoteFeatureClient_12,
+  "@payloadcms/richtext-lexical/client#RelationshipFeatureClient": RelationshipFeatureClient_13,
+  "@payloadcms/richtext-lexical/client#LinkFeatureClient": LinkFeatureClient_14,
+  "@payloadcms/richtext-lexical/client#ChecklistFeatureClient": ChecklistFeatureClient_15,
+  "@payloadcms/richtext-lexical/client#OrderedListFeatureClient": OrderedListFeatureClient_16,
+  "@payloadcms/richtext-lexical/client#UnorderedListFeatureClient": UnorderedListFeatureClient_17,
+  "@payloadcms/richtext-lexical/client#IndentFeatureClient": IndentFeatureClient_18,
+  "@payloadcms/richtext-lexical/client#AlignFeatureClient": AlignFeatureClient_19,
+  "@payloadcms/richtext-lexical/client#HeadingFeatureClient": HeadingFeatureClient_20,
+  "@payloadcms/richtext-lexical/client#ParagraphFeatureClient": ParagraphFeatureClient_21,
+  "@payloadcms/richtext-lexical/client#InlineCodeFeatureClient": InlineCodeFeatureClient_22,
+  "@payloadcms/richtext-lexical/client#SuperscriptFeatureClient": SuperscriptFeatureClient_23,
+  "@payloadcms/richtext-lexical/client#SubscriptFeatureClient": SubscriptFeatureClient_24,
+  "@payloadcms/richtext-lexical/client#StrikethroughFeatureClient": StrikethroughFeatureClient_25,
+  "@payloadcms/richtext-lexical/client#UnderlineFeatureClient": UnderlineFeatureClient_26,
+  "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_27,
+  "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_28
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -20,7 +20,7 @@ export interface Config {
     services: Service;
     clients: Client;
     testimonials: Testimonial;
-    in: In;
+    locations: Location;
     results: Result;
     users: User;
     'payload-preferences': PayloadPreference;
@@ -97,6 +97,7 @@ export interface Page {
     description?: string | null;
   };
   slug: string;
+  slugLock?: boolean | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -134,7 +135,7 @@ export interface Post {
     image?: (string | null) | Media;
     description?: string | null;
   };
-  slug?: string | null;
+  slug: string;
   slugLock?: boolean | null;
   publishedAt: string;
   updatedAt: string;
@@ -149,6 +150,7 @@ export interface Category {
   id: string;
   title: string;
   slug: string;
+  slugLock?: boolean | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -161,6 +163,7 @@ export interface Work {
   id: string;
   title: string;
   slug: string;
+  slugLock?: boolean | null;
   thumbnail: string | Media;
   testimonial?: (string | null) | Testimonial;
   metadata: {
@@ -168,8 +171,8 @@ export interface Work {
     relatedWorks?: (string | Work)[] | null;
   };
   seo?: {
-    image?: (string | null) | Media;
     title?: string | null;
+    image?: (string | null) | Media;
     description?: string | null;
   };
   updatedAt: string;
@@ -228,6 +231,7 @@ export interface Play {
   id: string;
   title: string;
   slug: string;
+  slugLock?: boolean | null;
   publishedAt: string;
   content: {
     imageThumbnail: string | Media;
@@ -252,17 +256,26 @@ export interface Service {
   id: string;
   title: string;
   slug: string;
+  slugLock?: boolean | null;
+  metadata?: {};
+  seo?: {
+    title?: string | null;
+    image?: (string | null) | Media;
+    description?: string | null;
+  };
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "in".
+ * via the `definition` "locations".
  */
-export interface In {
+export interface Location {
   id: string;
-  name?: string | null;
+  title: string;
+  slug: string;
+  slugLock?: boolean | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;

--- a/src/payload/collections/BlogCategories.ts
+++ b/src/payload/collections/BlogCategories.ts
@@ -2,7 +2,7 @@ import type { CollectionConfig } from "payload";
 import { authenticated } from "@/payload/access/authenticated";
 import { authenticatedOrPublished } from "@/payload/access/authenticatedOrPublished";
 import { UnderlineFeature, lexicalEditor } from "@payloadcms/richtext-lexical";
-
+import { slugField } from "@/fields/slug";
 import {
   MetaDescriptionField,
   MetaImageField,
@@ -26,16 +26,7 @@ export const BlogCategories: CollectionConfig = {
       },
       required: true,
     },
-    {
-      name: "slug",
-      type: "text",
-      label: "Slug",
-      required: true,
-      admin: {
-        position: "sidebar",
-        description: "Add a cool slug here",
-      },
-    },
+    ...slugField(),
   ],
 
   //* Admin Settings

--- a/src/payload/collections/BlogPosts.ts
+++ b/src/payload/collections/BlogPosts.ts
@@ -121,23 +121,12 @@ export const BlogPosts: CollectionConfig = {
         },
       ],
     },
-    // {
-    //   name: "slug",
-    //   type: "text",
-    //   label: "Slug",
-    //   required: true,
-    //   unique: true,
-    //   admin: {
-    //     position: "sidebar",
-    //     description: "Add the slug here",
-    //   },
-    // },
     ...slugField(),
     {
       name: "publishedAt",
       type: "date",
       required: true,
-      label: "Published Date",
+      label: "Published At",
       admin: {
         description:
           "The date the article was published. This is used to sort the articles.",

--- a/src/payload/collections/Locations.ts
+++ b/src/payload/collections/Locations.ts
@@ -1,12 +1,25 @@
 import type { CollectionConfig } from "payload";
 import { authenticated } from "@/payload/access/authenticated";
 import { authenticatedOrPublished } from "@/payload/access/authenticatedOrPublished";
+import { slugField } from "@/fields/slug";
 
 export const Location: CollectionConfig = {
-  slug: "in",
+  slug: "locations",
 
   //* Collection Fields
-  fields: [{ name: "name", type: "text", label: "Name" }],
+  fields: [
+    {
+      name: "title",
+      type: "text",
+      label: "Location Title",
+      required: true,
+      unique: true,
+      admin: {
+        description: "The title of the location as it appears around the site.",
+      },
+    },
+    ...slugField(),
+  ],
 
   //* Admin Settings
   access: {
@@ -18,7 +31,7 @@ export const Location: CollectionConfig = {
   admin: {
     description: "Landing pages for services",
     group: "Service",
-    useAsTitle: "name",
+    useAsTitle: "title",
   },
 
   labels: {

--- a/src/payload/collections/Pages/index.ts
+++ b/src/payload/collections/Pages/index.ts
@@ -1,6 +1,7 @@
 import type { CollectionConfig } from "payload";
 import { authenticated } from "@/payload/access/authenticated";
 import { authenticatedOrPublished } from "@/payload/access/authenticatedOrPublished";
+import { slugField } from "@/fields/slug";
 import { Cover } from "@/app/blocks/Cover/config";
 import {
   MetaDescriptionField,
@@ -65,17 +66,7 @@ export const Pages: CollectionConfig = {
         },
       ],
     },
-
-    {
-      name: "slug",
-      type: "text",
-      label: "Slug",
-      required: true,
-      admin: {
-        position: "sidebar",
-        description: "The slug goes here.",
-      },
-    },
+    ...slugField(),
   ],
 
   //* Admin Settings

--- a/src/payload/collections/Playground.ts
+++ b/src/payload/collections/Playground.ts
@@ -1,7 +1,7 @@
 import type { CollectionConfig } from "payload";
 import { authenticated } from "@/payload/access/authenticated";
 import { authenticatedOrPublished } from "@/payload/access/authenticatedOrPublished";
-
+import { slugField } from "@/fields/slug";
 import {
   MetaDescriptionField,
   MetaImageField,
@@ -25,17 +25,7 @@ export const Playground: CollectionConfig = {
         description: "Add the title of the Playground case study here.",
       },
     },
-    {
-      name: "slug",
-      type: "text",
-      label: "Slug",
-      required: true,
-      unique: true,
-      admin: {
-        position: "sidebar",
-        description: "Add a unique and SEO compelling slug here.",
-      },
-    },
+    ...slugField(),
     {
       name: "publishedAt",
       type: "date",

--- a/src/payload/collections/Results.ts
+++ b/src/payload/collections/Results.ts
@@ -47,7 +47,7 @@ export const Results: CollectionConfig = {
     },
     useAsTitle: "title",
   },
-  defaultSort: "title",
+  defaultSort: "-title",
   labels: {
     singular: "Result",
     plural: "Results",

--- a/src/payload/collections/Services.ts
+++ b/src/payload/collections/Services.ts
@@ -1,6 +1,14 @@
 import type { CollectionConfig } from "payload";
 import { authenticated } from "@/payload/access/authenticated";
 import { authenticatedOrPublished } from "@/payload/access/authenticatedOrPublished";
+import { slugField } from "@/fields/slug";
+import {
+  MetaDescriptionField,
+  MetaImageField,
+  MetaTitleField,
+  OverviewField,
+  PreviewField,
+} from "@payloadcms/plugin-seo/fields";
 
 export const Services: CollectionConfig = {
   slug: "services",
@@ -10,21 +18,50 @@ export const Services: CollectionConfig = {
     {
       name: "title",
       type: "text",
-      label: "ServiceTitle",
+      label: "Service Title",
       required: true,
+      unique: true,
       admin: {
-        description: "add a cool name here",
+        description: "The name of the service as it appears around the site.",
       },
     },
+    ...slugField(),
     {
-      name: "slug",
-      type: "text",
-      label: "Slug",
-      required: true,
-      admin: {
-        description: "add a cool slug",
-        position: "sidebar",
-      },
+      type: "tabs",
+      tabs: [
+        {
+          label: "Content",
+          fields: [],
+        },
+        {
+          name: "metadata",
+          label: "Meta",
+          fields: [],
+        },
+        {
+          name: "seo",
+          label: "SEO",
+          fields: [
+            PreviewField({
+              hasGenerateFn: true,
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+            }),
+            OverviewField({
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+              imagePath: "meta.image",
+            }),
+            MetaTitleField({
+              hasGenerateFn: true,
+            }),
+            MetaImageField({
+              relationTo: "media",
+            }),
+            MetaDescriptionField({}),
+          ],
+        },
+      ],
     },
   ],
 
@@ -36,7 +73,6 @@ export const Services: CollectionConfig = {
     update: authenticated,
   },
   admin: {
-    useAsTitle: "title",
     description: "How we help people. Be specific.",
     defaultColumns: ["title"],
     group: "Service",
@@ -45,8 +81,9 @@ export const Services: CollectionConfig = {
       defaultLimit: 25,
       limits: [10, 25, 50],
     },
+    useAsTitle: "title",
   },
-  defaultSort: "title",
+  defaultSort: "-title",
   labels: {
     singular: "Service",
     plural: "Services",

--- a/src/payload/collections/Work.ts
+++ b/src/payload/collections/Work.ts
@@ -1,6 +1,7 @@
 import type { CollectionConfig } from "payload";
 import { authenticated } from "@/payload/access/authenticated";
 import { authenticatedOrPublished } from "@/payload/access/authenticatedOrPublished";
+import { slugField } from "@/fields/slug";
 
 import {
   MetaDescriptionField,
@@ -24,17 +25,7 @@ export const Work: CollectionConfig = {
         description: "The title of the project as it appears around the site.",
       },
     },
-    {
-      name: "slug",
-      type: "text",
-      label: "Slug",
-      required: true,
-      unique: true,
-      admin: {
-        position: "sidebar",
-        description: "Add a unique and SEO compelling slug here.",
-      },
-    },
+    ...slugField(),
     {
       type: "tabs",
       tabs: [
@@ -93,6 +84,7 @@ export const Work: CollectionConfig = {
                 };
               },
               hasMany: true,
+              required: false,
               relationTo: "work",
             },
           ],
@@ -111,11 +103,11 @@ export const Work: CollectionConfig = {
               descriptionPath: "meta.description",
               imagePath: "meta.image",
             }),
-            MetaImageField({
-              relationTo: "media",
-            }),
             MetaTitleField({
               hasGenerateFn: true,
+            }),
+            MetaImageField({
+              relationTo: "media",
             }),
             MetaDescriptionField({}),
           ],

--- a/src/payload/fields/slug/SlugComponent.tsx
+++ b/src/payload/fields/slug/SlugComponent.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, MouseEvent } from "react";
 
 import {
   useField,
@@ -55,9 +55,8 @@ export const SlugComponent: React.FC<SlugComponentProps> = ({
   }, [fieldToUseValue, checkboxValue, setValue, value]);
 
   const handleLock = useCallback(
-    (e) => {
+    (e: MouseEvent<Element>) => {
       e.preventDefault();
-
       setCheckboxValue(!checkboxValue);
     },
     [checkboxValue, setCheckboxValue],

--- a/src/payload/fields/slug/index.ts
+++ b/src/payload/fields/slug/index.ts
@@ -33,6 +33,7 @@ export const slugField: Slug = (fieldToUse = "title", overrides = {}) => {
     type: "text",
     index: true,
     label: "Slug",
+    required: true,
     ...(slugOverrides || {}),
     hooks: {
       // Kept this in for hook or API based updates


### PR DESCRIPTION
### TL;DR

Refactored slug fields across collections and updated import order in admin import map.

### What changed?

- Implemented a reusable `slugField` function and applied it to various collections (BlogCategories, BlogPosts, Pages, Playground, Services, Work).
- Updated the `Location` collection to use `slugField` and renamed it from "in" to "locations".
- Adjusted the import order in the admin import map file.
- Made minor updates to field configurations, including adding `slugLock` to several types.
- Updated SEO fields in the Services collection.

### How to test?

1. Navigate to the admin panel and verify that slug fields are consistently implemented across all affected collections.
2. Check that the Location collection is now named "locations" and includes a slug field.
3. Ensure that SEO fields are properly displayed in the Services collection.
4. Verify that the admin interface loads correctly with the updated import map.

### Why make this change?

This change standardizes the implementation of slug fields across collections, improving code consistency and maintainability. The updates to the Location collection and Services SEO fields enhance the overall structure and functionality of the CMS. The import map adjustment ensures proper loading of components in the admin interface.