### PR TITLE
feat(cms): add code block option to Posts

### DIFF
--- a/src/app/blocks/Code/Component.client.tsx
+++ b/src/app/blocks/Code/Component.client.tsx
@@ -1,0 +1,33 @@
+"use client";
+import { Highlight, themes } from "prism-react-renderer";
+import React from "react";
+
+type Props = {
+  code: string;
+  language?: string;
+};
+
+export const Code: React.FC<Props> = ({ code, language = "" }) => {
+  if (!code) return null;
+
+  return (
+    <Highlight code={code} language={language} theme={themes.vsDark}>
+      {({ getLineProps, getTokenProps, tokens }) => (
+        <pre className="border-border overflow-x-auto rounded border bg-black p-4 text-xs">
+          {tokens.map((line, i) => (
+            <div key={i} {...getLineProps({ className: "table-row", line })}>
+              <span className="table-cell select-none text-right text-white/25">
+                {i + 1}
+              </span>
+              <span className="table-cell pl-4">
+                {line.map((token, key) => (
+                  <span key={key} {...getTokenProps({ token })} />
+                ))}
+              </span>
+            </div>
+          ))}
+        </pre>
+      )}
+    </Highlight>
+  );
+};

--- a/src/app/blocks/Code/Component.tsx
+++ b/src/app/blocks/Code/Component.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+import { Code } from "./Component.client";
+
+export type CodeBlockProps = {
+  code: string;
+  language?: string;
+  blockType: "code";
+};
+
+type Props = CodeBlockProps & {
+  className?: string;
+};
+
+export const CodeBlock: React.FC<Props> = ({ className, code, language }) => {
+  return (
+    <div className={[className, "not-prose"].filter(Boolean).join(" ")}>
+      <Code code={code} language={language} />
+    </div>
+  );
+};

--- a/src/app/blocks/Code/config.ts
+++ b/src/app/blocks/Code/config.ts
@@ -1,0 +1,33 @@
+import type { Block } from "payload";
+
+export const CodeBlock: Block = {
+  slug: "code",
+  interfaceName: "CodeBlock",
+  fields: [
+    {
+      name: "language",
+      type: "select",
+      defaultValue: "typescript",
+      options: [
+        {
+          label: "Typescript",
+          value: "typescript",
+        },
+        {
+          label: "Javascript",
+          value: "javascript",
+        },
+        {
+          label: "CSS",
+          value: "css",
+        },
+      ],
+    },
+    {
+      name: "code",
+      type: "code",
+      label: false,
+      required: true,
+    },
+  ],
+};

--- a/src/app/components/RichText/serialize.tsx
+++ b/src/app/components/RichText/serialize.tsx
@@ -1,6 +1,6 @@
 import { BannerBlock } from "@/blocks/Banner/Component";
 // import { CallToActionBlock } from "@/blocks/CallToAction/Component";
-// import { CodeBlock, CodeBlockProps } from "@/blocks/Code/Component";
+import { CodeBlock, CodeBlockProps } from "@/blocks/Code/Component";
 import { MediaBlock } from "@/blocks/MediaBlock/Component";
 import React, { Fragment, JSX } from "react";
 // import { CMSLink } from "@/components/Link";

--- a/src/payload/collections/BlogPosts/config.ts
+++ b/src/payload/collections/BlogPosts/config.ts
@@ -4,6 +4,7 @@ import { authenticatedOrPublished } from "@/payload/access/authenticatedOrPublis
 import { slugField } from "@/fields/slug";
 import { revalidatePost } from "./hooks/revalidatePost";
 import { MediaBlock } from "@/app/blocks/MediaBlock/config";
+import { CodeBlock } from "@/app/blocks/Code/config";
 import { Banner } from "@/app/blocks/Banner/config";
 
 import {
@@ -83,7 +84,7 @@ export const BlogPosts: CollectionConfig = {
                     enabledHeadingSizes: ["h2", "h3", "h4", "h5", "h6"],
                   }),
                   BlocksFeature({
-                    blocks: [MediaBlock, Banner],
+                    blocks: [MediaBlock, Banner, CodeBlock],
                   }),
                 ],
               }),


### PR DESCRIPTION
### TL;DR

Added a new Code block component for displaying syntax-highlighted code snippets in blog posts.

### What changed?

- Created a new `Code` component with syntax highlighting using `prism-react-renderer`
- Added a `CodeBlock` component to wrap the `Code` component
- Implemented a `CodeBlock` configuration for Payload CMS
- Updated the `serialize` function to include the `CodeBlock` component
- Added `CodeBlock` to the available blocks in the BlogPosts collection

### How to test?

1. Create or edit a blog post in the CMS
2. Add a Code block to the content
3. Select a language (TypeScript, JavaScript, or CSS) and enter some code
4. Preview or publish the blog post
5. Verify that the code is displayed with proper syntax highlighting

### Why make this change?

This change enhances the blogging capabilities by allowing authors to include formatted code snippets in their posts. Syntax highlighting improves readability and makes technical content more accessible to readers.