### PR TITLE
feat(forms): add text option to Payload Forms

### DIFF
--- a/src/app/blocks/Form/Text/index.tsx
+++ b/src/app/blocks/Form/Text/index.tsx
@@ -1,0 +1,45 @@
+import type { TextField } from "@payloadcms/plugin-form-builder/types";
+import type {
+  FieldErrorsImpl,
+  FieldValues,
+  UseFormRegister,
+} from "react-hook-form";
+
+import { Input } from "@/components/UI/Input/index";
+import { Label } from "@/components/UI/Label/index";
+import React from "react";
+
+import { Error } from "../Error";
+import { Width } from "../Width";
+
+export const Text: React.FC<
+  TextField & {
+    errors: Partial<
+      FieldErrorsImpl<{
+        [x: string]: any;
+      }>
+    >;
+    register: UseFormRegister<FieldValues>;
+  }
+> = ({
+  name,
+  defaultValue,
+  errors,
+  label,
+  register,
+  required: requiredFromProps,
+  width,
+}) => {
+  return (
+    <Width width={width}>
+      <Label htmlFor={name}>{label}</Label>
+      <Input
+        defaultValue={defaultValue}
+        id={name}
+        type="text"
+        {...register(name, { required: requiredFromProps })}
+      />
+      {requiredFromProps && errors[name] && <Error />}
+    </Width>
+  );
+};


### PR DESCRIPTION
### TL;DR

Added a new Text component for form input handling.

### What changed?

- Created a new file `src/app/blocks/Form/Text/index.tsx`
- Implemented a Text component that renders a labeled input field
- Integrated with react-hook-form for form state management
- Added error handling for required fields

### How to test?

1. Import the Text component in a form
2. Render it with appropriate props (name, label, register, errors, etc.)
3. Verify that the input field renders correctly with its label
4. Test form submission with both valid and invalid inputs
5. Ensure error messages appear for required fields when left empty

### Why make this change?

This new Text component enhances form functionality by providing a reusable, type-safe input field. It improves code organization and maintainability while ensuring consistent styling and behavior across forms in the application.