### PR TITLE
feat(dev): add GridGuide component in dev mode for greater ease of design work

### DIFF
--- a/src/app/(frontend)/(inner)/layout.tsx
+++ b/src/app/(frontend)/(inner)/layout.tsx
@@ -3,6 +3,7 @@ import "@styles/globals.css";
 import { Metadata } from "next";
 import Header from "@components/Header/index";
 import Footer from "@components/Footer/index";
+import { GridGuide } from "@components/GridGuide/index";
 
 export const metadata: Metadata = {
   title: "Inner Pages",
@@ -42,10 +43,9 @@ export default function InnerLayout({
     <html lang="en" className={`${DMSans.variable} ${BebasNeue.variable}`}>
       <body className="bg-gray-950 text-gray-50 antialiased">
         <Header />
-
         <main className="min-h-screen">{children}</main>
-
         <Footer />
+        <GridGuide />
       </body>
     </html>
   );

--- a/src/app/(frontend)/(inner)/work/ideas/page.tsx
+++ b/src/app/(frontend)/(inner)/work/ideas/page.tsx
@@ -1,0 +1,3 @@
+export default function IdeasPage() {
+  return <div>IdeasPage</div>;
+}

--- a/src/components/GridGuide/index.tsx
+++ b/src/components/GridGuide/index.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+export const GridGuide = ({
+  gap = 4,
+  color = "blue",
+  opacity = 5,
+  maxWidth = "1536px",
+}) => {
+  // Only render in development mode and when NEXT_PUBLIC_SHOW_GRID_GUIDE is true
+  if (
+    process.env.NODE_ENV !== "development" ||
+    process.env.NEXT_PUBLIC_SHOW_GRID_GUIDE !== "true"
+  ) {
+    return null;
+  }
+
+  return (
+    <div
+      className="pointer-events-none fixed inset-0 left-0 right-0 z-50 mx-auto"
+      style={{ maxWidth }}
+    >
+      <div className={`grid h-full grid-cols-12 gap-${gap}`}>
+        {Array.from({ length: 12 }).map((_, index) => (
+          <div key={index} className="relative h-full">
+            <div
+              className={`absolute inset-0 bg-${color}-500`}
+              style={{ opacity: opacity / 100 }}
+            />
+            <div
+              className={`absolute bottom-4 left-0 right-0 flex justify-center text-${color}-500 font-bold`}
+              style={{ opacity: 0.8 }}
+            >
+              {index + 1}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -178,13 +178,6 @@ export default function Header() {
         }`}
       >
         <div className="relative m-2 flex h-[calc(100vh-1rem)] w-[calc(100vw-1rem)] flex-col justify-between overflow-hidden rounded-md bg-brand-dark-surface p-6">
-          <Image
-            src="/static.gif"
-            alt="Static GIF"
-            fill
-            className="object-cover opacity-[0.01]"
-            unoptimized
-          />
           <div className="relative z-10 flex justify-end">
             <button
               onClick={toggleMenu}


### PR DESCRIPTION
### TL;DR

Added a GridGuide component for development, created an IdeasPage, and made minor layout adjustments.

### What changed?

- Introduced a new `GridGuide` component for visual guidance during development
- Created a new `IdeasPage` component for the work/ideas route
- Added `GridGuide` to the inner layout
- Removed the static GIF background from the Header component

### How to test?

1. Set the `NEXT_PUBLIC_SHOW_GRID_GUIDE` environment variable to "true"
2. Run the application in development mode
3. Verify that the grid guide appears on all inner pages
4. Navigate to the `/work/ideas` route and confirm the new page is accessible
5. Check that the Header no longer displays the static GIF background

### Why make this change?

The GridGuide component provides developers with a visual reference for layout and spacing, improving the consistency of the design implementation. The new IdeasPage sets up the structure for future content related to work ideas. Removing the static GIF from the Header simplifies the component and potentially improves performance.