### PR TITLE
feat(forms): add textarea component to Payload Forms

### DIFF
--- a/src/app/blocks/Form/Textarea/index.tsx
+++ b/src/app/blocks/Form/Textarea/index.tsx
@@ -1,0 +1,49 @@
+import type { TextField } from "@payloadcms/plugin-form-builder/types";
+import type {
+  FieldErrorsImpl,
+  FieldValues,
+  UseFormRegister,
+} from "react-hook-form";
+
+import { Label } from "@/components/UI/Label/index";
+import { Textarea as TextAreaComponent } from "@/components/UI/Textarea/index";
+import React from "react";
+
+import { Error } from "../Error";
+import { Width } from "../Width";
+
+export const Textarea: React.FC<
+  TextField & {
+    errors: Partial<
+      FieldErrorsImpl<{
+        [x: string]: any;
+      }>
+    >;
+    register: UseFormRegister<FieldValues>;
+    rows?: number;
+  }
+> = ({
+  name,
+  defaultValue,
+  errors,
+  label,
+  register,
+  required: requiredFromProps,
+  rows = 3,
+  width,
+}) => {
+  return (
+    <Width width={width}>
+      <Label htmlFor={name}>{label}</Label>
+
+      <TextAreaComponent
+        defaultValue={defaultValue}
+        id={name}
+        rows={rows}
+        {...register(name, { required: requiredFromProps })}
+      />
+
+      {requiredFromProps && errors[name] && <Error />}
+    </Width>
+  );
+};

--- a/src/app/components/UI/Textarea/index.tsx
+++ b/src/app/components/UI/Textarea/index.tsx
@@ -1,0 +1,23 @@
+import { cn } from "@/utilities/cn";
+import * as React from "react";
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "border-border bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[80px] w-full rounded border px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Textarea.displayName = "Textarea";
+
+export { Textarea };


### PR DESCRIPTION
### TL;DR

Added new Textarea components for form building and UI.

### What changed?

- Created a new `Textarea` component in `src/app/blocks/Form/Textarea/index.tsx` for use with the form builder plugin.
- Implemented a reusable `Textarea` UI component in `src/app/components/UI/Textarea/index.tsx`.

### How to test?

1. Import and use the new `Textarea` component from `src/app/blocks/Form/Textarea/index.tsx` in a form builder context.
2. Verify that the textarea renders correctly with proper styling and functionality.
3. Test the UI `Textarea` component from `src/app/components/UI/Textarea/index.tsx` in isolation to ensure it works as expected.
4. Check that both components handle props and user input correctly.

### Why make this change?

This change introduces dedicated textarea components to enhance form building capabilities and provide a consistent UI element for textarea inputs across the application. It improves code organization and reusability while ensuring a uniform user experience for text area inputs.