### PR TITLE
fix: update hardcoded line in slug index affecting importmap

### DIFF
--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -27,7 +27,7 @@ import { MetaTitleComponent as MetaTitleComponent_25 } from '@payloadcms/plugin-
 import { MetaImageComponent as MetaImageComponent_26 } from '@payloadcms/plugin-seo/client'
 import { MetaDescriptionComponent as MetaDescriptionComponent_27 } from '@payloadcms/plugin-seo/client'
 import { PreviewComponent as PreviewComponent_28 } from '@payloadcms/plugin-seo/client'
-import { SlugComponent as SlugComponent_29 } from '@fields/slug/SlugComponent'
+import { SlugComponent as SlugComponent_29 } from '@/fields/slug/SlugComponent'
 import { BlocksFeatureClient as BlocksFeatureClient_30 } from '@payloadcms/richtext-lexical/client'
 
 export const importMap = {
@@ -60,6 +60,6 @@ export const importMap = {
   "@payloadcms/plugin-seo/client#MetaImageComponent": MetaImageComponent_26,
   "@payloadcms/plugin-seo/client#MetaDescriptionComponent": MetaDescriptionComponent_27,
   "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_28,
-  "@fields/slug/SlugComponent#SlugComponent": SlugComponent_29,
+  "@/fields/slug/SlugComponent#SlugComponent": SlugComponent_29,
   "@payloadcms/richtext-lexical/client#BlocksFeatureClient": BlocksFeatureClient_30
 }

--- a/src/fields/slug/index.ts
+++ b/src/fields/slug/index.ts
@@ -44,7 +44,7 @@ export const slugField: Slug = (fieldToUse = "title", overrides = {}) => {
       ...(slugOverrides?.admin || {}),
       components: {
         Field: {
-          path: "@fields/slug/SlugComponent#SlugComponent",
+          path: "@/fields/slug/SlugComponent#SlugComponent",
           clientProps: {
             fieldToUse,
             checkboxFieldPath: checkBoxField.name,


### PR DESCRIPTION
### TL;DR

Updated import path for SlugComponent and its reference in the admin import map.

### What changed?

- Modified the import statement for SlugComponent in `src/app/(payload)/admin/importMap.js` to use an absolute path starting with `@/`.
- Updated the corresponding entry in the `importMap` object to reflect the new import path.
- In `src/fields/slug/index.ts`, updated the `path` property for the SlugComponent to use the new absolute path.

### How to test?

1. Ensure the application builds successfully without any import errors.
2. Navigate to the admin panel and verify that the slug field functionality works as expected in relevant content types.
3. Create or edit an item with a slug field and confirm that the SlugComponent renders and behaves correctly.

### Why make this change?

This change standardizes the import path for the SlugComponent, using an absolute path starting with `@/`. This approach improves consistency in import statements across the project and may help prevent potential issues with relative path resolution in different contexts.