### PR TITLE
feat(cms): create connection between Pillars and Services collection in Payload

### DIFF
--- a/src/payload/collections/Pillars/config.ts
+++ b/src/payload/collections/Pillars/config.ts
@@ -1,7 +1,7 @@
 import type { CollectionConfig } from "payload";
 import { authenticated } from "@/payload/access/authenticated";
 import { authenticatedOrPublished } from "@/payload/access/authenticatedOrPublished";
-import { slugField } from "@payloadcms/plugin-seo/fields";
+import { slugField } from "@/fields/slug";
 import {
   MetaDescriptionField,
   MetaImageField,
@@ -25,6 +25,15 @@ export const Pillars: CollectionConfig = {
         description: "Add the title of the pillar here.",
       },
     },
+    {
+      name: "tagline",
+      type: "text",
+      label: "Tagline",
+      required: true,
+      admin: {
+        description: "Add the tagline for the pillar here.",
+      },
+    },
     ...slugField(),
     {
       name: "description",
@@ -35,9 +44,82 @@ export const Pillars: CollectionConfig = {
         description: "Add the description of the pillar here.",
       },
     },
+    {
+      type: "tabs",
+      tabs: [
+        {
+          name: "content",
+          label: "Content",
+          fields: [],
+        },
+        {
+          name: "metadata",
+          label: "Meta",
+          fields: [
+            {
+              name: "services",
+              type: "relationship",
+              relationTo: "services",
+              label: "Services",
+              required: false,
+              admin: {
+                description: "Add the services for the pillar here.",
+              },
+            },
+          ],
+        },
+        {
+          name: "seo",
+          label: "SEO",
+          fields: [
+            OverviewField({
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+              imagePath: "meta.image",
+            }),
+            MetaImageField({
+              relationTo: "media",
+            }),
+            MetaTitleField({
+              hasGenerateFn: true,
+            }),
+            MetaDescriptionField({}),
+            PreviewField({
+              hasGenerateFn: true,
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+            }),
+          ],
+        },
+      ],
+    },
   ],
+
+  //* Admin Settings
+  access: {
+    create: authenticated,
+    delete: authenticated,
+    read: authenticatedOrPublished,
+    update: authenticated,
+  },
+  admin: {
+    description: "Pillars of Brewww",
+    defaultColumns: ["title", "updatedAt"],
+    group: "Services",
+    listSearchableFields: ["title", "description"],
+    pagination: {
+      defaultLimit: 25,
+      limits: [25, 50, 100],
+    },
+    useAsTitle: "title",
+  },
+  defaultSort: "title",
   labels: {
     singular: "Pillar",
     plural: "Pillars",
+  },
+  versions: {
+    drafts: true,
+    maxPerDoc: 25,
   },
 };


### PR DESCRIPTION
### TL;DR

Added new fields and structure to the Pillars collection configuration.

### What changed?

- Added a new "tagline" field to the Pillars collection
- Implemented a tab structure with "Content", "Meta", and "SEO" tabs
- Added a "services" relationship field under the "Meta" tab
- Included SEO-related fields (Overview, MetaImage, MetaTitle, MetaDescription, Preview) under the "SEO" tab
- Updated the import for the slugField function
- Added access control settings for CRUD operations
- Implemented admin settings for better management and display of Pillars
- Enabled versioning with drafts and a maximum of 25 versions per document

### How to test?

1. Navigate to the Pillars collection in the admin panel
2. Create a new Pillar and verify that all new fields are present and functional
3. Check that the tab structure is correctly displayed
4. Attempt to create, read, update, and delete Pillars to ensure access controls are working as expected
5. Verify that the admin panel displays Pillars according to the new settings (default columns, search, pagination, etc.)
6. Test the versioning feature by making multiple edits to a Pillar and checking that drafts are saved

### Why make this change?

This change enhances the Pillars collection by providing more structured content management, improved SEO capabilities, and better admin controls. The addition of the tagline and services relationship allows for more detailed information about each Pillar, while the new tab structure improves the organization of the content. The implementation of access controls and versioning adds security and allows for better content management workflows.