### PR TITLE
feat(ui): improve dark bg styling on multiple pages

### DIFF
--- a/src/app/(frontend)/(inner)/about/page.tsx
+++ b/src/app/(frontend)/(inner)/about/page.tsx
@@ -5,7 +5,7 @@ export default function About() {
   return (
     <>
       <section>
-        <div className="relative content-stretch items-start justify-start bg-neutral-900 pb-80 pl-60 pr-24 pt-64 font-light text-white">
+        <div className="relative content-stretch items-start justify-start bg-brand-dark-bg pb-80 pl-60 pr-24 pt-64 font-light text-white">
           <div className="grid-rows-auto grid-cols-[repeat(6, 1fr)] relative grid auto-cols-fr gap-4">
             <div className="col-span-4 row-start-1 row-end-2 flex h-full w-full flex-col items-start justify-start self-start font-bold uppercase">
               <div className="pb-5">+ About Our Studio</div>
@@ -53,7 +53,7 @@ export default function About() {
       </section>
 
       <section className="about-intro">
-        <div className="relative bg-gray-800 pb-12 pr-24 pt-4 text-white">
+        <div className="bg-brand-gunmetal relative pb-12 pr-24 pt-4 text-white">
           <div className="relative -mt-36 mr-24 h-[75vh] overflow-hidden">
             <Image
               src="/5ed749f69d85623011204b14_marybielskiandkevinwessa-6.1920.jpg"
@@ -64,7 +64,7 @@ export default function About() {
             />
           </div>
         </div>
-        <div className="bg-gray-800 px-24 py-48 font-light text-white">
+        <div className="bg-brand-gunmetal px-24 py-48 font-light text-white">
           <div className="m-auto max-w-[62.50rem]">
             <div className="grid grid-cols-6">
               <div className="col-start-2 col-end-6 flex flex-col items-start justify-center">
@@ -93,7 +93,7 @@ export default function About() {
         </div>
       </section>
 
-      <section className="bg-black text-white">
+      <section className="bg-brand-dark-bg text-white">
         <div className="mx-auto mb-72 max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
           <h2 className="mb-8 max-w-3xl text-4xl font-bold">
             Brewww: Where Creativity Meets Strategic Execution
@@ -127,7 +127,7 @@ export default function About() {
         </div>
       </section>
 
-      <section className="relative bg-neutral-900 px-24 py-36 font-light text-white">
+      <section className="relative bg-brand-dark-bg px-24 py-36 font-light text-white">
         <div className="relative grid auto-cols-fr grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr] grid-rows-[auto_auto_auto_auto_auto_auto] gap-4">
           <div className="col-start-3 col-end-6 row-start-1 row-end-2 flex h-full w-full flex-col items-end justify-start font-bold uppercase">
             <div className="pb-5">+ Our Values</div>
@@ -155,7 +155,7 @@ export default function About() {
         </div>
       </section>
 
-      <section className="h-full w-full bg-neutral-900 pl-0 pr-28 text-white">
+      <section className="h-full w-full bg-brand-dark-bg pl-0 pr-28 text-white">
         <div className="flex h-screen w-full max-w-full overflow-visible">
           <Image
             src="/5f53f60a0033860407ff3718_ThebyWessa2020-6960.jpg"
@@ -170,7 +170,7 @@ export default function About() {
         </div>
       </section>
 
-      <section className="bg-neutral-900 px-6 py-12 font-light text-white md:px-24 md:py-48">
+      <section className="bg-brand-dark-bg px-6 py-12 font-light text-white md:px-24 md:py-48">
         <div className="mx-auto max-w-5xl">
           <div className="grid gap-8 md:grid-cols-2 md:gap-x-12 md:gap-y-24">
             <div className="flex flex-col items-center text-center">
@@ -211,7 +211,7 @@ export default function About() {
         </div>
       </section>
 
-      <section className="cursor-none border-t-2 border-solid border-t-neutral-100/[0.23] bg-black text-[1.38rem] font-light leading-7 text-zinc-100">
+      <section className="cursor-none border-t-2 border-solid border-t-neutral-100/[0.23] bg-brand-dark-bg text-[1.38rem] font-light leading-7 text-zinc-100">
         <div className="container mx-auto py-16 lg:py-24">
           <div className="float-left mr-5 mt-1 text-sm lg:mr-8 lg:mt-3 lg:min-w-[7.50rem]">
             BREWWW

--- a/src/app/(frontend)/(inner)/blog/page.tsx
+++ b/src/app/(frontend)/(inner)/blog/page.tsx
@@ -13,7 +13,7 @@ export default async function BlogPage() {
 
   return (
     <>
-      <section className="bg-neutral-900 text-white">
+      <section className="bg-brand-dark-bg text-white">
         <div className="container mx-auto px-6 py-24">
           <div className="mx-auto flex max-w-4xl flex-col items-center justify-center text-center">
             <div className="mb-4 font-bold uppercase">+ Insights</div>
@@ -26,7 +26,7 @@ export default async function BlogPage() {
           </div>
         </div>
       </section>
-      <section className="bg-neutral-900 py-24">
+      <section className="bg-brand-dark-bg py-24">
         <div className="container mx-auto">
           <h1 className="mb-12 text-4xl font-bold text-white">Insights</h1>
           <div className="relative grid auto-rows-auto grid-cols-3 gap-8 text-sm font-semibold text-zinc-100">

--- a/src/app/(frontend)/(inner)/contact/page.tsx
+++ b/src/app/(frontend)/(inner)/contact/page.tsx
@@ -2,7 +2,7 @@ export default function Contact() {
   return (
     <>
       <section>
-        <div className="uppercase text-white min-[1600px]:pb-20 min-[1600px]:pt-20 min-[1920px]:pb-28 min-[1920px]:pt-28 min-[1921px]:pb-28 min-[1921px]:pt-28">
+        <div className="bg-brand-dark-bg uppercase text-white min-[1600px]:pb-20 min-[1600px]:pt-20 min-[1920px]:pb-28 min-[1920px]:pt-28 min-[1921px]:pb-28 min-[1921px]:pt-28">
           <div className="m-auto w-[92%] min-[1921px]:max-w-[118.75rem]">
             <div>
               <h2 className="inline-block min-[671px]:pl-6">
@@ -16,7 +16,7 @@ export default function Contact() {
           </div>
         </div>
       </section>
-      <section className="relative max-w-[156.25rem] pb-20 text-neutral-100">
+      <section className="relative max-w-[156.25rem] bg-brand-dark-bg pb-20 text-brand-dark-text">
         <div className="container mx-auto px-4">
           <div className="grid grid-cols-1 gap-[3.25rem] lg:grid-cols-2">
             <div className="w-full text-[1.38rem] leading-7">
@@ -165,7 +165,7 @@ export default function Contact() {
           </div>
         </div>
       </section>
-      <section className="relative w-full bg-black py-24 text-lg text-stone-400 md:py-32 xl:py-40">
+      <section className="relative w-full bg-brand-dark-bg py-24 text-lg text-brand-dark-text md:py-32 xl:py-40">
         <div className="container mx-auto px-4">
           <div className="relative xl:flex">
             <p className="mb-5 text-sm uppercase text-neutral-500 xl:mt-2 xl:w-28">

--- a/src/app/(frontend)/(inner)/play/page.tsx
+++ b/src/app/(frontend)/(inner)/play/page.tsx
@@ -12,7 +12,7 @@ export default async function PlayPage() {
 
   return (
     <>
-      <section className="bg-neutral-900">
+      <section className="bg-brand-dark-bg">
         <div className="container mx-auto px-4 py-24">
           <div className="max-w-[82.50rem] text-xl text-neutral-800 min-[480px]:max-w-[84.38rem] min-[720px]:max-w-[86.88rem] min-[720px]:pl-12 min-[720px]:pr-12 min-[1080px]:max-w-[89.38rem] min-[1080px]:pl-16 min-[1080px]:pr-16">
             <h1 className="mb-1 mt-28 text-[2.88rem] font-light leading-none text-white">
@@ -26,7 +26,7 @@ export default async function PlayPage() {
           </div>
         </div>
       </section>
-      <section className="py-16">
+      <section className="bg-brand-dark-bg py-16">
         <div className="container mx-auto">
           <div className="w-full px-20 text-lg text-white">
             <div>

--- a/src/app/(frontend)/(inner)/services/individual/page.tsx
+++ b/src/app/(frontend)/(inner)/services/individual/page.tsx
@@ -222,7 +222,7 @@ export default function IndividualPage() {
         </div>
       </section>
 
-      <section className="w-full bg-neutral-900 text-white min-[1600px]:pb-16 min-[1600px]:pt-20 min-[1920px]:pb-24 min-[1920px]:pt-28 min-[1921px]:pb-24 min-[1921px]:pt-28">
+      <section className="w-full bg-brand-dark-bg text-white min-[1600px]:pb-16 min-[1600px]:pt-20 min-[1920px]:pb-24 min-[1920px]:pt-28 min-[1921px]:pb-24 min-[1921px]:pt-28">
         <div className="mx-auto w-full max-w-[118.75rem] px-[4%]">
           <h3 className="inline-block text-lg uppercase min-[671px]:pl-6">
             Beautifully bespoke websites
@@ -431,7 +431,7 @@ export default function IndividualPage() {
         </div>
       </section>
 
-      <section className="bg-neutral-900 text-white min-[1600px]:pb-20 min-[1600px]:pt-20 min-[1920px]:pb-28 min-[1920px]:pt-28 min-[1921px]:pb-28 min-[1921px]:pt-28">
+      <section className="bg-brand-dark-bg text-white min-[1600px]:pb-20 min-[1600px]:pt-20 min-[1920px]:pb-28 min-[1920px]:pt-28 min-[1921px]:pb-28 min-[1921px]:pt-28">
         <div className="m-auto w-[92%] min-[769px]:flex min-[1600px]:mb-16 min-[1920px]:mb-24 min-[1921px]:mb-24 min-[1921px]:max-w-[118.75rem]">
           <div className="min-[769px]:w-[65.4737%]">
             <h6 className="inline-block text-lg uppercase min-[671px]:pl-6">
@@ -547,7 +547,7 @@ export default function IndividualPage() {
         </div>
       </section>
 
-      <section className="bg-neutral-900 text-white min-[769px]:flex min-[769px]:items-center">
+      <section className="bg-brand-dark-bg text-white min-[769px]:flex min-[769px]:items-center">
         <div className="overflow-hidden min-[769px]:w-[48.2105%]">
           <img
             className="h-auto w-full max-w-full"
@@ -576,7 +576,7 @@ export default function IndividualPage() {
         </div>
       </section>
 
-      <section className="text-white min-[1600px]:pb-20 min-[1600px]:pt-20 min-[1920px]:pb-28 min-[1920px]:pt-28 min-[1921px]:pb-28 min-[1921px]:pt-28">
+      <section className="bg-brand-dark-bg text-white min-[1600px]:pb-20 min-[1600px]:pt-20 min-[1920px]:pb-28 min-[1920px]:pt-28 min-[1921px]:pb-28 min-[1921px]:pt-28">
         <div className="m-auto w-[92%] min-[1921px]:max-w-[118.75rem]">
           <div className="min-[769px]:flex min-[769px]:items-center">
             <div className="order-1 overflow-hidden min-[769px]:ml-auto min-[769px]:w-[48.2105%]">
@@ -611,7 +611,7 @@ export default function IndividualPage() {
         </div>
       </section>
 
-      <section className="relative bg-neutral-900 text-white min-[1600px]:pb-20 min-[1600px]:pt-20 min-[1920px]:pb-28 min-[1920px]:pt-28 min-[1921px]:pb-28 min-[1921px]:pt-28">
+      <section className="relative bg-brand-dark-bg text-white min-[1600px]:pb-20 min-[1600px]:pt-20 min-[1920px]:pb-28 min-[1920px]:pt-28 min-[1921px]:pb-28 min-[1921px]:pt-28">
         <div className="m-auto w-[92%] min-[1921px]:max-w-[118.75rem]">
           <div className="min-[769px]:flex min-[769px]:items-center">
             <div className="overflow-hidden min-[769px]:w-[48.2105%]">
@@ -698,11 +698,11 @@ export default function IndividualPage() {
         </div>
       </section>
 
-      <section className="relative bg-neutral-900 text-white min-[1600px]:pb-20 min-[1600px]:pt-20 min-[1920px]:pb-28 min-[1920px]:pt-28 min-[1921px]:pb-28 min-[1921px]:pt-28">
+      <section className="relative bg-brand-dark-bg text-white min-[1600px]:pb-20 min-[1600px]:pt-20 min-[1920px]:pb-28 min-[1920px]:pt-28 min-[1921px]:pb-28 min-[1921px]:pt-28">
         <div className="m-auto w-[92%] text-center uppercase min-[1600px]:mb-16 min-[1920px]:mb-24 min-[1921px]:mb-24 min-[1921px]:max-w-[77.75rem]">
           <div>
             <h2 className="inline-block text-lg min-[671px]:pl-6">
-              Looking for a London WordPress agency?
+              Looking for a Cleveland Next JS agency?
             </h2>
 
             <h2 className="text-[8rem] font-bold leading-none lg:mt-10 min-[1025px]:mt-16">

--- a/src/app/(frontend)/(inner)/services/page.tsx
+++ b/src/app/(frontend)/(inner)/services/page.tsx
@@ -232,7 +232,7 @@ export default function ServicesPage() {
           </div>
         </div>
       </section>
-      <section className="flex min-h-[75vh] items-center bg-neutral-900 py-32 text-white">
+      <section className="flex min-h-[75vh] items-center bg-brand-dark-bg py-32 text-white">
         <div className="container mx-auto px-4">
           <h3 className="mb-8 text-lg">Digital agency services</h3>
 
@@ -367,7 +367,7 @@ export default function ServicesPage() {
         <div className="m-auto w-[92%] pt-24 min-[1921px]:max-w-[118.75rem]">
           <div className="relative">
             <div className="mb-4 flex items-center">
-              <span className="mr-2 inline-block h-2 w-2 rounded-full bg-black"></span>
+              <span className="mr-2 inline-block h-2 w-2 rounded-full bg-brand-dark-bg"></span>
               <span className="text-md font-medium uppercase">
                 Related Projects
               </span>
@@ -459,7 +459,7 @@ export default function ServicesPage() {
         </div>
       </section>
 
-      <section className="relative bg-neutral-900 text-white min-[1600px]:py-20 min-[1920px]:py-28 min-[1921px]:py-28">
+      <section className="relative bg-brand-dark-bg text-white min-[1600px]:py-20 min-[1920px]:py-28 min-[1921px]:py-28">
         <div className="m-auto w-[92%] min-[769px]:flex min-[1921px]:max-w-[118.75rem]">
           <div className="text-[3.13rem] uppercase leading-none min-[769px]:w-96">
             <p className="opacity-10">02</p>
@@ -723,7 +723,7 @@ export default function ServicesPage() {
         </div>
       </section>
 
-      <section className="relative bg-neutral-900 text-white min-[1600px]:py-20 min-[1920px]:py-28 min-[1921px]:py-28">
+      <section className="relative bg-brand-dark-bg text-white min-[1600px]:py-20 min-[1920px]:py-28 min-[1921px]:py-28">
         <div className="m-auto w-[92%] min-[769px]:flex min-[1921px]:max-w-[118.75rem]">
           <div className="text-[3.13rem] uppercase leading-none min-[769px]:w-96">
             <p className="opacity-10">04</p>
@@ -791,7 +791,7 @@ export default function ServicesPage() {
           </div>
         </div>
         <div>
-          <section className="relative overflow-hidden bg-neutral-900 text-white min-[1600px]:pb-20 min-[1600px]:pt-20 min-[1920px]:pb-28 min-[1920px]:pt-28 min-[1921px]:pb-28 min-[1921px]:pt-28">
+          <section className="relative overflow-hidden bg-brand-dark-bg text-white min-[1600px]:pb-20 min-[1600px]:pt-20 min-[1920px]:pb-28 min-[1920px]:pt-28 min-[1921px]:pb-28 min-[1921px]:pt-28">
             <div className="m-auto w-[92%] text-lg uppercase min-[1600px]:mb-10 min-[1920px]:mb-12 min-[1921px]:mb-12 min-[1921px]:max-w-[118.75rem]">
               <p className="inline-block min-[671px]:pl-6">Related Projects</p>
             </div>
@@ -887,7 +887,7 @@ export default function ServicesPage() {
         </div>
       </section>
 
-      <section className="relative grid grid-cols-[105.50rem] grid-rows-[1155px_104px] items-center justify-items-center bg-zinc-950 text-center uppercase text-neutral-400">
+      <section className="relative grid grid-cols-[105.50rem] grid-rows-[1155px_104px] items-center justify-items-center bg-brand-dark-bg text-center uppercase text-brand-dark-text">
         <span className="text-[13.00rem] font-bold leading-none text-white">
           <span>
             <span className="inline-block">

--- a/src/app/(frontend)/(inner)/why-brewww/page.tsx
+++ b/src/app/(frontend)/(inner)/why-brewww/page.tsx
@@ -602,6 +602,190 @@ export default function WhyPage() {
           </div>
         </div>
       </section>
+
+      <section className="flex min-h-[80vh] flex-col justify-between bg-black p-9 text-[2.75rem] leading-none text-white">
+        <div className="text-7xl">
+          <h1 className="max-w-4xl">
+            Our 'strategy-first' mentality is tailored for companies looking for
+            growth, change, or both. And we're ruthless when it comes to our
+            mantra 'Boring is for the Competitors'.
+          </h1>
+        </div>
+        <div className="flex items-end justify-between text-[1.38rem] leading-7">
+          <div>
+            <p className="text-xl">
+              <strong className="text-neutral-400">Latest insight: </strong>
+              <em className="cursor-pointer italic">
+                Elevating brands: Strategies for market leadership
+              </em>
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="relative h-[75vh] overflow-hidden text-stone-950">
+        <div className="absolute inset-0">
+          <picture>
+            <source srcSet="https://www.datocms-assets.com/63464/1661346969-stuurmen-office-interior.jpg?auto=format&dpr=0.25&w=2200 550w,https://www.datocms-assets.com/63464/1661346969-stuurmen-office-interior.jpg?auto=format&dpr=0.5&w=2200 1100w,https://www.datocms-assets.com/63464/1661346969-stuurmen-office-interior.jpg?auto=format&dpr=0.75&w=2200 1650w,https://www.datocms-assets.com/63464/1661346969-stuurmen-office-interior.jpg?auto=format&w=2200 2200w" />
+            <img
+              className="h-full w-full object-cover"
+              src="https://www.datocms-assets.com/63464/1661346969-stuurmen-office-interior.jpg?auto=format&w=2200"
+              alt="Stuurmen office interior"
+            />
+          </picture>
+        </div>
+        <div className="absolute inset-0 flex items-center justify-center">
+          <h2 className="text-8xl font-bold uppercase text-white">
+            Kill off the Average
+          </h2>
+        </div>
+      </section>
+
+      <section className="bg-white py-24 text-[1.38rem] leading-7 text-stone-950">
+        <div className="container mx-auto">
+          <div className="flex flex-wrap justify-between">
+            <div className="mb-16 w-full">
+              <h2 className="max-w-3xl text-7xl">
+                Our brands resonate even after they are no longer visible or
+                audible. You can still feel their presence because their message
+                settles smoothly into your brain. That's the power of premium.
+              </h2>
+            </div>
+            <div className="mt-8 w-full lg:w-1/2 lg:pr-16">
+              <div className="mb-12 text-[1.63rem] leading-8">
+                <p className="text-xl">
+                  Unleashing full potential goes beyond just design and
+                  development because success starts with the right strategy.
+                  Branding and business always go hand in hand. With this
+                  integrated approach, we transform companies into premium
+                  brands that people will fall in love with.
+                </p>
+              </div>
+              <div className="mt-16 text-xl">
+                <strong className="font-bold">Business</strong>
+                <p className="mt-4">
+                  At the core of branding lies business. That's where it all
+                  starts. We need to get to know your business as if it were our
+                  own. Through different techniques, we explore business
+                  objectives as well as business opportunities.
+                </p>
+              </div>
+              <div className="mt-16 text-xl">
+                <strong className="font-bold">Being</strong>
+                <p className="mt-4">
+                  Let's talk about the unique value that your brand has to
+                  offer, and why your clients should care. Premium brands know
+                  exactly what they stand for, and how they can use their core
+                  qualities to be a leader within their industry. We help you
+                  discover your brand's unique potential and positioning.
+                </p>
+              </div>
+              <div className="mt-16 text-xl">
+                <strong className="font-bold">Becoming</strong>
+                <p className="mt-4">
+                  Only when you know who you are can you become whatever you
+                  want. We help you translate 'business' and 'being' into a
+                  compelling brand that resonates with your target customers.
+                  The brand you always dreamt of.
+                </p>
+              </div>
+            </div>
+            <div className="relative mt-8 w-full lg:mt-0 lg:w-1/2 lg:pl-16">
+              <div className="aspect-w-16 aspect-h-9" style={{ height: "70%" }}>
+                <img
+                  className="h-full w-full object-cover"
+                  src="https://www.datocms-assets.com/63464/1661347408-stuurmen-office-interior.jpg?auto=format&h=1080&w=1920"
+                  alt="Stuurmen office interior"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-stone-950 py-24 text-stone-50">
+        <div className="container mx-auto px-6">
+          <h2 className="mb-16 text-5xl font-bold lg:text-7xl">
+            We supply a wide range of premium products and services. Always
+            tailor-made, always authentic.
+          </h2>
+          <div className="grid gap-12 md:grid-cols-2">
+            <div>
+              <h3 className="mb-4 text-3xl font-semibold">Brand strategy</h3>
+              <p className="mb-6 text-lg">
+                We help you create a strong brand foundation by exploring your
+                business goals, opportunities, market fit, and potential for
+                greatness. By helping you clarify your beliefs, strengths, and
+                desired perception among your target audience, we get a clear
+                understanding of your identity. Once you know who you are, you
+                can become whatever you want.
+              </p>
+              <ul className="text-neutral-400">
+                <li>Business strategy</li>
+                <li>Brand & Web strategy</li>
+                <li>Research & Insight</li>
+                <li>Brand & Product positioning</li>
+                <li>Naming</li>
+                <li>Concept development</li>
+              </ul>
+            </div>
+            <div>
+              <h3 className="mb-4 text-3xl font-semibold">Brand design</h3>
+              <p className="mb-6 text-lg">
+                We bring your brand to life by developing a solid base for
+                effective brand communication. This includes crafting the brand
+                narrative, tone of voice, logo, typography, colour palette and
+                more. Additionally, we will provide you with an online brand
+                book to help you utilise these assets like a pro. And to top it
+                off, we will create a plan for the next phase to maximise on
+                developing the brand experience.
+              </p>
+              <ul className="text-neutral-400">
+                <li>Creative direction</li>
+                <li>Brand narrative</li>
+                <li>Verbal & Visual identity</li>
+                <li>Systems & Guidelines</li>
+              </ul>
+            </div>
+            <div>
+              <h3 className="mb-4 text-3xl font-semibold">Brand experience</h3>
+              <p className="mb-6 text-lg">
+                We translate the brand strategy into eye-catching and
+                thought-provoking solutions that are more than just pretty to
+                look at. We aim to engage and inspire, from website and motion
+                to print and packaging. And with our plan in place from the
+                previous phase, we make sure your brand shines consistently and
+                in no-time, across all touchpoints.
+              </p>
+              <ul className="text-neutral-400">
+                <li>Web design & Development</li>
+                <li>Print & Packaging</li>
+                <li>Motion & Video</li>
+                <li>Environmental design</li>
+                <li>Copywriting & Photography</li>
+                <li>Illustration & 3D</li>
+              </ul>
+            </div>
+            <div>
+              <h3 className="mb-4 text-3xl font-semibold">Brand support</h3>
+              <p className="mb-6 text-lg">
+                Imagine your brand as a living, breathing thing, constantly
+                growing and evolving. Our brand support team is here to help you
+                maintain the relevance and consistency of your brand experience.
+                We will provide you with continuous assistance in areas like
+                content creation, design, development, social media, and SEO,
+                and tailor our services to your specific needs, so you can focus
+                on what you do best.
+              </p>
+              <ul className="text-neutral-400">
+                <li>Art direction</li>
+                <li>Planning & Consultancy</li>
+                <li>Asset development</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
     </>
   );
 }

--- a/src/app/(frontend)/(inner)/work/individual/page.tsx
+++ b/src/app/(frontend)/(inner)/work/individual/page.tsx
@@ -11,18 +11,20 @@ import AudioImageEight from "/public/images/audio-eight.jpg";
 export default function WorkIndividual() {
   return (
     <>
-      <section className="bg-zinc-950 py-40 text-center text-[11.00rem] font-bold uppercase leading-none text-neutral-400">
-        <h1 className="text-white">The Merry Beggars</h1>
-      </section>
-      <section className="mx-auto flex max-w-7xl items-center justify-between bg-zinc-950 px-4 py-2 text-sm text-white">
-        <div className="uppercase">
-          <span>Branding, Design, Development</span>
+      <section className="bg-brand-dark-bg py-40 text-center">
+        <h1 className="mb-16 text-[11.00rem] font-bold uppercase leading-none text-white">
+          The Merry Beggars
+        </h1>
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 text-sm text-white">
+          <div className="uppercase">
+            <span>Branding, Design, Development</span>
+          </div>
+          <div>
+            <span>/ 2022</span>
+          </div>
         </div>
-        <div>
-          <span>/ 2022</span>
-        </div>
       </section>
-      <section className="bg-zinc-950">
+      <section className="bg-brand-dark-bg">
         <div className="mx-auto max-w-7xl px-4 py-16">
           <div className="relative aspect-video w-full overflow-hidden rounded-lg">
             <Image
@@ -35,12 +37,12 @@ export default function WorkIndividual() {
           </div>
         </div>
       </section>
-      <section className="bg-zinc-950 py-16">
+      <section className="bg-brand-dark-bg py-16">
         <h1 className="text-center text-[7rem] font-bold uppercase leading-none text-white">
           Original Audio Entertainment for the Whole Family
         </h1>
       </section>
-      <section className="bg-zinc-950 text-neutral-400">
+      <section className="bg-brand-dark-bg text-neutral-400">
         <div className="container mx-auto px-4 py-16">
           <div className="grid grid-cols-[1fr_3fr] gap-5">
             <div className="col-start-1">
@@ -102,7 +104,7 @@ export default function WorkIndividual() {
           </div>
         </div>
       </section>
-      <section className="bg-zinc-950 text-neutral-400">
+      <section className="bg-brand-dark-bg text-neutral-400">
         <div className="container mx-auto px-4">
           <div className="flex flex-col items-end">
             <div className="mb-5 w-full max-w-[30.98rem]">
@@ -128,7 +130,7 @@ export default function WorkIndividual() {
           </div>
         </div>
       </section>
-      <section className="bg-zinc-950 py-32 text-neutral-400">
+      <section className="bg-brand-dark-bg py-32 text-neutral-400">
         <div className="container mx-auto px-4">
           <div className="flex flex-row">
             <div className="w-1/2 pr-8">
@@ -185,7 +187,7 @@ export default function WorkIndividual() {
           </div>
         </div>
       </section>
-      <section className="overflow-hidden bg-zinc-950">
+      <section className="overflow-hidden bg-brand-dark-bg">
         <div className="relative flex whitespace-nowrap">
           <div className="animate-marquee-reverse flex items-center">
             <span className="mx-4 text-[45.00rem] font-bold leading-none text-neutral-400">
@@ -208,7 +210,7 @@ export default function WorkIndividual() {
           </div>
         </div>
       </section>
-      <section className="bg-zinc-950">
+      <section className="bg-brand-dark-bg">
         <div className="container mx-auto px-4">
           <ul className="grid list-none grid-cols-[630.922px_374.844px_481.234px] grid-rows-[19.75rem] gap-5 text-neutral-400">
             <li className="list-item">
@@ -244,7 +246,7 @@ export default function WorkIndividual() {
           </ul>
         </div>
       </section>
-      <section className="bg-zinc-950 py-20 text-neutral-400">
+      <section className="bg-brand-dark-bg py-20 text-neutral-400">
         <div className="container mx-auto px-4">
           <div className="flex flex-row items-start gap-24">
             <div className="w-3/5 pt-48">
@@ -272,7 +274,7 @@ export default function WorkIndividual() {
           </div>
         </div>
       </section>
-      <section className="bg-zinc-950 py-20 text-neutral-400">
+      <section className="bg-brand-dark-bg py-20 text-neutral-400">
         <div className="container mx-auto px-4">
           <div className="flex items-start justify-between">
             <div className="flex items-center">
@@ -313,7 +315,7 @@ export default function WorkIndividual() {
           </div>
         </div>
       </section>
-      <section className="bg-zinc-950 pb-20 text-neutral-400">
+      <section className="bg-brand-dark-bg pb-20 text-neutral-400">
         <div className="container mx-auto px-4">
           <div className="grid grid-cols-1 items-center gap-8 md:grid-cols-2">
             <div className="relative">
@@ -343,7 +345,7 @@ export default function WorkIndividual() {
           </div>
         </div>
       </section>
-      <section className="bg-zinc-950 pt-20 text-neutral-400">
+      <section className="bg-brand-dark-bg pt-20 text-neutral-400">
         <div
           className="container relative mx-auto px-0"
           style={{ aspectRatio: "3/2" }}
@@ -356,7 +358,7 @@ export default function WorkIndividual() {
           />
         </div>
       </section>
-      <section className="bg-zinc-950 py-32 text-neutral-400">
+      <section className="bg-brand-dark-bg py-32 text-neutral-400">
         <div className="container mx-auto px-4">
           <div className="grid grid-cols-12">
             <div className="col-start-6 col-end-11">
@@ -382,7 +384,7 @@ export default function WorkIndividual() {
           </div>
         </div>
       </section>
-      <section className="bg-zinc-950 text-neutral-400">
+      <section className="bg-brand-dark-bg text-neutral-400">
         <div className="container mx-auto px-4">
           <div className="grid grid-cols-12 gap-8">
             <div className="col-span-7">
@@ -427,7 +429,7 @@ export default function WorkIndividual() {
           </div>
         </div>
       </section>
-      <section className="bg-zinc-950 pb-20 text-neutral-400">
+      <section className="bg-brand-dark-bg pb-20 text-neutral-400">
         <div className="container mx-auto px-4">
           <div className="grid grid-cols-1 items-center gap-8 md:grid-cols-2">
             <div className="relative">
@@ -460,7 +462,7 @@ export default function WorkIndividual() {
           </div>
         </div>
       </section>
-      <section className="relative overflow-hidden bg-zinc-950 py-20 pl-12 text-neutral-400">
+      <section className="relative overflow-hidden bg-brand-dark-bg py-20 pl-12 text-neutral-400">
         <div className="animate-slider flex space-x-12">
           <div className="relative flex-shrink-0">
             <div className="relative h-[59.63rem] w-[59.63rem]">
@@ -570,7 +572,7 @@ export default function WorkIndividual() {
           </div>
         </div>
       </section>
-      <section className="bg-zinc-950 text-neutral-400">
+      <section className="bg-brand-dark-bg text-neutral-400">
         <div className="container mx-auto px-4">
           <div className="grid grid-cols-12 gap-8">
             <div className="col-span-7">
@@ -616,7 +618,7 @@ export default function WorkIndividual() {
         </div>
       </section>
 
-      <section className="bg-zinc-950 pb-20 text-neutral-400">
+      <section className="bg-brand-dark-bg pb-20 text-neutral-400">
         <div className="container mx-auto px-4">
           <div className="grid grid-cols-1 items-center gap-8 md:grid-cols-2">
             <div className="relative">
@@ -646,7 +648,7 @@ export default function WorkIndividual() {
           </div>
         </div>
       </section>
-      <section className="bg-zinc-950 py-20 text-neutral-400">
+      <section className="bg-brand-dark-bg py-20 text-neutral-400">
         <div className="container mx-auto px-4">
           <div className="grid grid-cols-2 gap-5">
             <div className="relative" style={{ aspectRatio: "1/1" }}>
@@ -668,7 +670,7 @@ export default function WorkIndividual() {
           </div>
         </div>
       </section>
-      <section className="bg-zinc-950 py-32 text-neutral-400">
+      <section className="bg-brand-dark-bg py-32 text-neutral-400">
         <div className="container mx-auto px-4">
           <div className="grid grid-cols-12">
             <div className="col-start-6 col-end-11">
@@ -695,7 +697,7 @@ export default function WorkIndividual() {
           </div>
         </div>
       </section>
-      <section className="bg-zinc-950 pt-20 text-neutral-400">
+      <section className="bg-brand-dark-bg pt-20 text-neutral-400">
         <div
           className="container relative mx-auto px-0"
           style={{ aspectRatio: "3/2" }}

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -13,7 +13,7 @@ export default async function Footer() {
   };
   return (
     <>
-      <footer className="border-b-6 border-[#f8ac43] bg-[#060D0E] text-white">
+      <footer className="border-b-6 border-brand-gold bg-brand-dark-bg text-white">
         <div className="pt-28">
           <div className="container mx-auto max-w-4xl px-4">
             <div className="grid grid-cols-3 gap-8">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -50,9 +50,10 @@ const config: Config = {
       colors: {
         brand: {
           gold: "#f8ac43",
-          "dark-bg": "#0A0A0A",
-          "dark-surface": "#1D1D1D",
+          "dark-bg": "#010101",
+          "dark-surface": "#050609",
           "dark-text": "#E0E0E0",
+          gunmetal: "#242e2e",
           "light-bg": "#F5F5F5",
           "light-surface": "#FFFFFF",
           "light-text": "#333333",


### PR DESCRIPTION
### TL;DR

Updated color scheme across multiple pages to use brand-specific colors.

### What changed?

- Replaced hardcoded color values with brand-specific color classes
- Updated background colors to use `bg-brand-dark-bg` instead of `bg-neutral-900` or `bg-black`
- Changed text colors to use `text-brand-dark-text` where appropriate
- Introduced new brand color `brand-gunmetal`
- Updated footer border color to use `border-brand-gold`

### How to test?

1. Navigate through the following pages and verify the color changes:
   - About
   - Blog
   - Contact
   - Play
   - Services (individual and main)
   - Why Brewww
   - Work (individual)
2. Check the footer to ensure the border color is updated
3. Verify that the overall look and feel of the site remains consistent with the new color scheme

### Why make this change?

This change aims to improve brand consistency across the website by using a standardized set of colors. By utilizing Tailwind's custom color classes, we ensure a more cohesive visual identity and make it easier to maintain and update the color scheme in the future. This approach also reduces the likelihood of inconsistencies that can occur when using hardcoded color values.