### PR TITLE
feat(cms): add Call To Action block to Post blocks

### DIFF
--- a/src/app/blocks/CallToAction/Component.tsx
+++ b/src/app/blocks/CallToAction/Component.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+import type { Page } from "@/payload-types";
+
+import RichText from "@/components/RichText";
+import { CMSLink } from "@/app/components/Link";
+
+type Props = Extract<Page["layout"][0], { blockType: "cta" }>;
+
+export const CallToActionBlock: React.FC<
+  Props & {
+    id?: string;
+  }
+> = ({ links, richText }) => {
+  return (
+    <div className="container">
+      <div className="bg-card border-border flex flex-col gap-8 rounded border p-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex max-w-[48rem] items-center">
+          {richText && (
+            <RichText
+              className="mb-0"
+              content={richText}
+              enableGutter={false}
+            />
+          )}
+        </div>
+        <div className="flex flex-col gap-8">
+          {(links || []).map(({ link }, i) => {
+            return <CMSLink key={i} size="lg" {...link} />;
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/app/blocks/CallToAction/config.ts
+++ b/src/app/blocks/CallToAction/config.ts
@@ -1,0 +1,42 @@
+import type { Block } from "payload";
+
+import {
+  FixedToolbarFeature,
+  HeadingFeature,
+  InlineToolbarFeature,
+  lexicalEditor,
+} from "@payloadcms/richtext-lexical";
+
+import { linkGroup } from "../../fields/linkGroup";
+
+export const CallToAction: Block = {
+  slug: "cta",
+  interfaceName: "CallToActionBlock",
+  fields: [
+    {
+      name: "richText",
+      type: "richText",
+      editor: lexicalEditor({
+        features: ({ rootFeatures }) => {
+          return [
+            ...rootFeatures,
+            HeadingFeature({ enabledHeadingSizes: ["h1", "h2", "h3", "h4"] }),
+            FixedToolbarFeature(),
+            InlineToolbarFeature(),
+          ];
+        },
+      }),
+      label: false,
+    },
+    linkGroup({
+      appearances: ["default", "outline"],
+      overrides: {
+        maxRows: 2,
+      },
+    }),
+  ],
+  labels: {
+    plural: "Calls to Action",
+    singular: "Call to Action",
+  },
+};

--- a/src/app/blocks/Code/config.ts
+++ b/src/app/blocks/Code/config.ts
@@ -1,6 +1,6 @@
 import type { Block } from "payload";
 
-export const CodeBlock: Block = {
+export const Code: Block = {
   slug: "code",
   interfaceName: "CodeBlock",
   fields: [

--- a/src/app/components/Link/index.tsx
+++ b/src/app/components/Link/index.tsx
@@ -1,0 +1,70 @@
+import { Button, type ButtonProps } from "@/components/UI/Button";
+import { cn } from "@/utilities/cn";
+import Link from "next/link";
+import React from "react";
+
+import type { Page, Post } from "@/payload-types";
+
+type CMSLinkType = {
+  appearance?: "inline" | ButtonProps["variant"];
+  children?: React.ReactNode;
+  className?: string;
+  label?: string | null;
+  newTab?: boolean | null;
+  reference?: {
+    relationTo: "pages" | "posts";
+    value: Page | Post | string | number;
+  } | null;
+  size?: ButtonProps["size"] | null;
+  type?: "custom" | "reference" | null;
+  url?: string | null;
+};
+
+export const CMSLink: React.FC<CMSLinkType> = (props) => {
+  const {
+    type,
+    appearance = "inline",
+    children,
+    className,
+    label,
+    newTab,
+    reference,
+    size: sizeFromProps,
+    url,
+  } = props;
+
+  const href =
+    type === "reference" &&
+    typeof reference?.value === "object" &&
+    reference.value.slug
+      ? `${reference?.relationTo !== "pages" ? `/${reference?.relationTo}` : ""}/${
+          reference.value.slug
+        }`
+      : url;
+
+  if (!href) return null;
+
+  const size = appearance === "link" ? "clear" : sizeFromProps;
+  const newTabProps = newTab
+    ? { rel: "noopener noreferrer", target: "_blank" }
+    : {};
+
+  /* Ensure we don't break any styles set by richText */
+  if (appearance === "inline") {
+    return (
+      <Link className={cn(className)} href={href || url || ""} {...newTabProps}>
+        {label && label}
+        {children && children}
+      </Link>
+    );
+  }
+
+  return (
+    <Button asChild className={className} size={size} variant={appearance}>
+      <Link className={cn(className)} href={href || url || ""} {...newTabProps}>
+        {label && label}
+        {children && children}
+      </Link>
+    </Button>
+  );
+};

--- a/src/app/components/RichText/serialize.tsx
+++ b/src/app/components/RichText/serialize.tsx
@@ -1,5 +1,5 @@
 import { BannerBlock } from "@/blocks/Banner/Component";
-// import { CallToActionBlock } from "@/blocks/CallToAction/Component";
+import { CallToActionBlock } from "@/blocks/CallToAction/Component";
 import { CodeBlock, CodeBlockProps } from "@/blocks/Code/Component";
 import { MediaBlock } from "@/blocks/MediaBlock/Component";
 import React, { Fragment, JSX } from "react";
@@ -28,7 +28,7 @@ export type NodeTypes =
       | Extract<Page["layout"][0], { blockType: "cta" }>
       | Extract<Page["layout"][0], { blockType: "mediaBlock" }>
       | BannerBlockProps
-      // | CodeBlockProps
+      | CodeBlockProps
     >;
 
 type Props = {
@@ -112,7 +112,7 @@ export function serializeLexical({ nodes }: Props): JSX.Element {
 
           switch (blockType) {
             case "cta":
-              // return <CallToActionBlock key={index} {...block} />;
+              return <CallToActionBlock key={index} {...block} />;
               return null;
             case "mediaBlock":
               return (
@@ -136,9 +136,9 @@ export function serializeLexical({ nodes }: Props): JSX.Element {
               );
               return null;
             case "code":
-              // return (
-              //   <CodeBlock className="col-start-2" key={index} {...block} />
-              // );
+              return (
+                <CodeBlock className="col-start-2" key={index} {...block} />
+              );
               return null;
             default:
               return null;

--- a/src/payload/collections/BlogPosts/config.ts
+++ b/src/payload/collections/BlogPosts/config.ts
@@ -4,9 +4,9 @@ import { authenticatedOrPublished } from "@/payload/access/authenticatedOrPublis
 import { slugField } from "@/fields/slug";
 import { revalidatePost } from "./hooks/revalidatePost";
 import { MediaBlock } from "@/app/blocks/MediaBlock/config";
-import { CodeBlock } from "@/app/blocks/Code/config";
+import { Code } from "@/app/blocks/Code/config";
 import { Banner } from "@/app/blocks/Banner/config";
-
+import { CallToAction } from "@/app/blocks/CallToAction/config";
 import {
   MetaDescriptionField,
   MetaImageField,
@@ -84,7 +84,7 @@ export const BlogPosts: CollectionConfig = {
                     enabledHeadingSizes: ["h2", "h3", "h4", "h5", "h6"],
                   }),
                   BlocksFeature({
-                    blocks: [MediaBlock, Banner, CodeBlock],
+                    blocks: [MediaBlock, Banner, Code, CallToAction],
                   }),
                 ],
               }),


### PR DESCRIPTION
### TL;DR

Added a new Call to Action block and integrated it into the blog post layout.

### What changed?

- Created a new `CallToAction` component and configuration
- Added a `CMSLink` component for handling various link types
- Integrated the Call to Action block into the blog post layout
- Updated the `serializeLexical` function to render the new Call to Action block
- Renamed `CodeBlock` to `Code` in the blog post configuration

### How to test?

1. Navigate to the blog post creation/editing interface
2. Verify that the Call to Action block is available as an option
3. Create a new blog post with a Call to Action block
4. Preview the post to ensure the Call to Action renders correctly
5. Test different link types (custom, reference) within the Call to Action
6. Verify that the Code block still functions as expected

### Why make this change?

This change enhances the blog post layout by adding a versatile Call to Action block. It allows content creators to easily add engaging CTAs within their posts, improving user interaction and potentially driving more conversions. The new `CMSLink` component also provides a more flexible way to handle different types of links throughout the application.