### PR TITLE
feat(cms): create components for ImageMedia and VideoMedia

### DIFF
--- a/src/app/(frontend)/(inner)/play/page.tsx
+++ b/src/app/(frontend)/(inner)/play/page.tsx
@@ -6,26 +6,28 @@ export default async function PlayPage() {
   const payload = await getPayloadHMR({ config: configPromise });
   const projects = await payload.find({
     collection: "play",
-    limit: 4,
+    limit: 16,
     sort: "-publishedAt",
   });
 
   return (
     <>
-      <div>
-        <div className="max-w-[82.50rem] text-xl text-neutral-800 min-[480px]:max-w-[84.38rem] min-[720px]:max-w-[86.88rem] min-[720px]:pl-12 min-[720px]:pr-12 min-[1080px]:max-w-[89.38rem] min-[1080px]:pl-16 min-[1080px]:pr-16">
-          <h1 className="mb-1 mt-28 text-[2.88rem] font-light leading-none text-white">
-            Brewww Playground
-          </h1>
-          <p className="mb-24 max-w-[67.50rem] text-[2.88rem] leading-none text-neutral-500">
-            A playground where the artisans at Brewww share internal projects
-            that they are playing around with. From the ridiculous to the
-            somewhat useful, we hone skillsets through imagination and fun.
-          </p>
+      <section className="bg-neutral-900">
+        <div className="container mx-auto px-4 py-24">
+          <div className="max-w-[82.50rem] text-xl text-neutral-800 min-[480px]:max-w-[84.38rem] min-[720px]:max-w-[86.88rem] min-[720px]:pl-12 min-[720px]:pr-12 min-[1080px]:max-w-[89.38rem] min-[1080px]:pl-16 min-[1080px]:pr-16">
+            <h1 className="mb-1 mt-28 text-[2.88rem] font-light leading-none text-white">
+              Brewww Playground
+            </h1>
+            <p className="mb-24 max-w-[67.50rem] text-[2.88rem] leading-none text-neutral-500">
+              A playground where the artisans at Brewww share internal projects
+              that they are playing around with. From the ridiculous to the
+              somewhat useful, we hone skillsets through imagination and fun.
+            </p>
+          </div>
         </div>
-      </div>
-      <div className="py-16">
-        <div>
+      </section>
+      <section className="py-16">
+        <div className="container mx-auto">
           <div className="w-full px-20 text-lg text-white">
             <div>
               <div className="-ml-0 flex max-w-[18ch] items-center text-[4.25rem] leading-none">
@@ -35,238 +37,240 @@ export default async function PlayPage() {
               <div className="mb-4 mt-6 h-0.5 bg-zinc-900" />
               <div className="mb-4 text-xs uppercase">Selected Projects</div>
             </div>
-            {projects.docs.map((project) => {
-              const imageSrc =
-                typeof project.content.imageMain === "string"
-                  ? project.content.imageMain
-                  : project.content.imageMain?.url ||
-                    "https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10ccaad8365d669c95e70_63c91a92dc0c340932978b8f_image-ueno-template-04-p-3200.jpeg";
+            <div className="grid auto-rows-auto grid-cols-2 gap-8">
+              {projects.docs.map((project) => {
+                const imageSrc =
+                  typeof project.content.imageMain === "string"
+                    ? project.content.imageMain
+                    : project.content.imageMain?.url ||
+                      "https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10ccaad8365d669c95e70_63c91a92dc0c340932978b8f_image-ueno-template-04-p-3200.jpeg";
 
-              return (
-                <Link
-                  key={project.id}
+                return (
+                  <Link
+                    key={project.id}
+                    className="block w-full"
+                    href={`/play/${project.slug}`}
+                  >
+                    <div className="relative flex w-full cursor-pointer overflow-hidden rounded-md">
+                      <div className="relative w-full pt-[56.25%]">
+                        <Image
+                          className="absolute inset-0 h-full w-full"
+                          src={
+                            typeof project.content.imageMain === "string"
+                              ? project.content.imageMain
+                              : project.content.imageMain?.url ||
+                                "https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10ccaad8365d669c95e70_63c91a92dc0c340932978b8f_image-ueno-template-04-p-3200.jpeg"
+                          }
+                          alt={"Project Thumbnail"}
+                          layout="fill"
+                          style={{ objectFit: "cover" }}
+                        />
+                      </div>
+                    </div>
+                    <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1">
+                      <div>
+                        <div className="inline-block font-semibold uppercase">
+                          {project.title || "Untitled Project"}
+                        </div>
+                        <div className="m-1 inline-block">·</div>
+                        {project?.tagline || "Untitled Tagline"}
+                      </div>
+                      <div className="text-neutral-400">
+                        {"Write a cool category here"}
+                      </div>
+                    </div>
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </section>
+      <section className="bg-white py-24">
+        <div className="container mx-auto px-6">
+          <h2 className="mb-6 text-2xl font-bold">Alternate Style</h2>
+          <div className="flex flex-col gap-y-[7.38rem]">
+            <div className="grid w-full auto-cols-fr grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr] grid-rows-[auto] items-start gap-y-[7.38rem]">
+              <div
+                className="col-start-4 col-end-9 row-start-1 row-end-2"
+                style={{
+                  gridArea: "1/4/2/9",
+                }}
+              >
+                <a
                   className="col-span-2 row-span-1 inline-block w-full max-w-full"
-                  href={`/play/${project.slug}`}
+                  href=""
+                >
+                  <div className="flex w-full cursor-pointer overflow-hidden rounded-md">
+                    <img
+                      className="inline-block h-full w-full max-w-full object-contain align-middle"
+                      src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10dcd8842ec2b57b28cb6_63c9187126433a43129cc944_image-ueno-template-02.jpeg"
+                    />
+                  </div>
+                  <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1 text-black">
+                    <div>
+                      <div className="inline-block font-semibold uppercase">
+                        Square
+                      </div>
+                      <div className="m-1 inline-block">·</div>
+                      The new norm of life
+                    </div>
+                    <div className="text-gray-600">Brand identity, Website</div>
+                  </div>
+                </a>
+              </div>
+              <div
+                className="col-start-9 col-end-13 row-start-1 row-end-2 flex-grow pl-28"
+                style={{
+                  gridArea: "1/9/2/13",
+                }}
+              >
+                <a
+                  className="col-span-2 row-span-1 inline-block w-full max-w-full"
+                  href=""
+                >
+                  <div className="flex w-full cursor-pointer overflow-hidden rounded-md">
+                    <img
+                      className="inline-block h-full w-full max-w-full object-contain align-middle"
+                      src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10dfd80f1f22872630cce_63c91c81185e3416e7ba7960_image-ueno-template-06-p-2000.jpeg"
+                    />
+                  </div>
+                  <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1 text-black">
+                    <div>
+                      <div className="inline-block font-semibold uppercase">
+                        Castro Capital
+                      </div>
+                      <div className="m-1 inline-block">·</div>
+                      The new norm of life
+                    </div>
+                    <div className="text-gray-600">
+                      Digital design system, Website, Print
+                    </div>
+                  </div>
+                </a>
+              </div>
+            </div>
+            <div className="grid w-full auto-cols-fr grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr] grid-rows-[auto] items-start gap-y-[7.38rem]">
+              <div className="col-span-9 row-span-1 w-full">
+                <a
+                  className="col-span-2 row-span-1 inline-block w-full max-w-full"
+                  href=""
                 >
                   <div className="relative flex w-full cursor-pointer overflow-hidden rounded-md">
                     <div className="relative w-full pt-[56.25%]">
-                      <Image
-                        className="absolute inset-0 h-full w-full"
-                        src={
-                          typeof project.content.imageMain === "string"
-                            ? project.content.imageMain
-                            : project.content.imageMain?.url ||
-                              "https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10ccaad8365d669c95e70_63c91a92dc0c340932978b8f_image-ueno-template-04-p-3200.jpeg"
-                        }
-                        alt={"Project Thumbnail"}
-                        layout="fill"
-                        style={{ objectFit: "cover" }}
+                      <img
+                        className="absolute bottom-0 left-0 top-0 inline-block h-full w-full max-w-full object-cover align-middle"
+                        src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10e2f8842ec5dcab29324_63c91907a7ce6182b053ba02_image-ueno-template-03.jpeg"
                       />
                     </div>
                   </div>
-                  <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1">
+                  <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1 text-black">
                     <div>
                       <div className="inline-block font-semibold uppercase">
-                        {project.title || "Untitled Project"}
+                        Rucksack Magazine
                       </div>
                       <div className="m-1 inline-block">·</div>
-                      {project?.tagline || "Untitled Tagline"}
+                      All about photography
                     </div>
-                    <div className="text-neutral-400">
-                      {"Write a cool category here"}
+                    <div className="text-gray-600">
+                      Brand identity, Website, Print
                     </div>
                   </div>
-                </Link>
-              );
-            })}
-
-            <div className="flex flex-col gap-y-[7.38rem]">
-              <div className="grid w-full auto-cols-fr grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr] grid-rows-[auto] items-start gap-y-[7.38rem]">
-                <div
-                  className="col-start-4 col-end-9 row-start-1 row-end-2"
-                  style={{
-                    gridArea: "1/4/2/9",
-                  }}
-                >
-                  <a
-                    className="col-span-2 row-span-1 inline-block w-full max-w-full"
-                    href=""
-                  >
-                    <div className="flex w-full cursor-pointer overflow-hidden rounded-md">
-                      <img
-                        className="inline-block h-full w-full max-w-full object-contain align-middle"
-                        src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10dcd8842ec2b57b28cb6_63c9187126433a43129cc944_image-ueno-template-02.jpeg"
-                      />
-                    </div>
-                    <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1">
-                      <div>
-                        <div className="inline-block font-semibold uppercase">
-                          Square
-                        </div>
-                        <div className="m-1 inline-block">·</div>
-                        The new norm of life
-                      </div>
-                      <div className="text-neutral-400">
-                        Brand identity, Website
-                      </div>
-                    </div>
-                  </a>
-                </div>
-                <div
-                  className="col-start-9 col-end-13 row-start-1 row-end-2 flex-grow pl-28"
-                  style={{
-                    gridArea: "1/9/2/13",
-                  }}
-                >
-                  <a
-                    className="col-span-2 row-span-1 inline-block w-full max-w-full"
-                    href=""
-                  >
-                    <div className="flex w-full cursor-pointer overflow-hidden rounded-md">
-                      <img
-                        className="inline-block h-full w-full max-w-full object-contain align-middle"
-                        src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10dfd80f1f22872630cce_63c91c81185e3416e7ba7960_image-ueno-template-06-p-2000.jpeg"
-                      />
-                    </div>
-                    <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1">
-                      <div>
-                        <div className="inline-block font-semibold uppercase">
-                          Castro Capital
-                        </div>
-                        <div className="m-1 inline-block">·</div>
-                        The new norm of life
-                      </div>
-                      <div className="text-neutral-400">
-                        Digital design system, Website, Print
-                      </div>
-                    </div>
-                  </a>
-                </div>
+                </a>
               </div>
-              <div className="grid w-full auto-cols-fr grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr] grid-rows-[auto] items-start gap-y-[7.38rem]">
-                <div className="col-span-9 row-span-1 w-full">
-                  <a
-                    className="col-span-2 row-span-1 inline-block w-full max-w-full"
-                    href=""
-                  >
-                    <div className="relative flex w-full cursor-pointer overflow-hidden rounded-md">
-                      <div className="relative w-full pt-[56.25%]">
-                        <img
-                          className="absolute bottom-0 left-0 top-0 inline-block h-full w-full max-w-full object-cover align-middle"
-                          src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10e2f8842ec5dcab29324_63c91907a7ce6182b053ba02_image-ueno-template-03.jpeg"
-                        />
-                      </div>
-                    </div>
-                    <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1">
-                      <div>
-                        <div className="inline-block font-semibold uppercase">
-                          Rucksack Magazine
-                        </div>
-                        <div className="m-1 inline-block">·</div>
-                        All about photography
-                      </div>
-                      <div className="text-neutral-400">
-                        Brand identity, Website, Print
-                      </div>
-                    </div>
-                  </a>
-                </div>
-              </div>
-              <div className="grid w-full auto-cols-fr grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr] grid-rows-[auto] items-start gap-y-[7.38rem]">
-                <div
-                  className="col-start-7 col-end-13 row-start-1 row-end-2 flex-grow pl-28"
-                  style={{
-                    gridArea: "1/7/2/13",
-                  }}
+            </div>
+            <div className="grid w-full auto-cols-fr grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr] grid-rows-[auto] items-start gap-y-[7.38rem]">
+              <div
+                className="col-start-7 col-end-13 row-start-1 row-end-2 flex-grow pl-28"
+                style={{
+                  gridArea: "1/7/2/13",
+                }}
+              >
+                <a
+                  className="col-span-2 row-span-1 inline-block w-full max-w-full"
+                  href=""
                 >
-                  <a
-                    className="col-span-2 row-span-1 inline-block w-full max-w-full"
-                    href=""
-                  >
-                    <div className="flex w-full cursor-pointer overflow-hidden rounded-md">
+                  <div className="flex w-full cursor-pointer overflow-hidden rounded-md">
+                    <img
+                      className="inline-block h-full w-full max-w-full object-contain align-middle"
+                      src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10e81559654d00360030b_63c91be70da88459ac7b5a3a_image-ueno-template-05.jpeg"
+                    />
+                  </div>
+                  <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1 text-black">
+                    <div>
+                      <div className="inline-block font-semibold uppercase">
+                        Romans
+                      </div>
+                      <div className="m-1 inline-block">·</div>
+                      All about photography
+                    </div>
+                    <div className="text-gray-600">
+                      Brand identity, Website, Packaging
+                    </div>
+                  </div>
+                </a>
+              </div>
+              <div
+                className="col-start-4 col-end-7 row-start-1 row-end-2"
+                style={{
+                  gridArea: "1/4/2/7",
+                }}
+              >
+                <a
+                  className="col-span-2 row-span-1 inline-block w-full max-w-full"
+                  href=""
+                >
+                  <div className="flex w-full cursor-pointer overflow-hidden rounded-md">
+                    <img
+                      className="inline-block h-full w-full max-w-full object-contain align-middle"
+                      src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d1162e150c60446a56cadd_63c91d6bd8d50020d6d274c0_image-ueno-template-07-p-2000.jpeg"
+                    />
+                  </div>
+                  <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1 text-black">
+                    <div>
+                      <div className="inline-block font-semibold uppercase">
+                        Hakuha
+                      </div>
+                      <div className="m-1 inline-block">·</div>
+                      All about photography
+                    </div>
+                    <div className="text-gray-600">
+                      Digital product, Packaging
+                    </div>
+                  </div>
+                </a>
+              </div>
+            </div>
+            <div className="grid w-full auto-cols-fr grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr] grid-rows-[auto] items-start gap-y-[7.38rem]">
+              <div className="col-span-8 row-span-1">
+                <a
+                  className="col-span-2 row-span-1 inline-block w-full max-w-full"
+                  href=""
+                >
+                  <div className="relative flex w-full cursor-pointer overflow-hidden rounded-md">
+                    <div className="relative w-full pt-[56.25%]">
                       <img
-                        className="inline-block h-full w-full max-w-full object-contain align-middle"
-                        src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10e81559654d00360030b_63c91be70da88459ac7b5a3a_image-ueno-template-05.jpeg"
+                        className="absolute bottom-0 left-0 top-0 inline-block h-full w-full max-w-full object-cover align-middle"
+                        src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10ee4ad83658d2bc97c5a_63c91ec109d76d3e7e34327f_image-ueno-template-08-p-2000.jpeg"
                       />
                     </div>
-                    <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1">
-                      <div>
-                        <div className="inline-block font-semibold uppercase">
-                          Romans
-                        </div>
-                        <div className="m-1 inline-block">·</div>
-                        All about photography
+                  </div>
+                  <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1 text-black">
+                    <div>
+                      <div className="inline-block font-semibold uppercase">
+                        Café de especialidad
                       </div>
-                      <div className="text-neutral-400">
-                        Brand identity, Website, Packaging
-                      </div>
+                      <div className="m-1 inline-block">·</div>
+                      All about photography
                     </div>
-                  </a>
-                </div>
-                <div
-                  className="col-start-4 col-end-7 row-start-1 row-end-2"
-                  style={{
-                    gridArea: "1/4/2/7",
-                  }}
-                >
-                  <a
-                    className="col-span-2 row-span-1 inline-block w-full max-w-full"
-                    href=""
-                  >
-                    <div className="flex w-full cursor-pointer overflow-hidden rounded-md">
-                      <img
-                        className="inline-block h-full w-full max-w-full object-contain align-middle"
-                        src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d1162e150c60446a56cadd_63c91d6bd8d50020d6d274c0_image-ueno-template-07-p-2000.jpeg"
-                      />
-                    </div>
-                    <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1">
-                      <div>
-                        <div className="inline-block font-semibold uppercase">
-                          Hakuha
-                        </div>
-                        <div className="m-1 inline-block">·</div>
-                        All about photography
-                      </div>
-                      <div className="text-neutral-400">
-                        Digital product, Packaging
-                      </div>
-                    </div>
-                  </a>
-                </div>
-              </div>
-              <div className="grid w-full auto-cols-fr grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr] grid-rows-[auto] items-start gap-y-[7.38rem]">
-                <div className="col-span-8 row-span-1">
-                  <a
-                    className="col-span-2 row-span-1 inline-block w-full max-w-full"
-                    href=""
-                  >
-                    <div className="relative flex w-full cursor-pointer overflow-hidden rounded-md">
-                      <div className="relative w-full pt-[56.25%]">
-                        <img
-                          className="absolute bottom-0 left-0 top-0 inline-block h-full w-full max-w-full object-cover align-middle"
-                          src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10ee4ad83658d2bc97c5a_63c91ec109d76d3e7e34327f_image-ueno-template-08-p-2000.jpeg"
-                        />
-                      </div>
-                    </div>
-                    <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1">
-                      <div>
-                        <div className="inline-block font-semibold uppercase">
-                          Café de especialidad
-                        </div>
-                        <div className="m-1 inline-block">·</div>
-                        All about photography
-                      </div>
-                      <div className="text-neutral-400">
-                        Brand identity, Website
-                      </div>
-                    </div>
-                  </a>
-                </div>
+                    <div className="text-gray-600">Brand identity, Website</div>
+                  </div>
+                </a>
               </div>
             </div>
           </div>
         </div>
-      </div>
+      </section>
     </>
   );
 }

--- a/src/app/components/Media/ImageMedia/index.tsx
+++ b/src/app/components/Media/ImageMedia/index.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import type { StaticImageData } from "next/image";
+
+import { cn } from "src/utilities/cn";
+import NextImage from "next/image";
+import React from "react";
+
+import type { Props as MediaProps } from "../types";
+
+import cssVariables from "@/cssVariables";
+
+const { breakpoints } = cssVariables;
+
+export const ImageMedia: React.FC<MediaProps> = (props) => {
+  const {
+    alt: altFromProps,
+    fill,
+    imgClassName,
+    onClick,
+    onLoad: onLoadFromProps,
+    priority,
+    resource,
+    size: sizeFromProps,
+    src: srcFromProps,
+  } = props;
+
+  const [isLoading, setIsLoading] = React.useState(true);
+
+  let width: number | undefined;
+  let height: number | undefined;
+  let alt = altFromProps;
+  let src: StaticImageData | string = srcFromProps || "";
+
+  if (!src && resource && typeof resource === "object") {
+    const {
+      alt: altFromResource,
+      filename: fullFilename,
+      height: fullHeight,
+      url,
+      width: fullWidth,
+    } = resource;
+
+    width = fullWidth!;
+    height = fullHeight!;
+    alt = altFromResource;
+
+    src = `${process.env.NEXT_PUBLIC_SERVER_URL}${url}`;
+  }
+
+  // NOTE: this is used by the browser to determine which image to download at different screen sizes
+  const sizes = sizeFromProps
+    ? sizeFromProps
+    : Object.entries(breakpoints)
+        .map(([, value]) => `(max-width: ${value}px) ${value}px`)
+        .join(", ");
+
+  return (
+    <NextImage
+      alt={alt || ""}
+      className={cn(imgClassName)}
+      fill={fill}
+      height={!fill ? height : undefined}
+      onClick={onClick}
+      onLoad={() => {
+        setIsLoading(false);
+        if (typeof onLoadFromProps === "function") {
+          onLoadFromProps();
+        }
+      }}
+      priority={priority}
+      quality={90}
+      sizes={sizes}
+      src={src}
+      width={!fill ? width : undefined}
+    />
+  );
+};

--- a/src/app/components/Media/VideoMedia/index.tsx
+++ b/src/app/components/Media/VideoMedia/index.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { cn } from "src/utilities/cn";
+import React, { useEffect, useRef } from "react";
+
+import type { Props as MediaProps } from "../types";
+
+export const VideoMedia: React.FC<MediaProps> = (props) => {
+  const { onClick, resource, videoClassName } = props;
+
+  const videoRef = useRef<HTMLVideoElement>(null);
+  // const [showFallback] = useState<boolean>()
+
+  useEffect(() => {
+    const { current: video } = videoRef;
+    if (video) {
+      video.addEventListener("suspend", () => {
+        // setShowFallback(true);
+        // console.warn('Video was suspended, rendering fallback image.')
+      });
+    }
+  }, []);
+
+  if (resource && typeof resource === "object") {
+    const { filename } = resource;
+
+    return (
+      <video
+        autoPlay
+        className={cn(videoClassName)}
+        controls={false}
+        loop
+        muted
+        onClick={onClick}
+        playsInline
+        ref={videoRef}
+      >
+        <source
+          src={`${process.env.NEXT_PUBLIC_SERVER_URL}/media/${filename}`}
+        />
+      </video>
+    );
+  }
+
+  return null;
+};

--- a/src/app/components/Media/index.tsx
+++ b/src/app/components/Media/index.tsx
@@ -1,0 +1,26 @@
+import React, { Fragment } from "react";
+
+import type { Props } from "./types";
+
+import { ImageMedia } from "./ImageMedia";
+import { VideoMedia } from "./VideoMedia";
+
+export const Media: React.FC<Props> = (props) => {
+  const { className, htmlElement = "div", resource } = props;
+
+  const isVideo =
+    typeof resource === "object" && resource?.mimeType?.includes("video");
+  const Tag = (htmlElement as any) || Fragment;
+
+  return (
+    <Tag
+      {...(htmlElement !== null
+        ? {
+            className,
+          }
+        : {})}
+    >
+      {isVideo ? <VideoMedia {...props} /> : <ImageMedia {...props} />}
+    </Tag>
+  );
+};

--- a/src/app/components/Media/types.ts
+++ b/src/app/components/Media/types.ts
@@ -1,0 +1,20 @@
+import type { StaticImageData } from "next/image";
+import type { ElementType, Ref } from "react";
+
+import type { Media as MediaType } from "@/payload-types";
+
+export interface Props {
+  alt?: string;
+  className?: string;
+  fill?: boolean; // for NextImage only
+  htmlElement?: ElementType | null;
+  imgClassName?: string;
+  onClick?: () => void;
+  onLoad?: () => void;
+  priority?: boolean; // for NextImage only
+  ref?: Ref<HTMLImageElement | HTMLVideoElement | null>;
+  resource?: MediaType | string | number; // for Payload media
+  size?: string; // for NextImage only
+  src?: StaticImageData; // for static media
+  videoClassName?: string;
+}

--- a/src/app/utilities/cn.ts
+++ b/src/app/utilities/cn.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -127,7 +127,7 @@ export interface Post {
   title: string;
   tagline?: string | null;
   description?: string | null;
-  imageMain: string | Media;
+  imageMain?: (string | null) | Media;
   content: {
     root: {
       type: string;

--- a/src/payload/collections/Posts/config.ts
+++ b/src/payload/collections/Posts/config.ts
@@ -11,6 +11,15 @@ import {
   PreviewField,
 } from "@payloadcms/plugin-seo/fields";
 
+import {
+  BlocksFeature,
+  FixedToolbarFeature,
+  HeadingFeature,
+  HorizontalRuleFeature,
+  InlineToolbarFeature,
+  lexicalEditor,
+} from "@payloadcms/richtext-lexical";
+
 export const BlogPosts: CollectionConfig = {
   slug: "posts",
 
@@ -51,7 +60,7 @@ export const BlogPosts: CollectionConfig = {
       type: "upload",
       relationTo: "media",
       label: "Main Image",
-      required: true,
+      required: false,
       admin: {
         description:
           "The main image of the article that appears on the page and in the list of posts.",
@@ -67,6 +76,17 @@ export const BlogPosts: CollectionConfig = {
               name: "content",
               type: "richText",
               label: "Content",
+              editor: lexicalEditor({
+                features: [
+                  BlocksFeature(),
+                  FixedToolbarFeature(),
+                  HeadingFeature({
+                    enabledHeadingSizes: ["h2", "h3", "h4", "h5", "h6"],
+                  }),
+                  HorizontalRuleFeature(),
+                  InlineToolbarFeature(),
+                ],
+              }),
               required: true,
             },
           ],
@@ -168,7 +188,7 @@ export const BlogPosts: CollectionConfig = {
   admin: {
     description:
       "Writing brings clarity. Writing is a way to make sense of the world.",
-    defaultColumns: ["title", "publishedAt", "updatedAt"],
+    defaultColumns: ["title", "imageMain", "publishedAt", "updatedAt"],
     group: "Blog Posts",
     listSearchableFields: ["title"],
     pagination: {


### PR DESCRIPTION
### TL;DR

Enhanced the Play page layout and introduced new Media components for improved image and video handling.

### What changed?

- Restructured the Play page layout with new sections and improved styling
- Increased the limit of displayed projects from 4 to 16
- Added new Media components (ImageMedia and VideoMedia) for better media handling
- Introduced utility functions for class name management (cn)
- Updated the Posts collection configuration in Payload CMS
- Made the main image field optional in the Posts collection
- Added Lexical editor features to the content field in Posts collection

### How to test?

1. Navigate to the Play page and verify the new layout and styling
2. Check if 16 projects are now displayed instead of 4
3. Test the new Media components by adding both images and videos to projects
4. Verify that the main image is now optional when creating or editing a post
5. Test the new Lexical editor features in the content field when creating or editing a post

### Why make this change?

This change aims to improve the user experience on the Play page by showcasing more projects and enhancing the visual layout. The new Media components provide better handling of images and videos, allowing for more flexibility in content presentation. The updates to the Posts collection in Payload CMS offer more options for content creators, making the main image optional and introducing advanced editing features with the Lexical editor.