### PR TITLE
feat(ui): add off-canvas menu wrapper

### DIFF
--- a/src/app/components/Header/index.tsx
+++ b/src/app/components/Header/index.tsx
@@ -1,27 +1,41 @@
-import React from "react";
+"use client";
+
+import React, { useState } from "react";
 import { getPayloadHMR } from "@payloadcms/next/utilities";
 import config from "@payload-config";
 import Image from "next/image";
 import Link from "next/link";
 import BrewwwLogo from "/public/images/brewww-logotype-gold.png";
 
-export default async function Header() {
+export default function Header() {
   // TODO: bring back the Payload call when the design is completed
   // const payload = await getPayloadHMR({ config });
   // TODO: bring back the header when the design is completed
   // const header = (await payload.findGlobal({ slug: "header" })) as HeaderData;
+
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const toggleMenu = () => {
+    setIsMenuOpen(!isMenuOpen);
+  };
 
   return (
     <>
       <header className="sticky top-0 z-50 w-full bg-brand-black text-sm text-neutral-400">
         <div className="mx-auto max-w-[120rem] px-12">
           <div className="grid grid-cols-3 items-center py-4">
-            <nav className="flex items-center space-x-10 font-semibold uppercase text-white">
+            <nav className="flex items-center space-x-4 font-semibold uppercase text-white">
               <Link
                 className="relative inline-block min-w-max after:absolute after:bottom-0 after:left-0 after:h-[1px] after:w-0 after:bg-white after:transition-all after:duration-300 hover:after:w-full"
                 href="/work"
               >
                 Work
+              </Link>
+              <Link
+                className="relative inline-block min-w-max after:absolute after:bottom-0 after:left-0 after:h-[1px] after:w-0 after:bg-white after:transition-all after:duration-300 hover:after:w-full"
+                href="/work/individual"
+              >
+                /IN
               </Link>
               <Link
                 className="relative inline-block min-w-max after:absolute after:bottom-0 after:left-0 after:h-[1px] after:w-0 after:bg-white after:transition-all after:duration-300 hover:after:w-full"
@@ -31,9 +45,33 @@ export default async function Header() {
               </Link>
               <Link
                 className="relative inline-block min-w-max after:absolute after:bottom-0 after:left-0 after:h-[1px] after:w-0 after:bg-white after:transition-all after:duration-300 hover:after:w-full"
+                href="/play/individual"
+              >
+                /IN
+              </Link>
+              <Link
+                className="relative inline-block min-w-max after:absolute after:bottom-0 after:left-0 after:h-[1px] after:w-0 after:bg-white after:transition-all after:duration-300 hover:after:w-full"
                 href="/services"
               >
                 Services
+              </Link>
+              <Link
+                className="relative inline-block min-w-max after:absolute after:bottom-0 after:left-0 after:h-[1px] after:w-0 after:bg-white after:transition-all after:duration-300 hover:after:w-full"
+                href="/services/individual"
+              >
+                /IN
+              </Link>
+              <Link
+                className="relative inline-block min-w-max after:absolute after:bottom-0 after:left-0 after:h-[1px] after:w-0 after:bg-white after:transition-all after:duration-300 hover:after:w-full"
+                href="/blog"
+              >
+                Blog
+              </Link>
+              <Link
+                className="relative inline-block min-w-max after:absolute after:bottom-0 after:left-0 after:h-[1px] after:w-0 after:bg-white after:transition-all after:duration-300 hover:after:w-full"
+                href="/blog/individual"
+              >
+                /IN
               </Link>
               <Link
                 className="relative inline-block min-w-max after:absolute after:bottom-0 after:left-0 after:h-[1px] after:w-0 after:bg-white after:transition-all after:duration-300 hover:after:w-full"
@@ -46,12 +84,6 @@ export default async function Header() {
                 href="/about"
               >
                 About
-              </Link>
-              <Link
-                className="relative inline-block min-w-max after:absolute after:bottom-0 after:left-0 after:h-[1px] after:w-0 after:bg-white after:transition-all after:duration-300 hover:after:w-full"
-                href="/blog"
-              >
-                Blog
               </Link>
             </nav>
             <div className="flex justify-center">
@@ -82,26 +114,160 @@ export default async function Header() {
                   </span>
                 </Link>
               </div>
-              <button className="h-12 min-w-8 cursor-pointer">
+              <button
+                className="h-12 min-w-8 cursor-pointer"
+                onClick={toggleMenu}
+              >
                 <span className="flex h-full w-full items-center justify-center">
-                  <svg
-                    className="block h-4 w-4 max-w-full"
-                    fill="none"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M16 5H0v2h16V5Zm0 4H0v2h16V9Z"
-                      fill="rgb(255, 255, 255)"
-                    />
-                  </svg>
+                  {!isMenuOpen ? (
+                    <svg
+                      width="24"
+                      height="24"
+                      strokeWidth="1.5"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                      color="#000000"
+                    >
+                      <path
+                        d="M3 5H21"
+                        stroke="#FFFFFF"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      ></path>
+                      <path
+                        d="M3 12H21"
+                        stroke="#FFFFFF"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      ></path>
+                      <path
+                        d="M3 19H21"
+                        stroke="#FFFFFF"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      ></path>
+                    </svg>
+                  ) : (
+                    <svg
+                      width="24"
+                      height="24"
+                      strokeWidth="1.5"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                      color="#000000"
+                    >
+                      <path
+                        d="M9.87871 14.1213L12 12M14.1213 9.87868L12 12M12 12L9.87871 9.87868M12 12L14.1213 14.1213"
+                        stroke="#FFFFFF"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      ></path>
+                      <path
+                        d="M21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6Z"
+                        stroke="#FFFFFF"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      ></path>
+                    </svg>
+                  )}
                 </span>
               </button>
             </div>
           </div>
         </div>
       </header>
+      <div
+        className={`fixed inset-0 z-50 h-screen w-screen bg-brand-gold transition-opacity duration-300 ${
+          isMenuOpen ? "opacity-100" : "pointer-events-none opacity-0"
+        }`}
+      >
+        <div className="m-2 flex h-[calc(100vh-1rem)] w-[calc(100vw-1rem)] flex-col justify-between rounded-md bg-black p-6">
+          <div className="flex justify-end">
+            <button
+              onClick={toggleMenu}
+              className="text-white focus:outline-none"
+            >
+              <svg
+                width="32"
+                height="32"
+                strokeWidth="1.5"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                color="#FFFFFF"
+              >
+                <path
+                  d="M9.87871 14.1213L12 12M14.1213 9.87868L12 12M12 12L9.87871 9.87868M12 12L14.1213 14.1213"
+                  stroke="#FFFFFF"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                ></path>
+                <path
+                  d="M21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6Z"
+                  stroke="#FFFFFF"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                ></path>
+              </svg>
+            </button>
+          </div>
+          <div className="flex flex-col gap-y-4 pb-6 pl-6">
+            <div className="w-full overflow-hidden text-8xl uppercase leading-none text-white">
+              <Link
+                className="group relative flex w-full max-w-full items-center justify-start opacity-[0.35] transition-opacity duration-300 hover:opacity-100"
+                href=""
+              >
+                <div className="grid cursor-pointer auto-cols-fr grid-cols-[auto_auto] grid-rows-[auto] items-center justify-items-center">
+                  <div className="col-span-1 row-span-1 -mb-1">Work</div>
+                </div>
+                <span className="absolute bottom-0 left-0 h-[1px] w-0 bg-white transition-all duration-300 group-hover:w-full"></span>
+              </Link>
+            </div>
+            <div className="w-full overflow-hidden text-8xl uppercase leading-none text-white">
+              <Link
+                className="group relative flex w-full max-w-full items-center justify-start opacity-[0.35] transition-opacity duration-300 hover:opacity-100"
+                href=""
+              >
+                <div className="grid cursor-pointer auto-cols-fr grid-cols-[auto_auto] grid-rows-[auto] items-center justify-items-center">
+                  <div className="col-span-1 row-span-1 -mb-1">About</div>
+                </div>
+                <span className="absolute bottom-0 left-0 h-[1px] w-0 bg-white transition-all duration-300 group-hover:w-full"></span>
+              </Link>
+            </div>
+            <div className="w-full overflow-hidden text-8xl uppercase leading-none text-white">
+              <Link
+                className="group relative flex w-full max-w-full items-center justify-start opacity-[0.35] transition-opacity duration-300 hover:opacity-100"
+                href=""
+              >
+                <div className="grid cursor-pointer auto-cols-fr grid-cols-[auto_auto] grid-rows-[auto] items-center justify-items-center">
+                  <div className="col-span-1 row-span-1 -mb-1">Play</div>
+                </div>
+                <span className="absolute bottom-0 left-0 h-[1px] w-0 bg-white transition-all duration-300 group-hover:w-full"></span>
+              </Link>
+            </div>
+            <div className="w-full overflow-hidden text-8xl uppercase leading-none text-white">
+              <Link
+                className="group relative flex w-full max-w-full items-center justify-start opacity-[0.35] transition-opacity duration-300 hover:opacity-100"
+                href=""
+              >
+                <div className="grid cursor-pointer auto-cols-fr grid-cols-[auto_auto] grid-rows-[auto] items-center justify-items-center">
+                  <div className="col-span-1 row-span-1 -mb-1">Contact</div>
+                </div>
+                <span className="absolute bottom-0 left-0 h-[1px] w-0 bg-white transition-all duration-300 group-hover:w-full"></span>
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
### TL;DR

Updated the Header component with new navigation links and added a responsive mobile menu.

### What changed?

- Added new navigation links for individual sections (/IN) under Work, Play, Services, and Blog
- Implemented a responsive mobile menu with a toggle functionality
- Replaced the static menu icon with dynamic open/close icons
- Created a full-screen overlay menu for mobile devices
- Added large, animated menu items in the mobile overlay

### How to test?

1. Open the application and navigate to different screen sizes
2. Verify that all new navigation links are visible and functional on desktop
3. On mobile devices, click the menu icon to open the overlay menu
4. Test the functionality of the close button in the overlay menu
5. Ensure all links in the overlay menu are working correctly
6. Check the hover animations on menu items in both desktop and mobile views

### Why make this change?

This update improves the navigation experience for users across different devices. The addition of individual section links provides quicker access to specific content, while the responsive mobile menu enhances usability on smaller screens. These changes aim to improve overall user experience and make the site more accessible on various devices.