### PR TITLE
feat(forms): add input component to Payload Forms

### DIFF
--- a/src/app/components/Media/ImageMedia/index.tsx
+++ b/src/app/components/Media/ImageMedia/index.tsx
@@ -2,7 +2,7 @@
 
 import type { StaticImageData } from "next/image";
 
-import { cn } from "@/app/utilities/cn";
+import { cn } from "@/utilities/cn";
 import NextImage from "next/image";
 import React from "react";
 

--- a/src/app/components/Media/VideoMedia/index.tsx
+++ b/src/app/components/Media/VideoMedia/index.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { cn } from "@/app/utilities/cn";
+import { cn } from "@/utilities/cn";
 import React, { useEffect, useRef } from "react";
 
 import type { Props as MediaProps } from "../types";

--- a/src/app/components/UI/Input/index.tsx
+++ b/src/app/components/UI/Input/index.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@/utilities/cn";
+import * as React from "react";
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ type, className, ...props }, ref) => {
+    return (
+      <input
+        className={cn(
+          "border-border bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        ref={ref}
+        type={type}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = "Input";
+
+export { Input };


### PR DESCRIPTION
### TL;DR

Updated import paths and added a new Input component.

### What changed?

- Modified import paths for the `cn` utility in ImageMedia and VideoMedia components.
- Added a new reusable Input component with customizable styles.

### How to test?

1. Verify that the ImageMedia and VideoMedia components still function correctly after the import path changes.
2. Import and use the new Input component in a form or page.
3. Test the Input component with different props and ensure it renders correctly.
4. Check that the Input component's styles are applied as expected, including focus and disabled states.

### Why make this change?

- The import path changes likely improve the project structure or resolve import issues.
- The new Input component provides a consistent, styled input element that can be reused across the application, enhancing UI consistency and reducing code duplication.