### PR TITLE
feat(cms): improve Playground collection schema

### DIFF
--- a/src/app/(frontend)/(inner)/play/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/play/[slug]/page.tsx
@@ -1,0 +1,120 @@
+import configPromise from "@payload-config";
+import { getPayloadHMR } from "@payloadcms/next/utilities";
+import React from "react";
+import { notFound } from "next/navigation";
+import { Play } from "@/payload-types";
+import Image from "next/image";
+import Link from "next/link";
+import { MetaDot } from "@/app/components/MetaDot";
+import { formatDate } from "@/app/utilities/dateFormatter";
+
+//* Render the play page
+export default async function PlayPage({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  if (!params.slug) {
+    notFound();
+  }
+
+  const play = await queryPlayBySlug({ slug: params.slug });
+  if (!play) {
+    notFound();
+  }
+
+  const fallbackDescription = "Add a cool description here.";
+  const imageUrl =
+    typeof play.content.imageMain === "string"
+      ? play.content.imageMain
+      : play.content.imageMain?.url || "";
+  const imageAlt =
+    typeof play.content.imageMain === "object"
+      ? play.content.imageMain?.alt
+      : "Featured image for play project";
+
+  return (
+    <article className="bg-white pt-24 text-black">
+      <section className="container mx-auto px-4 pb-12 pt-12">
+        <div className="max-w-5xl">
+          <h1 className="mb-4 text-5xl font-medium leading-tight md:text-6xl">
+            {play.title}
+          </h1>
+          <p className="mb-8 max-w-3xl text-xl text-gray-700">
+            {play.description || fallbackDescription}
+          </p>
+          <div className="flex items-center gap-1 text-sm text-gray-500">
+            <span>
+              By{" "}
+              <Link className="text-gray-950" href={""}>
+                Kevin Wessa
+              </Link>
+            </span>
+            <MetaDot />
+            <span>
+              {play.publishedAt
+                ? formatDate(play.publishedAt)
+                : "Date not available"}
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <div className="w-full">
+        <div className="px-2">
+          <div className="relative aspect-[3/2] w-full">
+            <Image
+              src={imageUrl}
+              fill
+              alt={imageAlt}
+              className="rounded-md object-cover"
+              priority
+            />
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+//* Query function to fetch play by slug
+async function queryPlayBySlug({
+  slug,
+}: {
+  slug: string;
+}): Promise<Play | null> {
+  const payload = await getPayloadHMR({ config: configPromise });
+  try {
+    const result = await payload.find({
+      collection: "play",
+      limit: 1,
+      where: {
+        slug: {
+          equals: slug,
+        },
+      },
+    });
+    return result.docs[0] || null;
+  } catch (error) {
+    return null;
+  }
+}
+
+//* Generate static params for all play projects
+export async function generateStaticParams() {
+  const payload = await getPayloadHMR({ config: configPromise });
+  try {
+    const plays = await payload.find({
+      collection: "play",
+      limit: 1000,
+      overrideAccess: false,
+    });
+    return (
+      plays.docs?.map(({ slug }) => ({
+        params: { slug },
+      })) || []
+    );
+  } catch (error) {
+    return [];
+  }
+}

--- a/src/app/(frontend)/(inner)/play/individual/page.tsx
+++ b/src/app/(frontend)/(inner)/play/individual/page.tsx
@@ -1,3 +1,0 @@
-export default function IndividualPlayPage() {
-  return <div>Individual Play</div>;
-}

--- a/src/app/(frontend)/(inner)/play/page.tsx
+++ b/src/app/(frontend)/(inner)/play/page.tsx
@@ -9,7 +9,6 @@ export default async function PlayPage() {
     limit: 4,
     sort: "-publishedAt",
   });
-  console.log(projects);
 
   return (
     <>
@@ -71,7 +70,7 @@ export default async function PlayPage() {
                         {project.title || "Untitled Project"}
                       </div>
                       <div className="m-1 inline-block">·</div>
-                      {"Write a cool subtitle here"}
+                      {project?.tagline || "Untitled Tagline"}
                     </div>
                     <div className="text-neutral-400">
                       {"Write a cool category here"}

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -125,6 +125,8 @@ export interface Page {
 export interface Post {
   id: string;
   title: string;
+  tagline?: string | null;
+  description?: string | null;
   imageMain?: (string | null) | Media;
   content?: {
     root: {
@@ -246,13 +248,13 @@ export interface Client {
 export interface Play {
   id: string;
   title: string;
+  tagline: string;
+  description?: string | null;
   slug: string;
   slugLock?: boolean | null;
   publishedAt: string;
   content: {
     imageMain: string | Media;
-    tagline?: string | null;
-    description?: string | null;
   };
   metadata?: {
     relatedPlaygrounds?: (string | Play)[] | null;

--- a/src/payload/collections/Play/config.ts
+++ b/src/payload/collections/Play/config.ts
@@ -25,6 +25,25 @@ export const Playground: CollectionConfig = {
         description: "Add the title of the Playground case study here.",
       },
     },
+    {
+      name: "tagline",
+      type: "text",
+      label: "Tagline",
+      required: true,
+      admin: {
+        description: "Add the tagline for the playground here.",
+      },
+    },
+    {
+      name: "description",
+      type: "textarea",
+      label: "Description",
+      required: false,
+      admin: {
+        description: "Add the description for the playground here.",
+      },
+    },
+    // TODO: make sure the slug locks after being published
     ...slugField(),
     {
       name: "publishedAt",
@@ -65,24 +84,6 @@ export const Playground: CollectionConfig = {
               required: true,
               admin: {
                 description: "Add the main image for the playground here.",
-              },
-            },
-            {
-              name: "tagline",
-              type: "text",
-              label: "Tagline",
-              required: false,
-              admin: {
-                description: "Add the tagline for the playground here.",
-              },
-            },
-            {
-              name: "description",
-              type: "textarea",
-              label: "Description",
-              required: false,
-              admin: {
-                description: "Add the description for the playground here.",
               },
             },
           ],
@@ -147,12 +148,12 @@ export const Playground: CollectionConfig = {
   },
   admin: {
     description: "Interior Brewww projects",
-    defaultColumns: ["title", "updatedAt"],
+    defaultColumns: ["title", "tagline", "publishedAt", "updatedAt"],
     group: "Portfolio",
-    listSearchableFields: ["title"],
+    listSearchableFields: ["title", "tagline", "description"],
     pagination: {
       defaultLimit: 25,
-      limits: [25, 50],
+      limits: [25, 50, 100],
     },
     useAsTitle: "title",
   },
@@ -160,6 +161,20 @@ export const Playground: CollectionConfig = {
   labels: {
     singular: "Playground",
     plural: "Playground",
+  },
+  hooks: {
+    afterRead: [
+      ({ doc }) => {
+        if (
+          doc.publishedAt &&
+          typeof doc.publishedAt === "object" &&
+          "$date" in doc.publishedAt
+        ) {
+          doc.publishedAt = new Date(doc.publishedAt.$date);
+        }
+        return doc;
+      },
+    ],
   },
   versions: {
     drafts: true,

--- a/src/payload/collections/Posts/config.ts
+++ b/src/payload/collections/Posts/config.ts
@@ -27,6 +27,26 @@ export const BlogPosts: CollectionConfig = {
       },
     },
     {
+      name: "tagline",
+      type: "text",
+      label: "Post Tagline",
+      required: false,
+      admin: {
+        description:
+          "The tagline of the article as it appears around the site.",
+      },
+    },
+    {
+      name: "description",
+      type: "textarea",
+      label: "Post Description",
+      required: false,
+      admin: {
+        description:
+          "The description of the article as it appears around the site.",
+      },
+    },
+    {
       type: "tabs",
       tabs: [
         {


### PR DESCRIPTION
### TL;DR

Added a new Play page, updated Play and Post collections, and enhanced the Play listing page.

### What changed?

- Created a new `PlayPage` component for individual play projects
- Updated the Play collection config with new fields: tagline and description
- Modified the Post collection to include tagline and description fields
- Enhanced the Play listing page to display taglines
- Removed the placeholder IndividualPlayPage
- Updated payload types to reflect new field additions

### How to test?

1. Navigate to the Play listing page to verify taglines are displayed correctly
2. Click on a Play project to view its individual page
3. Check the Payload CMS admin panel to ensure new fields (tagline, description) are available for Play and Post collections
4. Create or edit a Play project to confirm all fields are working as expected

### Why make this change?

This change improves the structure and content of Play projects, allowing for more detailed and organized information. It also enhances the user experience by providing more context on both the listing and individual project pages. The addition of taglines and descriptions to Posts allows for consistent content structure across different types of content.