### PR TITLE
feat(ui): add initial code to build dynamic project pages

### DIFF
--- a/src/app/(frontend)/(inner)/work/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/work/[slug]/page.tsx
@@ -1,0 +1,171 @@
+import configPromise from "@payload-config";
+import { getPayloadHMR } from "@payloadcms/next/utilities";
+import React from "react";
+import RichText from "@/components/RichText/index";
+import { notFound } from "next/navigation";
+import { Work } from "@/payload-types";
+import Image from "next/image";
+import Link from "next/link";
+import { formatDate } from "@/app/utilities/dateFormatter";
+
+export async function generateStaticParams() {
+  const payload = await getPayloadHMR({ config: configPromise });
+  const projects = await payload.find({
+    collection: "work",
+    limit: 1000,
+    overrideAccess: false,
+  });
+  return (
+    projects.docs?.map(({ slug }) => ({
+      params: { slug },
+    })) || []
+  );
+}
+
+export default async function WorkPage({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  if (!params.slug) {
+    notFound();
+  }
+
+  const project = await queryPostBySlug({ slug: params.slug });
+  if (!project) {
+    notFound();
+  }
+
+  return (
+    <article className="bg-white pt-24 text-black">
+      <div className="container mx-auto px-4 py-4">
+        <div className="flex items-center justify-between">
+          <ul className="hidden list-none flex-wrap gap-4 md:flex">
+            <li>
+              <Link href="/posts" className="hover:underline">
+                All Posts
+              </Link>
+            </li>
+            <li>
+              <Link href="/posts/category/branding" className="hover:underline">
+                Branding
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/posts/category/web-design"
+                className="hover:underline"
+              >
+                Web Design
+              </Link>
+            </li>
+            <li>
+              <Link href="/posts/category/content" className="hover:underline">
+                Content
+              </Link>
+            </li>
+            <li>
+              <Link href="/posts/category/guides" className="hover:underline">
+                Guides
+              </Link>
+            </li>
+            <li>
+              <Link href="/posts/category/updates" className="hover:underline">
+                Updates
+              </Link>
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <section className="container mx-auto px-4 pb-12 pt-12">
+        <div className="max-w-5xl">
+          <h1 className="mb-4 text-5xl font-medium leading-tight md:text-6xl">
+            {project.title}
+          </h1>
+          <p className="mb-8 max-w-3xl text-xl text-gray-700">
+            {project.description || "Add a cool description here."}
+          </p>
+          <div className="flex items-center gap-1 text-sm text-gray-500">
+            <span>
+              By{" "}
+              <Link className="text-gray-950" href={""}>
+                Kevin Wessa
+              </Link>
+            </span>
+            <span>•</span>
+            <span>
+              {project.publishedAt
+                ? formatDate(project.publishedAt)
+                : "Date not available"}
+            </span>
+            <span>•</span>
+            <span>
+              {project.metadata.readTime
+                ? `${project.metadata.readTime} min read`
+                : "Add Read Time"}
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <div className="w-full">
+        <div className="px-2">
+          <div className="relative aspect-[3/2] w-full">
+            <Image
+              src={
+                typeof project.imageMain === "string"
+                  ? project.imageMain
+                  : project.imageMain?.url || ""
+              }
+              fill
+              alt={
+                typeof project.imageMain === "object"
+                  ? project.imageMain?.alt || ""
+                  : "Featured image for blog post"
+              }
+              className="rounded-md object-cover"
+              priority
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-8 pt-8">
+        <div></div>
+        <div className="flex flex-col justify-start">
+          <article className="mx-auto pb-24">
+            {/* <RichText
+              content={project.content || ""}
+              className="prose-lg"
+              enableProse={true}
+              enableGutter={false}
+            /> */}
+          </article>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+async function queryPostBySlug({
+  slug,
+}: {
+  slug: string;
+}): Promise<Work | null> {
+  const payload = await getPayloadHMR({ config: configPromise });
+  try {
+    const result = await payload.find({
+      collection: "work",
+      limit: 1,
+      where: {
+        slug: {
+          equals: slug,
+        },
+      },
+    });
+    return result.docs[0] || null;
+  } catch (error) {
+    return null;
+  }
+}

--- a/src/app/(frontend)/(inner)/work/page.tsx
+++ b/src/app/(frontend)/(inner)/work/page.tsx
@@ -8,11 +8,12 @@ export default async function WorkPage() {
   const projects = await payload.find({
     collection: "work",
     limit: 1000,
+    sort: "title",
     where: {
       _status: { equals: "published" },
     },
   });
-  console.log(projects);
+
   return (
     <>
       <div>
@@ -242,7 +243,10 @@ export default async function WorkPage() {
                 <div className="relative">
                   <ul className="grid list-none grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
                     {projects.docs.map((project, index) => {
-                      const isWide = index % 3 === 0;
+                      const rowIndex = Math.floor(index / 2);
+                      const isWide =
+                        (rowIndex % 2 === 0 && index % 2 === 0) ||
+                        (rowIndex % 2 === 1 && index % 2 === 1);
 
                       return (
                         <li
@@ -254,7 +258,7 @@ export default async function WorkPage() {
                           </span>
                           <Link
                             className="w-full flex-grow overflow-hidden"
-                            href=""
+                            href={`/work/${project.slug}`}
                           >
                             <div className="relative pt-[75%]">
                               <Image
@@ -284,7 +288,7 @@ export default async function WorkPage() {
                             <div className="text-lg uppercase">
                               <Link
                                 className="relative inline-block overflow-hidden rounded-full bg-gray-200 px-4 py-2 text-center"
-                                href=""
+                                href={`/work/${project.slug}`}
                               >
                                 <span className="relative cursor-pointer">
                                   View

--- a/src/payload/collections/Work/config.ts
+++ b/src/payload/collections/Work/config.ts
@@ -147,7 +147,7 @@ export const Work: CollectionConfig = {
   admin: {
     useAsTitle: "title",
     description: "All we do is work, work, work.",
-    defaultColumns: ["title", "tagline"],
+    defaultColumns: ["title", "tagline", "status"],
     group: "Portfolio",
     listSearchableFields: ["title", "tagline"],
     pagination: {


### PR DESCRIPTION
### TL;DR

Added a new page for individual work items and improved the work listing page.

### What changed?

- Created a new `[slug]/page.tsx` file for individual work items
- Updated the work listing page (`work/page.tsx`) to include links to individual work pages
- Modified the grid layout in the work listing page to alternate wide items
- Added sorting by title to the work listing query
- Updated the Work collection config to include 'status' in default columns

### How to test?

1. Navigate to the work listing page
2. Verify that the grid layout alternates wide items correctly
3. Click on a work item to ensure it links to the individual work page
4. Check that the individual work page displays the correct information
5. In the admin panel, verify that the Work collection now shows the 'status' column by default

### Why make this change?

This change enhances the user experience by providing detailed pages for individual work items and improving the visual layout of the work listing page. It also improves the admin interface by including the 'status' column in the default view, making it easier to manage work items.