### PR TITLE
feat(cms): improve Work collection schema

### DIFF
--- a/cssvariables.js
+++ b/cssvariables.js
@@ -1,0 +1,19 @@
+// Keep these in sync with the CSS variables in the `_css` directory
+
+const cssVariables = {
+  breakpoints: {
+    l: 1440,
+    m: 1024,
+    s: 768,
+  },
+  colors: {
+    base0: "rgb(255, 255, 255)",
+    base100: "rgb(235, 235, 235)",
+    base500: "rgb(128, 128, 128)",
+    base850: "rgb(34, 34, 34)",
+    base1000: "rgb(0, 0, 0)",
+    error500: "rgb(255, 111, 118)",
+  },
+};
+
+export default cssVariables;

--- a/src/app/(frontend)/(inner)/blog/page.tsx
+++ b/src/app/(frontend)/(inner)/blog/page.tsx
@@ -7,7 +7,7 @@ export default async function BlogPage() {
   const payload = await getPayloadHMR({ config: configPromise });
   const posts = await payload.find({
     collection: "posts",
-    limit: 6,
+    limit: 100,
     sort: "-publishedAt",
   });
 
@@ -56,7 +56,13 @@ export default async function BlogPage() {
                     <div className="mt-5 flex flex-col gap-[0.5rem]">
                       <div className="flex flex-wrap items-center justify-between gap-[0.15rem] text-xs uppercase text-zinc-500">
                         <div>
-                          {(post as any).category?.name || "Uncategorized"}
+                          {post.metadata?.categories
+                            ?.map((category) =>
+                              typeof category === "object"
+                                ? category.title
+                                : category,
+                            )
+                            .join(", ") || "Uncategorized"}
                         </div>
                         <div>
                           {post.metadata?.readTime

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -28,6 +28,7 @@ import { MetaImageComponent as MetaImageComponent_26 } from '@payloadcms/plugin-
 import { MetaDescriptionComponent as MetaDescriptionComponent_27 } from '@payloadcms/plugin-seo/client'
 import { PreviewComponent as PreviewComponent_28 } from '@payloadcms/plugin-seo/client'
 import { SlugComponent as SlugComponent_29 } from '@/fields/slug/SlugComponent'
+import { BlocksFeatureClient as BlocksFeatureClient_30 } from '@payloadcms/richtext-lexical/client'
 
 export const importMap = {
   "@payloadcms/richtext-lexical/client#RichTextCell": RichTextCell_0,
@@ -59,5 +60,6 @@ export const importMap = {
   "@payloadcms/plugin-seo/client#MetaImageComponent": MetaImageComponent_26,
   "@payloadcms/plugin-seo/client#MetaDescriptionComponent": MetaDescriptionComponent_27,
   "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_28,
-  "@/fields/slug/SlugComponent#SlugComponent": SlugComponent_29
+  "@/fields/slug/SlugComponent#SlugComponent": SlugComponent_29,
+  "@payloadcms/richtext-lexical/client#BlocksFeatureClient": BlocksFeatureClient_30
 }

--- a/src/app/blocks/MediaBlock/Component.tsx
+++ b/src/app/blocks/MediaBlock/Component.tsx
@@ -1,0 +1,74 @@
+import type { StaticImageData } from "next/image";
+
+import { cn } from "@/app/utilities/cn";
+import React from "react";
+import RichText from "@/components/RichText";
+
+import type { Page } from "@/payload-types";
+
+import { Media } from "../../components/Media";
+
+type Props = Extract<Page["layout"][0], { blockType: "mediaBlock" }> & {
+  breakout?: boolean;
+  captionClassName?: string;
+  className?: string;
+  enableGutter?: boolean;
+  id?: string;
+  imgClassName?: string;
+  staticImage?: StaticImageData;
+  disableInnerContainer?: boolean;
+};
+
+export const MediaBlock: React.FC<Props> = (props) => {
+  const {
+    captionClassName,
+    className,
+    enableGutter = true,
+    imgClassName,
+    media,
+    position = "default",
+    staticImage,
+    disableInnerContainer,
+  } = props;
+
+  let caption;
+  if (media && typeof media === "object") caption = media.caption;
+
+  return (
+    <div
+      className={cn(
+        "",
+        {
+          container: position === "default" && enableGutter,
+        },
+        className,
+      )}
+    >
+      {position === "fullscreen" && (
+        <div className="relative">
+          <Media resource={media} src={staticImage} />
+        </div>
+      )}
+      {position === "default" && (
+        <Media
+          imgClassName={cn("rounded", imgClassName)}
+          resource={media}
+          src={staticImage}
+        />
+      )}
+      {caption && (
+        <div
+          className={cn(
+            "mt-6",
+            {
+              container: position === "fullscreen" && !disableInnerContainer,
+            },
+            captionClassName,
+          )}
+        >
+          <RichText content={caption} enableGutter={false} />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/app/blocks/MediaBlock/config.ts
+++ b/src/app/blocks/MediaBlock/config.ts
@@ -1,0 +1,29 @@
+import type { Block } from "payload";
+
+export const MediaBlock: Block = {
+  slug: "mediaBlock",
+  interfaceName: "MediaBlock",
+  fields: [
+    {
+      name: "position",
+      type: "select",
+      defaultValue: "default",
+      options: [
+        {
+          label: "Default",
+          value: "default",
+        },
+        {
+          label: "Fullscreen",
+          value: "fullscreen",
+        },
+      ],
+    },
+    {
+      name: "media",
+      type: "upload",
+      relationTo: "media",
+      required: true,
+    },
+  ],
+};

--- a/src/app/components/Media/ImageMedia/index.tsx
+++ b/src/app/components/Media/ImageMedia/index.tsx
@@ -2,7 +2,7 @@
 
 import type { StaticImageData } from "next/image";
 
-import { cn } from "src/utilities/cn";
+import { cn } from "@/app/utilities/cn";
 import NextImage from "next/image";
 import React from "react";
 

--- a/src/app/components/Media/VideoMedia/index.tsx
+++ b/src/app/components/Media/VideoMedia/index.tsx
@@ -1,6 +1,5 @@
 "use client";
-
-import { cn } from "src/utilities/cn";
+import { cn } from "@/app/utilities/cn";
 import React, { useEffect, useRef } from "react";
 
 import type { Props as MediaProps } from "../types";

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -19,7 +19,7 @@ export interface Config {
     play: Play;
     services: Service;
     faq: Faq;
-    clients: Client;
+    brands: Brand;
     testimonials: Testimonial;
     locations: Location;
     results: Result;
@@ -127,7 +127,7 @@ export interface Post {
   title: string;
   tagline?: string | null;
   description?: string | null;
-  imageMain?: (string | null) | Media;
+  imageMain: string | Media;
   content: {
     root: {
       type: string;
@@ -180,12 +180,14 @@ export interface Category {
 export interface Work {
   id: string;
   title: string;
+  tagline: string;
+  description?: string | null;
+  imageMain: string | Media;
   slug: string;
   slugLock?: boolean | null;
-  thumbnail: string | Media;
-  testimonial?: (string | null) | Testimonial;
-  metadata: {
-    client: string | Client;
+  brand: string | Brand;
+  metadata?: {
+    testimonial?: (string | null) | Testimonial;
     relatedWorks?: (string | Work)[] | null;
   };
   seo?: {
@@ -193,6 +195,21 @@ export interface Work {
     image?: (string | null) | Media;
     description?: string | null;
   };
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "brands".
+ */
+export interface Brand {
+  id: string;
+  title: string;
+  logoLight?: (string | null) | Media;
+  logoDark?: (string | null) | Media;
+  city: string;
+  state: string;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -220,23 +237,8 @@ export interface Testimonial {
     };
     [k: string]: unknown;
   };
-  client: string | Client;
+  brand: string | Brand;
   author: string;
-  updatedAt: string;
-  createdAt: string;
-  _status?: ('draft' | 'published') | null;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "clients".
- */
-export interface Client {
-  id: string;
-  title: string;
-  logoLight?: (string | null) | Media;
-  logoDark?: (string | null) | Media;
-  city: string;
-  state: string;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -332,7 +334,7 @@ export interface Location {
 export interface Result {
   id: string;
   title: string;
-  client: string | Client;
+  client: string | Brand;
   number: string;
   support: string;
   description?: string | null;
@@ -419,6 +421,17 @@ export interface Footer {
   copyrightNotice?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "MediaBlock".
+ */
+export interface MediaBlock {
+  position?: ('default' | 'fullscreen') | null;
+  media: string | Media;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'mediaBlock';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -14,7 +14,7 @@ import { lexicalEditor } from "@payloadcms/richtext-lexical";
 import { Users } from "./payload/collections/Users/config";
 import { Media } from "./payload/collections/Media/config";
 import { Work } from "./payload/collections/Work/config";
-import { Clients } from "./payload/collections/Clients/config";
+import { Brands } from "./payload/collections/Brands/config";
 import { BlogPosts } from "./payload/collections/Posts/config";
 import { BlogCategories } from "./payload/collections/Categories/config";
 import { Services } from "./payload/collections/Services/config";
@@ -119,7 +119,7 @@ export default buildConfig({
     Playground,
     Services,
     FAQ,
-    Clients,
+    Brands,
     Testimonials,
     Location,
     Results,

--- a/src/payload/collections/Brands/config.ts
+++ b/src/payload/collections/Brands/config.ts
@@ -2,8 +2,8 @@ import type { CollectionConfig } from "payload";
 import { authenticated } from "@/payload/access/authenticated";
 import { authenticatedOrPublished } from "@/payload/access/authenticatedOrPublished";
 
-export const Clients: CollectionConfig = {
-  slug: "clients",
+export const Brands: CollectionConfig = {
+  slug: "brands",
 
   //* Collection Fields
   fields: [
@@ -67,20 +67,20 @@ export const Clients: CollectionConfig = {
   },
   admin: {
     description:
-      "Our bread and butter. Add (or remove) clients from this list carefully.",
-    defaultColumns: ["title", "logoLight", "city", "state"],
+      "Our bread and butter. Add (or remove) brands from this list carefully.",
+    defaultColumns: ["title", "city", "state"],
     group: "Portfolio",
     listSearchableFields: ["title", "city", "state"],
     pagination: {
-      defaultLimit: 10,
-      limits: [10, 20, 50],
+      defaultLimit: 25,
+      limits: [25, 50, 100],
     },
     useAsTitle: "title",
   },
   defaultSort: "title",
   labels: {
-    singular: "Client",
-    plural: "Clients",
+    singular: "Brand",
+    plural: "Brands",
   },
   versions: {
     drafts: true,

--- a/src/payload/collections/Posts/config.ts
+++ b/src/payload/collections/Posts/config.ts
@@ -3,6 +3,7 @@ import { authenticated } from "@/payload/access/authenticated";
 import { authenticatedOrPublished } from "@/payload/access/authenticatedOrPublished";
 import { slugField } from "@/fields/slug";
 import { revalidatePost } from "./hooks/revalidatePost";
+import { MediaBlock } from "@/app/blocks/MediaBlock/config";
 import {
   MetaDescriptionField,
   MetaImageField,
@@ -13,10 +14,7 @@ import {
 
 import {
   BlocksFeature,
-  FixedToolbarFeature,
   HeadingFeature,
-  HorizontalRuleFeature,
-  InlineToolbarFeature,
   lexicalEditor,
 } from "@payloadcms/richtext-lexical";
 
@@ -60,7 +58,7 @@ export const BlogPosts: CollectionConfig = {
       type: "upload",
       relationTo: "media",
       label: "Main Image",
-      required: false,
+      required: true,
       admin: {
         description:
           "The main image of the article that appears on the page and in the list of posts.",
@@ -77,14 +75,14 @@ export const BlogPosts: CollectionConfig = {
               type: "richText",
               label: "Content",
               editor: lexicalEditor({
-                features: [
-                  BlocksFeature(),
-                  FixedToolbarFeature(),
+                features: ({ defaultFeatures }) => [
+                  ...defaultFeatures,
                   HeadingFeature({
                     enabledHeadingSizes: ["h2", "h3", "h4", "h5", "h6"],
                   }),
-                  HorizontalRuleFeature(),
-                  InlineToolbarFeature(),
+                  BlocksFeature({
+                    blocks: [MediaBlock],
+                  }),
                 ],
               }),
               required: true,

--- a/src/payload/collections/Results/config.ts
+++ b/src/payload/collections/Results/config.ts
@@ -16,7 +16,7 @@ export const Results: CollectionConfig = {
     {
       name: "client",
       type: "relationship",
-      relationTo: "clients",
+      relationTo: "brands",
       required: true,
     },
     { name: "number", type: "text", label: "Number", required: true },

--- a/src/payload/collections/Testimonials/config.ts
+++ b/src/payload/collections/Testimonials/config.ts
@@ -46,9 +46,9 @@ export const Testimonials: CollectionConfig = {
           label: "Meta",
           fields: [
             {
-              name: "client",
+              name: "brand",
               type: "relationship",
-              relationTo: "clients",
+              relationTo: "brands",
               required: true,
               hasMany: false,
               unique: true,

--- a/src/payload/collections/Work/config.ts
+++ b/src/payload/collections/Work/config.ts
@@ -14,6 +14,7 @@ import {
 export const Work: CollectionConfig = {
   slug: "work",
 
+  //* Collection Fields
   fields: [
     {
       name: "title",
@@ -25,24 +26,60 @@ export const Work: CollectionConfig = {
         description: "The title of the project as it appears around the site.",
       },
     },
+    {
+      name: "tagline",
+      type: "text",
+      label: "Tagline",
+      required: true,
+      admin: {
+        description:
+          "The tagline of the project as it appears around the site.",
+      },
+    },
+    {
+      name: "description",
+      type: "textarea",
+      label: "Description",
+      required: false,
+      admin: {
+        description:
+          "The description of the project as it appears around the site.",
+      },
+    },
+    {
+      name: "imageMain",
+      type: "upload",
+      label: "Main Image",
+      required: true,
+      relationTo: "media",
+      admin: {
+        description: "This image appears on the site.",
+      },
+    },
     ...slugField(),
+    {
+      name: "brand",
+      type: "relationship",
+      relationTo: "brands",
+      hasMany: false,
+      required: true,
+      admin: {
+        position: "sidebar",
+        description: "Add the name of the brand here.",
+      },
+    },
+
     {
       type: "tabs",
       tabs: [
         {
           label: "Content",
+          fields: [],
+        },
+        {
+          name: "metadata",
+          label: "Meta",
           fields: [
-            {
-              name: "thumbnail",
-              type: "upload",
-              label: "Thumbnail",
-              required: true,
-              relationTo: "media",
-              admin: {
-                description:
-                  "This image appears on the WorkCard thumbnail images.",
-              },
-            },
             {
               name: "testimonial",
               type: "relationship",
@@ -51,22 +88,6 @@ export const Work: CollectionConfig = {
               required: false,
               admin: {
                 description: "If a testimonial exists, add it here.",
-              },
-            },
-          ],
-        },
-        {
-          name: "metadata",
-          label: "Meta",
-          fields: [
-            {
-              name: "client",
-              type: "relationship",
-              relationTo: "clients",
-              hasMany: false,
-              required: true,
-              admin: {
-                description: "Add the name of the client here.",
               },
             },
             {
@@ -126,9 +147,9 @@ export const Work: CollectionConfig = {
   admin: {
     useAsTitle: "title",
     description: "All we do is work, work, work.",
-    defaultColumns: ["title", "testimonial"],
+    defaultColumns: ["title", "tagline"],
     group: "Portfolio",
-    listSearchableFields: ["title"],
+    listSearchableFields: ["title", "tagline"],
     pagination: {
       defaultLimit: 25,
       limits: [10, 25, 50],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
       "@/lib/*": ["src/app/lib/*"],
       "@/access/*": ["src/payload/access"],
       "@/public/*": ["./public/*"],
+      "@/cssVariables": ["./cssvariables.js"],
       "@/styles/*": ["src/styles/*"],
       "@/types/*": ["src/app/types/*"],
       "@/utils/*": ["src/app/utilities/*"],


### PR DESCRIPTION
### TL;DR

Added a new MediaBlock component, updated blog post display, and refactored client-related collections to brands.

### What changed?

- Created a new `MediaBlock` component for rich text content
- Updated blog post display to show up to 100 posts and improved category rendering
- Renamed `Clients` collection to `Brands` and updated related references
- Enhanced `Work` collection with new fields like tagline, description, and main image
- Added CSS variables file for consistent styling
- Updated `Posts` collection to require a main image and include MediaBlock in rich text editor

### How to test?

1. Check the blog page to ensure it displays up to 100 posts with correct category information
2. Verify that the new MediaBlock component works in rich text content for blog posts
3. Test the Work collection by adding new entries with tagline, description, and main image
4. Confirm that the Brands collection (formerly Clients) functions correctly and is referenced properly in other collections
5. Review the CSS variables file to ensure it matches the existing CSS styles

### Why make this change?

These changes aim to improve content management flexibility, enhance the visual presentation of work and blog posts, and streamline the organization of brand-related information. The new MediaBlock component allows for more dynamic content creation, while the refactoring of clients to brands provides a more accurate representation of the relationships between entities in the system.