### PR TITLE
feat(forms): add number to Payload Forms

### DIFF
--- a/src/app/blocks/Form/Number/index.tsx
+++ b/src/app/blocks/Form/Number/index.tsx
@@ -1,0 +1,44 @@
+import type { TextField } from "@payloadcms/plugin-form-builder/types";
+import type {
+  FieldErrorsImpl,
+  FieldValues,
+  UseFormRegister,
+} from "react-hook-form";
+
+import { Input } from "@/components/UI/Input/index";
+import { Label } from "@/components/UI/Label/index";
+import React from "react";
+
+import { Error } from "../Error";
+import { Width } from "../Width";
+export const Number: React.FC<
+  TextField & {
+    errors: Partial<
+      FieldErrorsImpl<{
+        [x: string]: any;
+      }>
+    >;
+    register: UseFormRegister<FieldValues>;
+  }
+> = ({
+  name,
+  defaultValue,
+  errors,
+  label,
+  register,
+  required: requiredFromProps,
+  width,
+}) => {
+  return (
+    <Width width={width}>
+      <Label htmlFor={name}>{label}</Label>
+      <Input
+        defaultValue={defaultValue}
+        id={name}
+        type="number"
+        {...register(name, { required: requiredFromProps })}
+      />
+      {requiredFromProps && errors[name] && <Error />}
+    </Width>
+  );
+};


### PR DESCRIPTION
### TL;DR

Added a new Number component for form input handling.

### What changed?

- Created a new file `src/app/blocks/Form/Number/index.tsx`
- Implemented a Number component that renders a numeric input field
- Integrated with react-hook-form for form handling
- Added error handling and validation support
- Implemented width customization using the Width component

### How to test?

1. Import and use the Number component in a form
2. Provide necessary props such as name, label, and register function
3. Test input with various numeric values
4. Verify error display for required fields when left empty
5. Check if the width prop correctly adjusts the component's width

### Why make this change?

This change introduces a specialized Number input component to enhance form functionality. It provides a consistent way to handle numeric inputs across the application, integrating seamlessly with the existing form builder plugin and react-hook-form library. This addition improves code reusability and maintains a uniform user experience for numeric data entry.