### PR TITLE
feat(cms): add Banner block to Post block options

### DIFF
--- a/src/app/blocks/Banner/Component.tsx
+++ b/src/app/blocks/Banner/Component.tsx
@@ -1,0 +1,26 @@
+import type { BannerBlock as BannerBlockProps } from "src/payload-types";
+
+import { cn } from "@/app/utilities/cn";
+import React from "react";
+import RichText from "@/components/RichText";
+
+type Props = {
+  className?: string;
+} & BannerBlockProps;
+
+export const BannerBlock: React.FC<Props> = ({ className, content, style }) => {
+  return (
+    <div className={cn("mx-auto my-8 w-full", className)}>
+      <div
+        className={cn("flex items-center rounded border px-6 py-3", {
+          "border-border bg-card": style === "info",
+          "border-error bg-error/30": style === "error",
+          "border-success bg-success/30": style === "success",
+          "border-warning bg-warning/30": style === "warning",
+        })}
+      >
+        <RichText content={content} enableGutter={false} enableProse={false} />
+      </div>
+    </div>
+  );
+};

--- a/src/app/blocks/Banner/config.ts
+++ b/src/app/blocks/Banner/config.ts
@@ -1,0 +1,41 @@
+import type { Block } from "payload";
+
+import {
+  FixedToolbarFeature,
+  InlineToolbarFeature,
+  lexicalEditor,
+} from "@payloadcms/richtext-lexical";
+
+export const Banner: Block = {
+  slug: "banner",
+  fields: [
+    {
+      name: "style",
+      type: "select",
+      defaultValue: "info",
+      options: [
+        { label: "Info", value: "info" },
+        { label: "Warning", value: "warning" },
+        { label: "Error", value: "error" },
+        { label: "Success", value: "success" },
+      ],
+      required: true,
+    },
+    {
+      name: "content",
+      type: "richText",
+      editor: lexicalEditor({
+        features: ({ rootFeatures }) => {
+          return [
+            ...rootFeatures,
+            FixedToolbarFeature(),
+            InlineToolbarFeature(),
+          ];
+        },
+      }),
+      label: false,
+      required: true,
+    },
+  ],
+  interfaceName: "BannerBlock",
+};

--- a/src/app/components/RichText/serialize.tsx
+++ b/src/app/components/RichText/serialize.tsx
@@ -1,4 +1,4 @@
-// import { BannerBlock } from "@/blocks/Banner/Component";
+import { BannerBlock } from "@/blocks/Banner/Component";
 // import { CallToActionBlock } from "@/blocks/CallToAction/Component";
 // import { CodeBlock, CodeBlockProps } from "@/blocks/Code/Component";
 import { MediaBlock } from "@/blocks/MediaBlock/Component";
@@ -8,7 +8,7 @@ import {
   DefaultNodeTypes,
   SerializedBlockNode,
 } from "@payloadcms/richtext-lexical";
-// import type { BannerBlock as BannerBlockProps } from "@/payload-types";
+import type { BannerBlock as BannerBlockProps } from "@/payload-types";
 
 import {
   IS_BOLD,
@@ -27,7 +27,7 @@ export type NodeTypes =
       // @ts-ignore // TODO: Fix this
       | Extract<Page["layout"][0], { blockType: "cta" }>
       | Extract<Page["layout"][0], { blockType: "mediaBlock" }>
-      // | BannerBlockProps
+      | BannerBlockProps
       // | CodeBlockProps
     >;
 
@@ -127,13 +127,13 @@ export function serializeLexical({ nodes }: Props): JSX.Element {
                 />
               );
             case "banner":
-              // return (
-              //   <BannerBlock
-              //     className="col-start-2 mb-4"
-              //     key={index}
-              //     {...block}
-              //   />
-              // );
+              return (
+                <BannerBlock
+                  className="col-start-2 mb-4"
+                  key={index}
+                  {...block}
+                />
+              );
               return null;
             case "code":
               // return (

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -675,6 +675,31 @@ export interface MediaBlock {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "BannerBlock".
+ */
+export interface BannerBlock {
+  style: 'info' | 'warning' | 'error' | 'success';
+  content: {
+    root: {
+      type: string;
+      children: {
+        type: string;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  };
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'banner';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "auth".
  */
 export interface Auth {

--- a/src/payload/collections/BlogPosts/config.ts
+++ b/src/payload/collections/BlogPosts/config.ts
@@ -4,6 +4,8 @@ import { authenticatedOrPublished } from "@/payload/access/authenticatedOrPublis
 import { slugField } from "@/fields/slug";
 import { revalidatePost } from "./hooks/revalidatePost";
 import { MediaBlock } from "@/app/blocks/MediaBlock/config";
+import { Banner } from "@/app/blocks/Banner/config";
+
 import {
   MetaDescriptionField,
   MetaImageField,
@@ -81,7 +83,7 @@ export const BlogPosts: CollectionConfig = {
                     enabledHeadingSizes: ["h2", "h3", "h4", "h5", "h6"],
                   }),
                   BlocksFeature({
-                    blocks: [MediaBlock],
+                    blocks: [MediaBlock, Banner],
                   }),
                 ],
               }),


### PR DESCRIPTION
### TL;DR

Added a new Banner block component with configurable styles for info, warning, error, and success messages.

### What changed?

- Created a new `BannerBlock` component in `src/app/blocks/Banner/Component.tsx`
- Added configuration for the Banner block in `src/app/blocks/Banner/config.ts`
- Updated `serializeLexical` function in `src/app/components/RichText/serialize.tsx` to include the new Banner block
- Modified `payload-types.ts` to include the BannerBlock interface
- Updated the BlogPosts collection configuration to include the Banner block in the rich text editor

### How to test?

1. Navigate to the admin panel and create or edit a blog post
2. In the content editor, add a new Banner block
3. Configure the banner style (info, warning, error, or success) and add content
4. Preview the blog post to ensure the banner appears with the correct styling

### Why make this change?

This change introduces a versatile Banner component that allows content creators to highlight important information within blog posts. The configurable styles (info, warning, error, and success) provide flexibility in communicating different types of messages, improving the overall user experience and content presentation.