### PR TITLE
feat(home): add two new sections to explore alternate layouts

### DIFF
--- a/src/app/(frontend)/(inner)/home/page.tsx
+++ b/src/app/(frontend)/(inner)/home/page.tsx
@@ -899,6 +899,103 @@ export default function Home() {
           </div>
         </div>
       </section>
+      <section className="h-[37.50rem] w-screen bg-white p-6 text-black min-[576px]:h-[33.13rem] min-[992px]:h-screen min-[992px]:min-h-[34.38rem] min-[992px]:p-12 min-[1200px]:min-h-[40.63rem] min-[1200px]:p-20 min-[1600px]:min-h-[46.88rem] min-[1600px]:p-24">
+        <div className="relative h-full w-full overflow-hidden bg-gray-800 text-white">
+          <div className="flex h-full w-full items-center justify-center">
+            <div className="relative flex h-full w-full items-center justify-center overflow-hidden">
+              <video className="h-auto w-[55.31rem] max-w-[17.50rem] object-contain min-[576px]:max-w-[21.25rem] md:max-w-[31.06rem] min-[992px]:max-w-[37.63rem] min-[1200px]:max-w-[44.38rem] min-[1600px]:max-w-[55.31rem]">
+                <source
+                  src="https://1minus1-2021.s3.eu-west-2.amazonaws.com/playground_games_d668388ab5.webm"
+                  type="video/webm"
+                />
+                <source
+                  src="https://1minus1-2021.s3.eu-west-2.amazonaws.com/playground_games_ed3cb8c0ea.mp4"
+                  type="video/mp4"
+                />
+              </video>
+            </div>
+            <aside className="absolute bottom-[1.88rem] left-[1.88rem] z-[3] w-80 max-w-[14.38rem] md:bottom-[2.50rem] md:left-[2.50rem] md:w-[33%] md:max-w-[15.63rem] min-[992px]:bottom-[3.13rem] min-[992px]:left-[3.13rem] min-[992px]:w-96 min-[1600px]:bottom-[6.25rem] min-[1600px]:left-[6.25rem]">
+              <h4 className="mb-1.5 text-4xl">Playground Games</h4>
+              <p className="text-neutral-500">
+                Scalable content managed website for the Microsoft games studio.
+                <a className="text-black" href="https://1minus1.com/projects">
+                  View projects
+                </a>
+              </p>
+            </aside>
+          </div>
+        </div>
+      </section>
+      <section className="relative bg-stone-50 py-36 text-[0.63rem] uppercase">
+        <h1 className="m-auto grid w-full max-w-[96.90rem] grid-cols-[repeat(36,_minmax(0px,_1fr))] grid-rows-[220px_195px_195px] text-[16rem] leading-none text-black">
+          <div
+            className="col-start-12"
+            style={{
+              gridColumnEnd: "span 12",
+            }}
+          >
+            TAKING
+          </div>
+          <div
+            className="col-start-7"
+            style={{
+              gridColumnEnd: "span 12",
+            }}
+          >
+            BRANDS
+          </div>
+          <div
+            className="col-start-11"
+            style={{
+              gridColumnEnd: "span 12",
+            }}
+          >
+            FURTHER
+          </div>
+        </h1>
+        <div className="m-auto grid w-full max-w-[96.90rem] grid-cols-[repeat(36,_minmax(0px,_1fr))] text-lg font-medium text-black">
+          <div
+            className="absolute bottom-0 left-0 pb-20"
+            style={{
+              gridColumn: "2 / span 10",
+            }}
+          >
+            <div className="w-32">
+              <div>A digital</div>
+              <div>first</div>
+              <div>design studio</div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section className="bg-stone-50 py-36 text-black">
+        <div className="mx-auto w-full max-w-[96.90rem] px-4">
+          <div className="max-w-5xl">
+            <p className="mb-8 text-7xl leading-none">
+              Through strategy, innovation and creativity we take your brand on
+              a journey of discovery and transformation creating emotional
+              experiences that leave a lasting impression and drive behaviour.
+            </p>
+            <a
+              className="border-3 relative mt-10 inline-flex h-16 items-center overflow-hidden rounded-full border-solid border-black bg-black px-10 text-xl font-medium text-stone-50 transition-colors hover:bg-stone-50 hover:text-black"
+              href="https://outpost.design/about"
+            >
+              <span className="mr-4">About us</span>
+              <svg
+                className="h-auto w-4"
+                fill="none"
+                viewBox="0 0 15 13"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.02 0.535156L12.18 5.73516L0 5.73516L0 7.15516L12.24 7.15516L7.02 12.4152H9L14.92 6.47516L9 0.535156L7.02 0.535156Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </a>
+          </div>
+        </div>
+      </section>
     </>
   );
 }


### PR DESCRIPTION
### TL;DR

Added new sections to the Home page, including a video showcase, a large text display, and an "About Us" section.

### What changed?

- Introduced a new video section featuring Playground Games, with responsive sizing and an informative aside.
- Added a large text display section with the phrase "TAKING BRANDS FURTHER" in a grid layout.
- Included a new "About Us" section with a brief description and a call-to-action button.

### How to test?

1. Navigate to the Home page.
2. Scroll down to view the new Playground Games video section.
3. Continue scrolling to see the large text display "TAKING BRANDS FURTHER".
4. Check the "About Us" section for correct text and button functionality.
5. Verify responsiveness across different screen sizes for all new sections.

### Why make this change?

These additions enhance the Home page by:
- Showcasing a specific project (Playground Games) to demonstrate the company's capabilities.
- Creating a visually striking text display to reinforce the company's mission.
- Providing more information about the company and encouraging user engagement through the "About Us" section.