### PR TITLE
feat(forms): add checkbox ui to Payload forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-react-compiler": "0.0.0-experimental-75b9fd4-20240912",
     "graphql": "^16.9.0",
     "gsap": "^3.12.5",
+    "lucide-react": "^0.380.0",
     "next": "15.0.0-canary.156",
     "payload": "beta",
     "payload-admin-bar": "^1.0.6",

--- a/src/app/blocks/Form/Checkbox/index.tsx
+++ b/src/app/blocks/Form/Checkbox/index.tsx
@@ -1,0 +1,56 @@
+import type { CheckboxField } from "@payloadcms/plugin-form-builder/types";
+import type {
+  FieldErrorsImpl,
+  FieldValues,
+  UseFormRegister,
+} from "react-hook-form";
+
+import { useFormContext } from "react-hook-form";
+
+import { Checkbox as CheckboxUi } from "@/components/UI/Checkbox/index";
+import { Label } from "@/components/ui/label";
+import React from "react";
+
+import { Error } from "../Error";
+import { Width } from "../Width";
+
+export const Checkbox: React.FC<
+  CheckboxField & {
+    errors: Partial<
+      FieldErrorsImpl<{
+        [x: string]: any;
+      }>
+    >;
+    getValues: any;
+    register: UseFormRegister<FieldValues>;
+    setValue: any;
+  }
+> = ({
+  name,
+  defaultValue,
+  errors,
+  label,
+  register,
+  required: requiredFromProps,
+  width,
+}) => {
+  const props = register(name, { required: requiredFromProps });
+  const { setValue } = useFormContext();
+
+  return (
+    <Width width={width}>
+      <div className="flex items-center gap-2">
+        <CheckboxUi
+          defaultChecked={defaultValue}
+          id={name}
+          {...props}
+          onCheckedChange={(checked) => {
+            setValue(props.name, checked);
+          }}
+        />
+        <Label htmlFor={name}>{label}</Label>
+      </div>
+      {requiredFromProps && errors[name] && <Error />}
+    </Width>
+  );
+};

--- a/src/app/components/UI/Checkbox/index.tsx
+++ b/src/app/components/UI/Checkbox/index.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { cn } from "@/app/utilities/cn";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Check } from "lucide-react";
+import * as React from "react";
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    className={cn(
+      "border-primary ring-offset-background focus-visible:ring-ring data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground peer h-4 w-4 shrink-0 rounded border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -25,6 +25,8 @@ export interface Config {
     locations: Location;
     results: Result;
     users: User;
+    forms: Form;
+    'form-submissions': FormSubmission;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
@@ -387,6 +389,187 @@ export interface User {
   loginAttempts?: number | null;
   lockUntil?: string | null;
   password?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "forms".
+ */
+export interface Form {
+  id: string;
+  title: string;
+  fields?:
+    | (
+        | {
+            name: string;
+            label?: string | null;
+            width?: number | null;
+            required?: boolean | null;
+            defaultValue?: boolean | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'checkbox';
+          }
+        | {
+            name: string;
+            label?: string | null;
+            width?: number | null;
+            required?: boolean | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'country';
+          }
+        | {
+            name: string;
+            label?: string | null;
+            width?: number | null;
+            required?: boolean | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'email';
+          }
+        | {
+            message?: {
+              root: {
+                type: string;
+                children: {
+                  type: string;
+                  version: number;
+                  [k: string]: unknown;
+                }[];
+                direction: ('ltr' | 'rtl') | null;
+                format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+                indent: number;
+                version: number;
+              };
+              [k: string]: unknown;
+            } | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'message';
+          }
+        | {
+            name: string;
+            label?: string | null;
+            width?: number | null;
+            defaultValue?: number | null;
+            required?: boolean | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'number';
+          }
+        | {
+            name: string;
+            label?: string | null;
+            width?: number | null;
+            defaultValue?: string | null;
+            options?:
+              | {
+                  label: string;
+                  value: string;
+                  id?: string | null;
+                }[]
+              | null;
+            required?: boolean | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'select';
+          }
+        | {
+            name: string;
+            label?: string | null;
+            width?: number | null;
+            required?: boolean | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'state';
+          }
+        | {
+            name: string;
+            label?: string | null;
+            width?: number | null;
+            defaultValue?: string | null;
+            required?: boolean | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'text';
+          }
+        | {
+            name: string;
+            label?: string | null;
+            width?: number | null;
+            defaultValue?: string | null;
+            required?: boolean | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'textarea';
+          }
+      )[]
+    | null;
+  submitButtonLabel?: string | null;
+  confirmationType?: ('message' | 'redirect') | null;
+  confirmationMessage?: {
+    root: {
+      type: string;
+      children: {
+        type: string;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
+  redirect?: {
+    url: string;
+  };
+  emails?:
+    | {
+        emailTo?: string | null;
+        cc?: string | null;
+        bcc?: string | null;
+        replyTo?: string | null;
+        emailFrom?: string | null;
+        subject: string;
+        message?: {
+          root: {
+            type: string;
+            children: {
+              type: string;
+              version: number;
+              [k: string]: unknown;
+            }[];
+            direction: ('ltr' | 'rtl') | null;
+            format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+            indent: number;
+            version: number;
+          };
+          [k: string]: unknown;
+        } | null;
+        id?: string | null;
+      }[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "form-submissions".
+ */
+export interface FormSubmission {
+  id: string;
+  form: string | Form;
+  submissionData?:
+    | {
+        field: string;
+        value: string;
+        id?: string | null;
+      }[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -9,6 +9,7 @@ import { seoPlugin } from "@payloadcms/plugin-seo";
 import { GenerateTitle, GenerateURL } from "@payloadcms/plugin-seo/types";
 import { mongooseAdapter } from "@payloadcms/db-mongodb";
 import { lexicalEditor } from "@payloadcms/richtext-lexical";
+import { formBuilderPlugin } from "@payloadcms/plugin-form-builder";
 
 //* Import Collections
 import { Users } from "./payload/collections/Users/config";
@@ -167,7 +168,13 @@ export default buildConfig({
         image: { required: false },
       },
     }),
+    formBuilderPlugin({
+      fields: {
+        payment: false,
+      },
+    }),
   ],
+
   typescript: {
     outputFile: path.resolve(dirname, "payload-types.ts"),
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,7 @@
       "@/cssVariables": ["./cssvariables.js"],
       "@/styles/*": ["src/styles/*"],
       "@/types/*": ["src/app/types/*"],
-      "@/utils/*": ["src/app/utilities/*"],
+      "@/utilities/*": ["src/app/utilities/*"],
       "@payload-config": ["./src/payload.config.ts"],
       "@payload-types": ["./src/payload-types.ts"]
     },


### PR DESCRIPTION
### TL;DR

Added form builder functionality and checkbox component to the project.

### What changed?

- Installed `lucide-react` package for icons
- Added a new `Checkbox` component in `src/app/blocks/Form/Checkbox/index.tsx`
- Created a reusable `Checkbox` UI component in `src/app/components/UI/Checkbox/index.tsx`
- Updated `payload-types.ts` to include new form and form submission interfaces
- Integrated form builder plugin in `payload.config.ts`
- Updated `tsconfig.json` to change `@/utils/*` path alias to `@/utilities/*`

### How to test?

1. Install the new dependencies by running `npm install`
2. Verify that the new Checkbox components are working correctly in the form builder
3. Test form creation and submission functionality in the Payload CMS admin panel
4. Ensure that the form builder plugin is properly integrated and functioning

### Why make this change?

This change introduces form building capabilities to the project, allowing for dynamic creation and management of forms. The addition of the checkbox component enhances the available form field types, providing more flexibility in form design. These improvements will enable easier creation and customization of forms within the application.