### PR TITLE
chore(cms): move globals folder and update access controls

### DIFF
--- a/src/globals/Footer/index.tsx
+++ b/src/globals/Footer/index.tsx
@@ -1,7 +1,13 @@
 import type { GlobalConfig } from "payload";
-
+import { isAdmin } from "@/access/isAdmin";
 export const Footer: GlobalConfig = {
   slug: "footer",
+
+  //* Admin Settings
+  access: {
+    read: () => true,
+    update: isAdmin,
+  },
 
   //* Global Fields
   fields: [
@@ -23,9 +29,4 @@ export const Footer: GlobalConfig = {
       },
     },
   ],
-
-  //* Admin Settings
-  access: {
-    read: () => true,
-  },
 };

--- a/src/globals/Header/index.tsx
+++ b/src/globals/Header/index.tsx
@@ -1,7 +1,14 @@
 import type { GlobalConfig } from "payload";
+import { isAdmin } from "@/access/isAdmin";
 
 export const Header: GlobalConfig = {
   slug: "header",
+
+  //* Access Settings
+  access: {
+    read: () => true,
+    update: isAdmin,
+  },
 
   //* Global Fields
   fields: [
@@ -23,9 +30,4 @@ export const Header: GlobalConfig = {
       ],
     },
   ],
-
-  //* Admin Settings
-  access: {
-    read: () => true,
-  },
 };

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -28,8 +28,8 @@ import { Users } from "@/collections/Users/config";
 import { Work } from "@/collections/Work/config";
 
 //* Import Globals
-import { Header } from "./payload/globals/Header/index";
-import { Footer } from "./payload/globals/Footer/index";
+import { Header } from "./globals/Header/index";
+import { Footer } from "./globals/Footer/index";
 
 //* Import Types
 import { Page, Post } from "@/payload-types";


### PR DESCRIPTION
### TL;DR

Updated access control for Header and Footer globals and relocated their files.

### What changed?

- Moved Header and Footer global configurations from `src/payload/globals/` to `src/globals/`
- Added `update` access control to both Header and Footer, restricting updates to admin users
- Imported `isAdmin` function for access control
- Reordered the access settings in both files to appear before the fields

### How to test?

1. Verify that the Header and Footer globals are still accessible in the admin panel
2. Log in as a non-admin user and attempt to update the Header or Footer globals
3. Log in as an admin user and confirm that you can update the Header and Footer globals
4. Ensure that the application still functions correctly with the new file locations

### Why make this change?

This change improves security by restricting updates to Header and Footer globals to admin users only. It also reorganizes the file structure for better maintainability and consistency. The relocation of files helps to streamline the project structure and make it easier to manage global configurations.