### PR TITLE
feat(utils): add formatPermalink to handle breadcrumbs

### DIFF
--- a/src/utilities/formatPermalink.js
+++ b/src/utilities/formatPermalink.js
@@ -1,0 +1,33 @@
+// cannot use ts here, for nodejs sitemap and redirects module
+// this means we have to send through the 'currentCategory' which is a url param not accessible within node
+
+export const formatPermalink = (reference) => {
+  let permalink = "";
+
+  const { relationTo, value } = reference;
+
+  if (typeof value === "object" && value !== null) {
+    const { slug: referenceSlug, breadcrumbs } = value;
+
+    // pages could be nested, so use breadcrumbs
+    if (relationTo === "pages") {
+      if (breadcrumbs) {
+        const { url: lastCrumbURL = "" } =
+          breadcrumbs?.[breadcrumbs.length - 1] || {}; // last crumb
+        permalink = lastCrumbURL;
+      } else {
+        permalink = referenceSlug;
+      }
+    }
+
+    if (relationTo !== "pages") {
+      permalink = `/${relationTo}/${referenceSlug}`;
+
+      if (relationTo === "media") {
+        permalink = value.url;
+      }
+    }
+  }
+
+  return permalink;
+};


### PR DESCRIPTION
### TL;DR

Added a new utility function `formatPermalink` to handle permalink generation for different types of references.

### What changed?

- Created a new file `src/utilities/formatPermalink.js`
- Implemented the `formatPermalink` function to generate permalinks based on the reference type and structure
- Handled different scenarios for pages, media, and other relation types
- Utilized breadcrumbs for nested pages to generate accurate permalinks

### How to test?

1. Import the `formatPermalink` function in a component or utility where permalinks are needed
2. Pass different types of references to the function, including:
   - Pages with and without breadcrumbs
   - Media references
   - Other relation types
3. Verify that the generated permalinks are correct for each case

### Why make this change?

This utility function centralizes permalink generation logic, ensuring consistency across the application. It handles various scenarios, including nested pages and different relation types, making it easier to manage and maintain permalink creation throughout the project.