### PR TITLE
feat(cms): update RichText component with CVA and improved styling

### DIFF
--- a/src/components/RichText/nodeFormat.tsx
+++ b/src/components/RichText/nodeFormat.tsx
@@ -1,5 +1,36 @@
-// Constants for text formatting
-// These use bitwise flags for efficient storage and checking of multiple formats
+// @ts-nocheck
+//This copy-and-pasted from lexical here: https://github.com/facebook/lexical/blob/c2ceee223f46543d12c574e62155e619f9a18a5d/packages/lexical/src/LexicalConstants.ts
+
+import type { ElementFormatType, TextFormatType } from "lexical";
+import type {
+  TextDetailType,
+  TextModeType,
+} from "lexical/nodes/LexicalTextNode";
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+// DOM
+export const DOM_ELEMENT_TYPE = 1;
+export const DOM_TEXT_TYPE = 3;
+
+// Reconciling
+export const NO_DIRTY_NODES = 0;
+export const HAS_DIRTY_NODES = 1;
+export const FULL_RECONCILE = 2;
+
+// Text node modes
+export const IS_NORMAL = 0;
+export const IS_TOKEN = 1;
+export const IS_SEGMENTED = 2;
+// IS_INERT = 3
+
+// Text node formatting
 export const IS_BOLD = 1;
 export const IS_ITALIC = 1 << 1;
 export const IS_STRIKETHROUGH = 1 << 2;
@@ -7,8 +38,99 @@ export const IS_UNDERLINE = 1 << 3;
 export const IS_CODE = 1 << 4;
 export const IS_SUBSCRIPT = 1 << 5;
 export const IS_SUPERSCRIPT = 1 << 6;
+export const IS_HIGHLIGHT = 1 << 7;
 
-// Type definition for a text node in the Lexical structure
+export const IS_ALL_FORMATTING =
+  IS_BOLD |
+  IS_ITALIC |
+  IS_STRIKETHROUGH |
+  IS_UNDERLINE |
+  IS_CODE |
+  IS_SUBSCRIPT |
+  IS_SUPERSCRIPT |
+  IS_HIGHLIGHT;
+
+// Text node details
+export const IS_DIRECTIONLESS = 1;
+export const IS_UNMERGEABLE = 1 << 1;
+
+// Element node formatting
+export const IS_ALIGN_LEFT = 1;
+export const IS_ALIGN_CENTER = 2;
+export const IS_ALIGN_RIGHT = 3;
+export const IS_ALIGN_JUSTIFY = 4;
+export const IS_ALIGN_START = 5;
+export const IS_ALIGN_END = 6;
+
+// Reconciliation
+export const NON_BREAKING_SPACE = "\u00A0";
+const ZERO_WIDTH_SPACE = "\u200b";
+
+export const DOUBLE_LINE_BREAK = "\n\n";
+
+// For FF, we need to use a non-breaking space, or it gets composition
+// in a stuck state.
+
+const RTL = "\u0591-\u07FF\uFB1D-\uFDFD\uFE70-\uFEFC";
+const LTR =
+  "A-Za-z\u00C0-\u00D6\u00D8-\u00F6" +
+  "\u00F8-\u02B8\u0300-\u0590\u0800-\u1FFF\u200E\u2C00-\uFB1C" +
+  "\uFE00-\uFE6F\uFEFD-\uFFFF";
+
+export const RTL_REGEX = new RegExp("^[^" + LTR + "]*[" + RTL + "]");
+
+export const LTR_REGEX = new RegExp("^[^" + RTL + "]*[" + LTR + "]");
+
+export const TEXT_TYPE_TO_FORMAT: Record<TextFormatType | string, number> = {
+  bold: IS_BOLD,
+  code: IS_CODE,
+  highlight: IS_HIGHLIGHT,
+  italic: IS_ITALIC,
+  strikethrough: IS_STRIKETHROUGH,
+  subscript: IS_SUBSCRIPT,
+  superscript: IS_SUPERSCRIPT,
+  underline: IS_UNDERLINE,
+};
+
+export const DETAIL_TYPE_TO_DETAIL: Record<TextDetailType | string, number> = {
+  directionless: IS_DIRECTIONLESS,
+  unmergeable: IS_UNMERGEABLE,
+};
+
+export const ELEMENT_TYPE_TO_FORMAT: Record<
+  Exclude<ElementFormatType, "">,
+  number
+> = {
+  center: IS_ALIGN_CENTER,
+  end: IS_ALIGN_END,
+  justify: IS_ALIGN_JUSTIFY,
+  left: IS_ALIGN_LEFT,
+  right: IS_ALIGN_RIGHT,
+  start: IS_ALIGN_START,
+};
+
+export const ELEMENT_FORMAT_TO_TYPE: Record<number, ElementFormatType> = {
+  [IS_ALIGN_CENTER]: "center",
+  [IS_ALIGN_END]: "end",
+  [IS_ALIGN_JUSTIFY]: "justify",
+  [IS_ALIGN_LEFT]: "left",
+  [IS_ALIGN_RIGHT]: "right",
+  [IS_ALIGN_START]: "start",
+};
+
+export const TEXT_MODE_TO_TYPE: Record<TextModeType, 0 | 1 | 2> = {
+  normal: IS_NORMAL,
+  segmented: IS_SEGMENTED,
+  token: IS_TOKEN,
+};
+
+export const TEXT_TYPE_TO_MODE: Record<number, TextModeType> = {
+  [IS_NORMAL]: "normal",
+  [IS_SEGMENTED]: "segmented",
+  [IS_TOKEN]: "token",
+};
+
+// Type definitions for Lexical nodes
 export type TextNode = {
   type: "text";
   text: string;
@@ -16,7 +138,6 @@ export type TextNode = {
   version: number;
 };
 
-// Type definition for an element node in the Lexical structure
 export type ElementNode = {
   type:
     | "root"
@@ -36,5 +157,4 @@ export type ElementNode = {
   url?: string; // Used for links
 };
 
-// Union type for all possible Lexical nodes
 export type LexicalNode = TextNode | ElementNode;


### PR DESCRIPTION
### TL;DR

Refactored the RichText component to use class-variance-authority for styling and improved content rendering.

### What changed?

- Introduced `class-variance-authority` for managing component variants
- Added `colorLinks`, `enableGutter`, and `enableProse` as configurable props
- Improved content rendering logic to handle both string and object content
- Implemented HTML entity decoding for string content
- Removed console logging and error handling, opting for cleaner code
- Updated type definitions and imports

### How to test?

1. Render the RichText component with various prop combinations:
   - Different `content` types (string and object)
   - Toggle `colorLinks`, `enableGutter`, and `enableProse` props
2. Verify that the component renders correctly for all scenarios
3. Check that links are properly styled when `colorLinks` is true
4. Ensure that gutter and prose styles are applied correctly based on their respective props
5. Test with both valid and invalid content to ensure proper handling

### Why make this change?

This refactoring improves the flexibility and maintainability of the RichText component. By using class-variance-authority, we can more easily manage different style variants. The improved content rendering logic allows for better handling of different content types, making the component more versatile. These changes should result in a more robust and easier-to-use component for displaying rich text content.