### PR TITLE
feat(utils): add helper util to format page paths and preview urls

### DIFF
--- a/src/utilities/formatPagePath.ts
+++ b/src/utilities/formatPagePath.ts
@@ -1,0 +1,32 @@
+export const formatPagePath = (
+  collection: string,
+  doc: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+): string => {
+  const { slug, breadcrumbs } = doc;
+
+  const nestedSlug = breadcrumbs?.slice(-1)?.[0]?.url;
+
+  let prefix = "";
+  const slugPath = nestedSlug ?? `/${slug}`;
+
+  if (collection) {
+    switch (collection) {
+      case "pages":
+        prefix = "";
+        break;
+      case "posts":
+        prefix = "/blog";
+        break;
+      case "work":
+        prefix = "/work";
+        break;
+      case "play":
+        prefix = "/play";
+        break;
+      default:
+        prefix = `/${collection}`;
+    }
+  }
+
+  return `${prefix}${slugPath}`;
+};

--- a/src/utilities/formatPreviewURL.ts
+++ b/src/utilities/formatPreviewURL.ts
@@ -1,0 +1,11 @@
+import { formatPagePath } from "./formatPagePath";
+
+export const formatPreviewURL = (
+  collection: string,
+  doc: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+): string => {
+  return `${process.env.NEXT_PUBLIC_SITE_URL}/api/preview?url=${formatPagePath(
+    collection,
+    doc,
+  )}&secret=${process.env.NEXT_PRIVATE_DRAFT_SECRET}`;
+};


### PR DESCRIPTION
### TL;DR

Added utility functions for formatting page paths and preview URLs.

### What changed?

- Created `formatPagePath.ts` to generate page paths based on collection and document properties.
- Created `formatPreviewURL.ts` to construct preview URLs using the formatted page path.

### How to test?

1. Import and use `formatPagePath` function with different collections and document objects.
2. Test `formatPreviewURL` function by providing various collections and documents.
3. Verify that the generated paths and URLs are correct for different scenarios (pages, posts, work, play, and custom collections).

### Why make this change?

These utility functions standardize the creation of page paths and preview URLs across the application. They handle different collections and nested slugs, ensuring consistent URL generation for various content types. This change improves code reusability and maintainability when dealing with dynamic routing and content previews.