### PR TITLE
feat(utils): add util to help format slug

### DIFF
--- a/src/utilities/formatSlug.ts
+++ b/src/utilities/formatSlug.ts
@@ -1,0 +1,27 @@
+import type { FieldHook } from "payload";
+
+const format = (val: string): string =>
+  val
+    .replace(/ /g, "-")
+    .replace(/[^\w-]+/g, "")
+    .toLowerCase();
+
+const formatSlug =
+  (fallback: string): FieldHook =>
+  ({ operation, value, originalDoc, data }) => {
+    if (typeof value === "string") {
+      return format(value);
+    }
+
+    if (operation === "create") {
+      const fallbackData = data?.[fallback] || originalDoc?.[fallback];
+
+      if (fallbackData && typeof fallbackData === "string") {
+        return format(fallbackData);
+      }
+    }
+
+    return value;
+  };
+
+export default formatSlug;


### PR DESCRIPTION
### TL;DR

Added a new utility function `formatSlug` for generating URL-friendly slugs.

### What changed?

- Created a new file `src/utilities/formatSlug.ts`
- Implemented a `format` function that converts strings to lowercase, replaces spaces with hyphens, and removes non-alphanumeric characters
- Developed a `formatSlug` function that acts as a field hook for Payload CMS
- The `formatSlug` function handles both create and update operations, falling back to a specified field if no slug is provided during creation

### How to test?

1. Import the `formatSlug` function in a Payload CMS collection configuration
2. Apply it as a hook to a slug field, specifying a fallback field (e.g., title)
3. Create a new document without providing a slug, and verify that it generates one from the fallback field
4. Update an existing document with a new slug value, and confirm it's properly formatted

### Why make this change?

This utility function enhances the content management experience by:
- Ensuring consistent and SEO-friendly URL slugs across the application
- Automating slug generation when creating new content
- Allowing manual overrides while maintaining proper formatting
- Improving code reusability by centralizing slug formatting logic