### PR TITLE
feat(forms): add config and compmonent for Payload Forms

### DIFF
--- a/src/app/blocks/Form/Component.tsx
+++ b/src/app/blocks/Form/Component.tsx
@@ -1,0 +1,188 @@
+"use client";
+import type { Form as FormType } from "@payloadcms/plugin-form-builder/types";
+
+import { useRouter } from "next/navigation";
+import React, { useCallback, useState } from "react";
+import { useForm, FormProvider } from "react-hook-form";
+import RichText from "@/components/RichText";
+import { Button } from "@/components/ui/button";
+
+import { buildInitialFormState } from "./buildInitialFormState";
+import { fields } from "./fields";
+
+export type Value = unknown;
+
+export interface Property {
+  [key: string]: Value;
+}
+
+export interface Data {
+  [key: string]: Property | Property[];
+}
+
+export type FormBlockType = {
+  blockName?: string;
+  blockType?: "formBlock";
+  enableIntro: boolean;
+  form: FormType;
+  introContent?: {
+    [k: string]: unknown;
+  }[];
+};
+
+export const FormBlock: React.FC<
+  {
+    id?: string;
+  } & FormBlockType
+> = (props) => {
+  const {
+    enableIntro,
+    form: formFromProps,
+    form: {
+      id: formID,
+      confirmationMessage,
+      confirmationType,
+      redirect,
+      submitButtonLabel,
+    } = {},
+    introContent,
+  } = props;
+
+  const formMethods = useForm({
+    defaultValues: buildInitialFormState(formFromProps.fields),
+  });
+  const {
+    control,
+    formState: { errors },
+    handleSubmit,
+    register,
+  } = formMethods;
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasSubmitted, setHasSubmitted] = useState<boolean>();
+  const [error, setError] = useState<
+    { message: string; status?: string } | undefined
+  >();
+  const router = useRouter();
+
+  const onSubmit = useCallback(
+    (data: Data) => {
+      let loadingTimerID: ReturnType<typeof setTimeout>;
+      const submitForm = async () => {
+        setError(undefined);
+
+        const dataToSend = Object.entries(data).map(([name, value]) => ({
+          field: name,
+          value,
+        }));
+
+        // delay loading indicator by 1s
+        loadingTimerID = setTimeout(() => {
+          setIsLoading(true);
+        }, 1000);
+
+        try {
+          const req = await fetch(
+            `${process.env.NEXT_PUBLIC_SERVER_URL}/api/form-submissions`,
+            {
+              body: JSON.stringify({
+                form: formID,
+                submissionData: dataToSend,
+              }),
+              headers: {
+                "Content-Type": "application/json",
+              },
+              method: "POST",
+            },
+          );
+
+          const res = await req.json();
+
+          clearTimeout(loadingTimerID);
+
+          if (req.status >= 400) {
+            setIsLoading(false);
+
+            setError({
+              message: res.errors?.[0]?.message || "Internal Server Error",
+              status: res.status,
+            });
+
+            return;
+          }
+
+          setIsLoading(false);
+          setHasSubmitted(true);
+
+          if (confirmationType === "redirect" && redirect) {
+            const { url } = redirect;
+
+            const redirectUrl = url;
+
+            if (redirectUrl) router.push(redirectUrl);
+          }
+        } catch (err) {
+          console.warn(err);
+          setIsLoading(false);
+          setError({
+            message: "Something went wrong.",
+          });
+        }
+      };
+
+      void submitForm();
+    },
+    [router, formID, redirect, confirmationType],
+  );
+
+  return (
+    <div className="container pb-20 lg:max-w-[48rem]">
+      <FormProvider {...formMethods}>
+        {enableIntro && introContent && !hasSubmitted && (
+          <RichText
+            className="mb-8"
+            content={introContent}
+            enableGutter={false}
+          />
+        )}
+        {!isLoading && hasSubmitted && confirmationType === "message" && (
+          <RichText content={confirmationMessage} />
+        )}
+        {isLoading && !hasSubmitted && <p>Loading, please wait...</p>}
+        {error && (
+          <div>{`${error.status || "500"}: ${error.message || ""}`}</div>
+        )}
+        {!hasSubmitted && (
+          <form id={formID} onSubmit={handleSubmit(onSubmit)}>
+            <div className="mb-4 last:mb-0">
+              {formFromProps &&
+                formFromProps.fields &&
+                formFromProps.fields?.map((field, index) => {
+                  const Field: React.FC<any> = fields?.[field.blockType];
+                  if (Field) {
+                    return (
+                      <div className="mb-6 last:mb-0" key={index}>
+                        <Field
+                          form={formFromProps}
+                          {...field}
+                          {...formMethods}
+                          control={control}
+                          errors={errors}
+                          register={register}
+                        />
+                      </div>
+                    );
+                  }
+                  return null;
+                })}
+            </div>
+
+            <Button form={formID} type="submit" variant="default">
+              {submitButtonLabel}
+            </Button>
+          </form>
+        )}
+      </FormProvider>
+    </div>
+  );
+};

--- a/src/app/blocks/Form/buildInitialFormState.tsx
+++ b/src/app/blocks/Form/buildInitialFormState.tsx
@@ -1,0 +1,36 @@
+import type { FormFieldBlock } from "@payloadcms/plugin-form-builder/types";
+
+export const buildInitialFormState = (fields: FormFieldBlock[]) => {
+  return fields?.reduce((initialSchema, field) => {
+    if (field.blockType === "checkbox") {
+      return {
+        ...initialSchema,
+        [field.name]: field.defaultValue,
+      };
+    }
+    if (field.blockType === "email") {
+      return {
+        ...initialSchema,
+        [field.name]: "",
+      };
+    }
+    if (field.blockType === "text") {
+      return {
+        ...initialSchema,
+        [field.name]: "",
+      };
+    }
+    if (field.blockType === "select") {
+      return {
+        ...initialSchema,
+        [field.name]: "",
+      };
+    }
+    if (field.blockType === "state") {
+      return {
+        ...initialSchema,
+        [field.name]: "",
+      };
+    }
+  }, {});
+};

--- a/src/app/blocks/Form/config.ts
+++ b/src/app/blocks/Form/config.ts
@@ -1,0 +1,51 @@
+import type { Block } from "payload";
+
+import {
+  FixedToolbarFeature,
+  HeadingFeature,
+  InlineToolbarFeature,
+  lexicalEditor,
+} from "@payloadcms/richtext-lexical";
+
+export const FormBlock: Block = {
+  slug: "formBlock",
+  interfaceName: "FormBlock",
+  fields: [
+    {
+      name: "form",
+      type: "relationship",
+      relationTo: "forms",
+      required: true,
+    },
+    {
+      name: "enableIntro",
+      type: "checkbox",
+      label: "Enable Intro Content",
+    },
+    {
+      name: "introContent",
+      type: "richText",
+      admin: {
+        condition: (_, { enableIntro }) => Boolean(enableIntro),
+      },
+      editor: lexicalEditor({
+        features: ({ rootFeatures }) => {
+          return [
+            ...rootFeatures,
+            HeadingFeature({ enabledHeadingSizes: ["h1", "h2", "h3", "h4"] }),
+            FixedToolbarFeature(),
+            InlineToolbarFeature(),
+          ];
+        },
+      }),
+      label: "Intro Content",
+    },
+  ],
+  graphQL: {
+    singularName: "FormBlock",
+  },
+  labels: {
+    plural: "Form Blocks",
+    singular: "Form Block",
+  },
+};

--- a/src/app/blocks/Form/fields.tsx
+++ b/src/app/blocks/Form/fields.tsx
@@ -1,0 +1,19 @@
+import { Checkbox } from "./Checkbox";
+import { Email } from "./Email";
+import { Message } from "./Message";
+import { Number } from "./Number";
+import { Select } from "./Select";
+import { State } from "./State";
+import { Text } from "./Text";
+import { Textarea } from "./Textarea";
+
+export const fields = {
+  checkbox: Checkbox,
+  email: Email,
+  message: Message,
+  number: Number,
+  select: Select,
+  state: State,
+  text: Text,
+  textarea: Textarea,
+};


### PR DESCRIPTION
### TL;DR

Implemented a new Form Block component with various form fields and submission handling.

### What changed?

- Added a new `FormBlock` component in `Component.tsx` that renders a form with customizable fields and handles form submission.
- Created `buildInitialFormState.tsx` to generate initial form state based on field types.
- Implemented `config.ts` to define the Form Block structure for the CMS.
- Added `fields.tsx` to export various form field components.

### How to test?

1. Create a new form in the CMS using the Form Block.
2. Add different field types (checkbox, email, text, select, etc.) to the form.
3. Render the form on a page and verify that all fields are displayed correctly.
4. Submit the form with valid and invalid data to test error handling and submission process.
5. Check if the confirmation message or redirect works as expected after successful submission.

### Why make this change?

This change introduces a flexible and customizable form building system, allowing content editors to create and manage forms directly through the CMS. It enhances the website's functionality by providing a seamless way to collect user input and handle form submissions.