### PR TITLE
feat(forms): add width to Payload Forms

### DIFF
--- a/src/app/blocks/Form/Width/index.tsx
+++ b/src/app/blocks/Form/Width/index.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+
+export const Width: React.FC<{
+  children: React.ReactNode;
+  className?: string;
+  width?: number | string;
+}> = ({ children, className, width }) => {
+  return (
+    <div
+      className={className}
+      style={{ maxWidth: width ? `${width}%` : undefined }}
+    >
+      {children}
+    </div>
+  );
+};


### PR DESCRIPTION
### TL;DR

Added a new `Width` component for form blocks.

### What changed?

- Created a new file `src/app/blocks/Form/Width/index.tsx`
- Implemented a `Width` component that wraps its children in a div with an optional max-width
- The component accepts `children`, `className`, and `width` props

### How to test?

1. Import the `Width` component in a form block
2. Use it to wrap form elements, passing different width values
3. Verify that the content is constrained to the specified width
4. Check that the component renders correctly with and without a `className`

### Why make this change?

This new component provides a flexible way to control the width of form elements, improving layout consistency and responsiveness across different form implementations.