### PR TITLE
feat(ui): add Gutter component to give spacing to blocks

### DIFF
--- a/src/app/(frontend)/(home)/layout.tsx
+++ b/src/app/(frontend)/(home)/layout.tsx
@@ -1,6 +1,7 @@
 import localFont from "next/font/local";
 import "@styles/globals.css";
 import { Metadata, Viewport } from "next";
+import { GridGuide } from "@components/GridGuide/index";
 
 export const viewport: Viewport = {
   width: "device-width",
@@ -59,6 +60,7 @@ export default function RootLayout({
     <html lang="en" className={`${DMSans.variable}`}>
       <body className="bg-gray-950 text-gray-50 antialiased">
         <main className="flex min-h-svh flex-col">{children}</main>
+        <GridGuide />
       </body>
     </html>
   );

--- a/src/components/GridGuide/index.tsx
+++ b/src/components/GridGuide/index.tsx
@@ -1,9 +1,11 @@
-import React from "react";
+"use client";
+
+import React, { useEffect, useState } from "react";
 
 export const GridGuide = ({
-  gap = 4,
-  color = "blue",
-  opacity = 5,
+  gap = 2,
+  columnColor = "blue",
+  opacity = 3,
   maxWidth = "1536px",
 }) => {
   // Only render in development mode and when NEXT_PUBLIC_SHOW_GRID_GUIDE is true
@@ -16,24 +18,29 @@ export const GridGuide = ({
 
   return (
     <div
-      className="pointer-events-none fixed inset-0 left-0 right-0 z-50 mx-auto"
+      className="pointer-events-none fixed inset-0 z-50 mx-auto"
       style={{ maxWidth }}
     >
-      <div className={`grid h-full grid-cols-12 gap-${gap}`}>
-        {Array.from({ length: 12 }).map((_, index) => (
-          <div key={index} className="relative h-full">
-            <div
-              className={`absolute inset-0 bg-${color}-500`}
-              style={{ opacity: opacity / 100 }}
-            />
-            <div
-              className={`absolute bottom-4 left-0 right-0 flex justify-center text-${color}-500 font-bold`}
-              style={{ opacity: 0.8 }}
-            >
-              {index + 1}
+      <div className="h-full bg-transparent">
+        <div
+          className={`grid h-full grid-cols-12 gap-${gap}`}
+          style={{ backgroundColor: `rgba(255, 0, 0, ${opacity / 100})` }}
+        >
+          {Array.from({ length: 12 }).map((_, index) => (
+            <div key={index} className="relative h-full">
+              <div
+                className={`absolute inset-0 bg-${columnColor}-500`}
+                style={{ opacity: opacity / 100 }}
+              />
+              <div
+                className={`absolute bottom-4 left-0 right-0 flex justify-center text-${columnColor}-500 font-bold`}
+                style={{ opacity: 0.8 }}
+              >
+                {index + 1}
+              </div>
             </div>
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/components/Gutter/index.tsx
+++ b/src/components/Gutter/index.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+type Props = {
+  children: React.ReactNode;
+  className?: string;
+  dataTheme?: string;
+  disableMobile?: boolean;
+  leftGutter?: boolean;
+  rightGutter?: boolean;
+  ref?: React.MutableRefObject<any>;
+};
+
+export const Gutter: React.FC<Props> = ({
+  children,
+  className,
+  dataTheme,
+  disableMobile,
+  leftGutter = true,
+  rightGutter = true,
+  ref: refFromProps,
+}) => {
+  return (
+    <div
+      className={` ${className || ""} ${leftGutter ? "pl-[var(--gutter-h)]" : ""} ${rightGutter ? "pr-[var(--gutter-h)]" : ""} ${disableMobile ? "md:px-0" : ""} `.trim()}
+      data-theme={dataTheme}
+      ref={refFromProps || null}
+    >
+      {children}
+    </div>
+  );
+};


### PR DESCRIPTION
### TL;DR

Enhanced grid guide component and added a new Gutter component for layout control.

### What changed?

- Updated the GridGuide component:
  - Added client-side rendering
  - Adjusted default props (gap, columnColor, opacity)
  - Improved grid visualization with background color
- Integrated GridGuide into the root layout
- Created a new Gutter component for flexible padding control

### How to test?

1. Run the application in development mode
2. Verify the GridGuide is visible and correctly displays the 12-column layout
3. Check that the Gutter component applies correct padding when used in layouts
4. Test the Gutter component with different prop combinations (leftGutter, rightGutter, disableMobile)

### Why make this change?

These changes improve the development experience by providing better visual guides for layout design and introducing a flexible padding system. The GridGuide enhancement allows for easier alignment of elements to the grid, while the Gutter component offers a consistent way to manage horizontal spacing across the application.