### PR TITLE
chore(cms): update access settings for all collections

### DIFF
--- a/src/payload/collections/BlogCategories/config.ts
+++ b/src/payload/collections/BlogCategories/config.ts
@@ -1,7 +1,6 @@
 import type { CollectionConfig } from "payload";
-import { authenticated } from "@/access/authenticated";
-import { authenticatedOrPublished } from "@/access/authenticatedOrPublished";
-import { UnderlineFeature, lexicalEditor } from "@payloadcms/richtext-lexical";
+import { isAdmin } from "@/access/isAdmin";
+import { publishedOnly } from "@/access/publishedOnly";
 import { slugField } from "@/fields/slug";
 import {
   MetaDescriptionField,
@@ -13,6 +12,15 @@ import {
 
 export const BlogCategories: CollectionConfig = {
   slug: "categories",
+
+  //* Access Settings
+  access: {
+    create: isAdmin,
+    delete: isAdmin,
+    read: publishedOnly,
+    readVersions: isAdmin,
+    update: isAdmin,
+  },
 
   //* Collection Fields
   fields: [
@@ -30,12 +38,6 @@ export const BlogCategories: CollectionConfig = {
   ],
 
   //* Admin Settings
-  access: {
-    create: authenticated,
-    delete: authenticated,
-    read: authenticatedOrPublished,
-    update: authenticated,
-  },
   admin: {
     description: "Categories for blog posts.",
     defaultColumns: ["title"],

--- a/src/payload/collections/BlogPosts/config.ts
+++ b/src/payload/collections/BlogPosts/config.ts
@@ -1,6 +1,6 @@
 import type { CollectionConfig } from "payload";
-import { authenticated } from "@/access/authenticated";
-import { authenticatedOrPublished } from "@/access/authenticatedOrPublished";
+import { isAdmin } from "@/access/isAdmin";
+import { publishedOnly } from "@/access/publishedOnly";
 import { slugField } from "@/fields/slug";
 import { revalidatePost } from "./hooks/revalidatePost";
 import { MediaBlock } from "@/app/blocks/MediaBlock/config";
@@ -23,6 +23,15 @@ import {
 
 export const BlogPosts: CollectionConfig = {
   slug: "posts",
+
+  //* Access Settings
+  access: {
+    create: isAdmin,
+    delete: isAdmin,
+    read: publishedOnly,
+    readVersions: isAdmin,
+    update: isAdmin,
+  },
 
   //* Collection Fields
   fields: [
@@ -180,12 +189,7 @@ export const BlogPosts: CollectionConfig = {
   ],
 
   //* Admin Settings
-  access: {
-    create: authenticated,
-    delete: authenticated,
-    read: authenticatedOrPublished,
-    update: authenticated,
-  },
+
   admin: {
     description:
       "Writing brings clarity. Writing is a way to make sense of the world.",

--- a/src/payload/collections/Brands/config.ts
+++ b/src/payload/collections/Brands/config.ts
@@ -1,9 +1,19 @@
 import type { CollectionConfig } from "payload";
-import { authenticated } from "@/access/authenticated";
-import { authenticatedOrPublished } from "@/access/authenticatedOrPublished";
+
+import { isAdmin } from "@/access/isAdmin";
+import { publishedOnly } from "@/access/publishedOnly";
 
 export const Brands: CollectionConfig = {
   slug: "brands",
+
+  //* Access Settings
+  access: {
+    create: isAdmin,
+    delete: isAdmin,
+    read: publishedOnly,
+    readVersions: isAdmin,
+    update: isAdmin,
+  },
 
   //* Collection Fields
   fields: [
@@ -59,12 +69,7 @@ export const Brands: CollectionConfig = {
   ],
 
   //* Admin Settings
-  access: {
-    create: authenticated,
-    delete: authenticated,
-    read: authenticatedOrPublished,
-    update: authenticated,
-  },
+
   admin: {
     description:
       "Our bread and butter. Add (or remove) brands from this list carefully.",

--- a/src/payload/collections/FAQ/config.ts
+++ b/src/payload/collections/FAQ/config.ts
@@ -1,9 +1,18 @@
 import type { CollectionConfig } from "payload";
-import { authenticated } from "@/access/authenticated";
-import { authenticatedOrPublished } from "@/access/authenticatedOrPublished";
+import { isAdmin } from "@/access/isAdmin";
+import { publishedOnly } from "@/access/publishedOnly";
 
 export const FAQ: CollectionConfig = {
   slug: "faq",
+
+  //* Access Settings
+  access: {
+    create: isAdmin,
+    delete: isAdmin,
+    read: publishedOnly,
+    readVersions: isAdmin,
+    update: isAdmin,
+  },
 
   //* Collection Fields
   fields: [
@@ -22,12 +31,7 @@ export const FAQ: CollectionConfig = {
   ],
 
   //* Admin Settings
-  access: {
-    create: authenticated,
-    delete: authenticated,
-    read: authenticatedOrPublished,
-    update: authenticated,
-  },
+
   admin: {
     description: "Frequently asked questions",
     group: "Company",

--- a/src/payload/collections/Locations/config.ts
+++ b/src/payload/collections/Locations/config.ts
@@ -1,10 +1,19 @@
 import type { CollectionConfig } from "payload";
-import { authenticated } from "@/access/authenticated";
-import { authenticatedOrPublished } from "@/access/authenticatedOrPublished";
+import { isAdmin } from "@/access/isAdmin";
+import { publishedOnly } from "@/access/publishedOnly";
 import { slugField } from "@/fields/slug";
 
 export const Location: CollectionConfig = {
   slug: "locations",
+
+  //* Access Settings
+  access: {
+    create: isAdmin,
+    delete: isAdmin,
+    read: publishedOnly,
+    readVersions: isAdmin,
+    update: isAdmin,
+  },
 
   //* Collection Fields
   fields: [
@@ -22,12 +31,7 @@ export const Location: CollectionConfig = {
   ],
 
   //* Admin Settings
-  access: {
-    create: authenticated,
-    delete: authenticated,
-    read: authenticatedOrPublished,
-    update: authenticated,
-  },
+
   admin: {
     description: "Landing pages for services",
     group: "Service",

--- a/src/payload/collections/Media/config.ts
+++ b/src/payload/collections/Media/config.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from "payload";
+import { isAdmin } from "@/access/isAdmin";
 import {
   FixedToolbarFeature,
   InlineToolbarFeature,
@@ -7,6 +8,14 @@ import {
 
 export const Media: CollectionConfig = {
   slug: "media",
+
+  //* Access Settings
+  access: {
+    create: isAdmin,
+    delete: isAdmin,
+    read: () => true,
+    update: isAdmin,
+  },
 
   //* Collection Fields
   fields: [
@@ -53,8 +62,6 @@ export const Media: CollectionConfig = {
   admin: {
     listSearchableFields: ["title", "url", "alt"],
   },
-  access: {
-    read: () => true,
-  },
+
   upload: true,
 };

--- a/src/payload/collections/Pages/config.ts
+++ b/src/payload/collections/Pages/config.ts
@@ -1,7 +1,7 @@
 import type { CollectionConfig } from "payload";
-import { authenticated } from "@/access/authenticated";
-import { authenticatedOrPublished } from "@/access/authenticatedOrPublished";
+import { isAdmin } from "@/access/isAdmin";
 import { slugField } from "@/fields/slug";
+import { publishedOnly } from "@/access/publishedOnly";
 
 import {
   MetaDescriptionField,
@@ -16,6 +16,15 @@ import { Cover } from "@/app/blocks/Cover/config";
 
 export const Pages: CollectionConfig = {
   slug: "pages",
+
+  //* Access Settings
+  access: {
+    create: isAdmin,
+    delete: isAdmin,
+    read: publishedOnly,
+    readVersions: isAdmin,
+    update: isAdmin,
+  },
 
   //* Collection Fields
   fields: [
@@ -72,12 +81,7 @@ export const Pages: CollectionConfig = {
   ],
 
   //* Admin Settings
-  access: {
-    create: authenticated,
-    delete: authenticated,
-    read: authenticatedOrPublished,
-    update: authenticated,
-  },
+
   admin: {
     useAsTitle: "title",
     livePreview: {

--- a/src/payload/collections/Pillars/config.ts
+++ b/src/payload/collections/Pillars/config.ts
@@ -1,6 +1,6 @@
 import type { CollectionConfig } from "payload";
-import { authenticated } from "@/access/authenticated";
-import { authenticatedOrPublished } from "@/access/authenticatedOrPublished";
+import { isAdmin } from "@/access/isAdmin";
+import { publishedOnly } from "@/access/publishedOnly";
 import { slugField } from "@/fields/slug";
 import {
   MetaDescriptionField,
@@ -12,6 +12,14 @@ import {
 
 export const Pillars: CollectionConfig = {
   slug: "pillars",
+
+  access: {
+    create: isAdmin,
+    delete: isAdmin,
+    read: publishedOnly,
+    readVersions: isAdmin,
+    update: isAdmin,
+  },
 
   //* Collection Fields
   fields: [
@@ -96,12 +104,7 @@ export const Pillars: CollectionConfig = {
   ],
 
   //* Admin Settings
-  access: {
-    create: authenticated,
-    delete: authenticated,
-    read: authenticatedOrPublished,
-    update: authenticated,
-  },
+
   admin: {
     description: "Pillars of Brewww",
     defaultColumns: ["title", "updatedAt"],

--- a/src/payload/collections/Play/config.ts
+++ b/src/payload/collections/Play/config.ts
@@ -1,6 +1,6 @@
 import type { CollectionConfig } from "payload";
-import { authenticated } from "@/access/authenticated";
-import { authenticatedOrPublished } from "@/access/authenticatedOrPublished";
+import { isAdmin } from "@/access/isAdmin";
+import { publishedOnly } from "@/access/publishedOnly";
 import { slugField } from "@/fields/slug";
 import {
   MetaDescriptionField,
@@ -12,6 +12,15 @@ import {
 
 export const Playground: CollectionConfig = {
   slug: "play",
+
+  //* Access Settings
+  access: {
+    create: isAdmin,
+    delete: isAdmin,
+    read: publishedOnly,
+    readVersions: isAdmin,
+    update: isAdmin,
+  },
 
   //* Collection Fields
   fields: [
@@ -140,12 +149,7 @@ export const Playground: CollectionConfig = {
   ],
 
   //* Admin Settings
-  access: {
-    create: authenticated,
-    delete: authenticated,
-    read: authenticatedOrPublished,
-    update: authenticated,
-  },
+
   admin: {
     description: "Interior Brewww projects",
     defaultColumns: ["title", "tagline", "publishedAt", "updatedAt"],

--- a/src/payload/collections/Results/config.ts
+++ b/src/payload/collections/Results/config.ts
@@ -1,9 +1,18 @@
 import type { CollectionConfig } from "payload";
-import { authenticated } from "@/access/authenticated";
-import { authenticatedOrPublished } from "@/access/authenticatedOrPublished";
+import { isAdmin } from "@/access/isAdmin";
+import { publishedOnly } from "@/access/publishedOnly";
 
 export const Results: CollectionConfig = {
   slug: "results",
+
+  //* Access Settings
+  access: {
+    create: isAdmin,
+    delete: isAdmin,
+    read: publishedOnly,
+    readVersions: isAdmin,
+    update: isAdmin,
+  },
 
   //* Collection Fields
   fields: [
@@ -30,12 +39,7 @@ export const Results: CollectionConfig = {
   ],
 
   //* Admin Settings
-  access: {
-    create: authenticated,
-    delete: authenticated,
-    read: authenticatedOrPublished,
-    update: authenticated,
-  },
+
   admin: {
     description: "The impact of our work",
     defaultColumns: ["title"],

--- a/src/payload/collections/Services/config.ts
+++ b/src/payload/collections/Services/config.ts
@@ -1,6 +1,6 @@
 import type { CollectionConfig } from "payload";
-import { authenticated } from "@/access/authenticated";
-import { authenticatedOrPublished } from "@/access/authenticatedOrPublished";
+import { isAdmin } from "@/access/isAdmin";
+import { publishedOnly } from "@/access/publishedOnly";
 import { slugField } from "@/fields/slug";
 import {
   MetaDescriptionField,
@@ -12,6 +12,15 @@ import {
 
 export const Services: CollectionConfig = {
   slug: "services",
+
+  //* Access Settings
+  access: {
+    create: isAdmin,
+    delete: isAdmin,
+    read: publishedOnly,
+    readVersions: isAdmin,
+    update: isAdmin,
+  },
 
   //* Collection Fields
   fields: [
@@ -98,12 +107,7 @@ export const Services: CollectionConfig = {
   ],
 
   //* Admin Settings
-  access: {
-    create: authenticated,
-    delete: authenticated,
-    read: authenticatedOrPublished,
-    update: authenticated,
-  },
+
   admin: {
     description: "How we help people. Be specific.",
     defaultColumns: ["title"],

--- a/src/payload/collections/Testimonials/config.ts
+++ b/src/payload/collections/Testimonials/config.ts
@@ -1,9 +1,18 @@
 import type { CollectionConfig } from "payload";
-import { authenticated } from "@/access/authenticated";
-import { authenticatedOrPublished } from "@/access/authenticatedOrPublished";
+import { isAdmin } from "@/access/isAdmin";
+import { publishedOnly } from "@/access/publishedOnly";
 
 export const Testimonials: CollectionConfig = {
   slug: "testimonials",
+
+  //* Access Settings
+  access: {
+    create: isAdmin,
+    delete: isAdmin,
+    read: publishedOnly,
+    readVersions: isAdmin,
+    update: isAdmin,
+  },
 
   //* Collection Fields
   fields: [
@@ -75,12 +84,7 @@ export const Testimonials: CollectionConfig = {
   ],
 
   //* Admin Settings
-  access: {
-    create: authenticated,
-    delete: authenticated,
-    read: authenticatedOrPublished,
-    update: authenticated,
-  },
+
   admin: {
     description: "Kind clients saying kind things.",
     defaultColumns: ["title", "callout", "author"],

--- a/src/payload/collections/Work/config.ts
+++ b/src/payload/collections/Work/config.ts
@@ -1,6 +1,6 @@
 import type { CollectionConfig } from "payload";
-import { authenticated } from "@/access/authenticated";
-import { authenticatedOrPublished } from "@/access/authenticatedOrPublished";
+import { isAdmin } from "@/access/isAdmin";
+import { publishedOnly } from "@/access/publishedOnly";
 import { slugField } from "@/fields/slug";
 
 import {
@@ -13,6 +13,15 @@ import {
 
 export const Work: CollectionConfig = {
   slug: "work",
+
+  //* Access Settings
+  access: {
+    create: isAdmin,
+    delete: isAdmin,
+    read: publishedOnly,
+    readVersions: isAdmin,
+    update: isAdmin,
+  },
 
   //* Collection Fields
   fields: [
@@ -138,12 +147,7 @@ export const Work: CollectionConfig = {
   ],
 
   //* Admin Settings
-  access: {
-    create: authenticated,
-    delete: authenticated,
-    read: authenticatedOrPublished,
-    update: authenticated,
-  },
+
   admin: {
     useAsTitle: "title",
     description: "All we do is work, work, work.",


### PR DESCRIPTION
### TL;DR

Updated access control for all collections to use `isAdmin` and `publishedOnly` functions.

### What changed?

- Replaced `authenticated` and `authenticatedOrPublished` access controls with `isAdmin` and `publishedOnly` across all collections.
- Added explicit access control settings for create, delete, read, readVersions, and update operations.
- Removed unused imports related to the old access control methods.
- Standardized the structure of access control settings across all collections.

### How to test?

1. Log in as an admin user and verify that you can create, read, update, and delete items in all collections.
2. Log in as a non-admin user and verify that you can only read published items.
3. Test the readVersions access by attempting to view version history as both admin and non-admin users.
4. Ensure that public access is limited to reading published items only.

### Why make this change?

This change improves the security and consistency of access control across all collections. By using `isAdmin` for create, update, and delete operations, we ensure that only authorized users can modify content. The `publishedOnly` function for read operations allows public access to published content while restricting access to draft or unpublished items. This standardized approach simplifies maintenance and reduces the risk of accidental permission misconfigurations.