### PR TITLE
feat: add initial styles page to see elements side by side

### DIFF
--- a/next-sitemap.config.cjs
+++ b/next-sitemap.config.cjs
@@ -17,5 +17,6 @@ module.exports = {
     "/work/*",
     "/why-brewww",
     "/clients",
+    "/styles",
   ],
 };

--- a/src/app/(frontend)/(inner)/clients/page.tsx
+++ b/src/app/(frontend)/(inner)/clients/page.tsx
@@ -86,7 +86,7 @@ export default async function Page() {
   }));
 
   return (
-    <section className="w-full overflow-hidden bg-black pb-10 pt-32 text-lg text-white md:pb-16 md:pt-44 min-[1250px]:pb-20 min-[1250px]:pt-48 min-[1900px]:pb-20 min-[1900px]:pt-56">
+    <section className="w-full overflow-hidden bg-brand-dark-bg pb-10 pt-32 text-lg text-white md:pb-16 md:pt-44 min-[1250px]:pb-20 min-[1250px]:pt-48 min-[1900px]:pb-20 min-[1900px]:pt-56">
       <div className="m-6 md:mx-10 min-[1250px]:mx-20 min-[1550px]:mx-auto min-[1550px]:w-full min-[1550px]:max-w-[87.50rem] min-[1900px]:max-w-screen-2xl min-[2048px]:mx-48 min-[2048px]:w-auto min-[2048px]:max-w-full min-[2560px]:max-w-[160.00rem] min-[2940px]:mx-auto">
         <HeroSection />
         <ClientGridWithImages brands={brands} />

--- a/src/app/(frontend)/(inner)/styles/page.tsx
+++ b/src/app/(frontend)/(inner)/styles/page.tsx
@@ -1,0 +1,58 @@
+import { Button } from "@/components/Button";
+
+export default function StylesPage() {
+  return (
+    <div className="bg-brand-dark-bg p-8">
+      <h1 className="mb-8 text-4xl font-bold">Button Styleguide</h1>
+
+      <section className="mb-8">
+        <h2 className="mb-4 text-2xl font-semibold">Variants</h2>
+        <div className="flex flex-wrap gap-4">
+          <Button intent="primary" label="Primary" />
+          <Button intent="secondary" label="Secondary" />
+          <Button intent="outline" label="Outline" />
+          <Button intent="ghost" label="Ghost" />
+          <Button intent="link" label="Link" />
+          <Button intent="destructive" label="Destructive" />
+        </div>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="mb-4 text-2xl font-semibold">Sizes</h2>
+        <div className="flex flex-wrap items-center gap-4">
+          <Button size="default" label="Default" />
+          <Button size="sm" label="Small" />
+          <Button size="lg" label="Large" />
+          <Button size="icon" icon="plus" />
+        </div>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="mb-4 text-2xl font-semibold">With Icons</h2>
+        <div className="flex flex-wrap gap-4">
+          <Button icon="arrow" label="Arrow Right" />
+          <Button icon="arrow" iconPosition="left" label="Arrow Left" />
+          <Button icon="search" label="Search" />
+        </div>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="mb-4 text-2xl font-semibold">Full Width</h2>
+        <div className="space-y-4">
+          <Button fullWidth label="Full Width" />
+          <Button mobileFullWidth label="Mobile Full Width" />
+        </div>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="mb-4 text-2xl font-semibold">Disabled</h2>
+        <Button disabled label="Disabled Button" />
+      </section>
+
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold">As Link</h2>
+        <Button el="link" href="/example" label="Link Button" />
+      </section>
+    </div>
+  );
+}

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -7,32 +7,29 @@ import Link from "next/link";
 import { LinkType, Reference } from "../CMSLink/index.js";
 import { Page as PayloadPage } from "@/payload-types";
 
-// Import your icons here
-// import { ArrowIcon, SearchIcon, GitHubIcon, PlusIcon, LoaderIcon } from "@/icons";
-
 interface Page extends PayloadPage {
   breadcrumbs?: { url: string }[];
 }
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-sm font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
-      variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+      intent: {
+        primary: "bg-brand-gold text-black hover:bg-brand-gold/90",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
           "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
+        default: "h-12 text-base px-5 min-w-[9.88rem] ",
+        sm: "h-9 rounded-md px-3 text-sm",
+        lg: "h-16 rounded-md px-8 text-xl",
         icon: "h-10 w-10",
       },
       fullWidth: {
@@ -43,7 +40,7 @@ const buttonVariants = cva(
       },
     },
     defaultVariants: {
-      variant: "default",
+      intent: "primary",
       size: "default",
     },
   },
@@ -52,24 +49,12 @@ const buttonVariants = cva(
 export interface ButtonProps
   extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "type">,
     VariantProps<typeof buttonVariants> {
-  appearance?:
-    | "default"
-    | "text"
-    | "primary"
-    | "secondary"
-    | "danger"
-    | "warning"
-    | "success"
-    | "null";
   href?: string;
   newTab?: boolean;
-  icon?: "arrow" | "search" | "github" | "plus" | "loading";
+  icon?: "arrow" | "search" | "plus" | "loading";
   iconPosition?: "left" | "right";
-  iconSize?: "large" | "medium" | "small";
-  iconRotation?: number;
   label?: string;
-  labelStyle?: "mono" | "regular";
-  el?: "button" | "link" | "a" | "div";
+  el?: "button" | "link" | "a";
   type?: LinkType | "submit" | "reset" | "button";
   reference?: Reference;
   fullWidth?: boolean;
@@ -78,14 +63,6 @@ export interface ButtonProps
   url?: string;
   disabled?: boolean;
 }
-
-const icons: Record<string, React.ComponentType<any>> = {
-  // arrow: ArrowIcon,
-  // search: SearchIcon,
-  // github: GitHubIcon,
-  // plus: PlusIcon,
-  // loading: LoaderIcon,
-};
 
 const generateHref = ({
   type,
@@ -133,16 +110,13 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       className,
-      variant,
+      intent,
       size,
       fullWidth,
       mobileFullWidth,
       icon,
       iconPosition = "right",
-      iconSize = "medium",
-      iconRotation,
       label,
-      labelStyle = "mono",
       el = "button",
       href,
       newTab,
@@ -157,36 +131,11 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ) => {
     const hrefValue =
       href || generateHref({ type: type as LinkType, reference, url });
-    const Icon = icon ? icons[icon] : null;
 
     const content = (
-      <>
-        {iconPosition === "left" && Icon && (
-          <Icon
-            className={cn("mr-2", `icon-${iconSize}`)}
-            style={
-              iconRotation
-                ? { transform: `rotate(${iconRotation}deg)` }
-                : undefined
-            }
-          />
-        )}
-        {label && (
-          <span className={cn(labelStyle === "mono" && "font-mono")}>
-            {label}
-          </span>
-        )}
-        {iconPosition === "right" && Icon && (
-          <Icon
-            className={cn("ml-2", `icon-${iconSize}`)}
-            style={
-              iconRotation
-                ? { transform: `rotate(${iconRotation}deg)` }
-                : undefined
-            }
-          />
-        )}
-      </>
+      <span className="flex h-full w-full cursor-pointer items-center justify-center">
+        {label}
+      </span>
     );
 
     if (el === "link") {
@@ -195,7 +144,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           href={hrefValue}
           className={cn(
             buttonVariants({
-              variant,
+              intent,
               size,
               fullWidth,
               mobileFullWidth,
@@ -214,7 +163,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         <a
           className={cn(
             buttonVariants({
-              variant,
+              intent,
               size,
               fullWidth,
               mobileFullWidth,
@@ -234,7 +183,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       <button
         className={cn(
           buttonVariants({
-            variant,
+            intent,
             size,
             fullWidth,
             mobileFullWidth,

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -6,6 +6,7 @@ import config from "@payload-config";
 import Image from "next/image";
 import Link from "next/link";
 import BrewwwLogo from "/public/images/brewww-logotype-gold.png";
+import { Button } from "@/components/Button";
 
 export default function Header() {
   // TODO: bring back the Payload call when the design is completed
@@ -94,14 +95,7 @@ export default function Header() {
                 >
                   hello@brewww.studio
                 </Link>
-                <Link
-                  className="inline-block h-12 min-w-[9.88rem] rounded-sm bg-brand-gold px-5 font-bold text-black md:min-w-[10.63rem] min-[1680px]:h-16 min-[1680px]:min-w-[13.75rem]"
-                  href="/contact"
-                >
-                  <span className="flex h-full w-full cursor-pointer items-center justify-center">
-                    Let's talk
-                  </span>
-                </Link>
+                <Button href="/contact" label="Let's talk" />
               </div>
               <button
                 className="h-12 min-w-8 cursor-pointer"


### PR DESCRIPTION
### TL;DR

Added a new styles page and updated the Button component for improved consistency and flexibility.

### What changed?

- Created a new `/styles` page showcasing various Button component variations
- Updated the Button component to use `intent` instead of `variant` for better semantic clarity
- Refined Button styles, including font weight, padding, and hover states
- Simplified Button content rendering and removed unused icon-related code
- Updated the Header component to use the new Button component
- Added `/styles` to the sitemap configuration

### How to test?

1. Navigate to the new `/styles` page to view all Button variations
2. Check the Header component to ensure the "Let's talk" button appears correctly
3. Verify that existing Button usages throughout the site still function and appear as expected
4. Confirm that the `/styles` page is included in the sitemap

### Why make this change?

This change improves the consistency and maintainability of the Button component across the application. By creating a dedicated styles page, it becomes easier for developers to reference and implement various button designs. The updates to the Button component itself provide more flexibility and clearer intent, making it easier to use and customize in different contexts.