### PR TITLE
feat(forms): add email to Payload Forms

### DIFF
--- a/src/app/blocks/Form/Email/index.tsx
+++ b/src/app/blocks/Form/Email/index.tsx
@@ -1,0 +1,49 @@
+import type { EmailField } from "@payloadcms/plugin-form-builder/types";
+import type {
+  FieldErrorsImpl,
+  FieldValues,
+  UseFormRegister,
+} from "react-hook-form";
+
+import { Input } from "@/components/UI/Input/index";
+import { Label } from "@/components/UI/Label/index";
+import React from "react";
+
+import { Error } from "../Error";
+import { Width } from "../Width";
+
+export const Email: React.FC<
+  EmailField & {
+    errors: Partial<
+      FieldErrorsImpl<{
+        [x: string]: any;
+      }>
+    >;
+    register: UseFormRegister<FieldValues>;
+  }
+> = ({
+  name,
+  defaultValue,
+  errors,
+  label,
+  register,
+  required: requiredFromProps,
+  width,
+}) => {
+  return (
+    <Width width={width}>
+      <Label htmlFor={name}>{label}</Label>
+      <Input
+        defaultValue={defaultValue}
+        id={name}
+        type="text"
+        {...register(name, {
+          pattern: /^\S[^\s@]*@\S+$/,
+          required: requiredFromProps,
+        })}
+      />
+
+      {requiredFromProps && errors[name] && <Error />}
+    </Width>
+  );
+};


### PR DESCRIPTION
### TL;DR

Added a new Email component for form handling.

### What changed?

- Created a new `Email` component in `src/app/blocks/Form/Email/index.tsx`.
- The component handles email input fields within forms.
- Implements validation for email format using a regex pattern.
- Utilizes React Hook Form for form handling and validation.
- Incorporates UI components like `Input`, `Label`, and `Error`.

### How to test?

1. Import and use the `Email` component in a form.
2. Provide necessary props such as `name`, `label`, `register`, and `errors`.
3. Test with valid and invalid email inputs to ensure proper validation.
4. Verify that error messages appear for invalid inputs when the field is required.

### Why make this change?

This change introduces a reusable Email component to standardize email input handling across the application. It enhances form functionality by providing built-in email validation and integrating seamlessly with the existing form builder plugin and React Hook Form library.