### PR TITLE
fix(link): remove variant from Link component missing in ButtonProps

### DIFF
--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -6,7 +6,6 @@ import React from "react";
 import type { Page, Post } from "@/payload-types";
 
 type CMSLinkType = {
-  appearance?: "inline" | ButtonProps["variant"];
   children?: React.ReactNode;
   className?: string;
   label?: string | null;
@@ -23,7 +22,6 @@ type CMSLinkType = {
 export const CMSLink: React.FC<CMSLinkType> = (props) => {
   const {
     type,
-    appearance = "inline",
     children,
     className,
     label,
@@ -44,13 +42,11 @@ export const CMSLink: React.FC<CMSLinkType> = (props) => {
 
   if (!href) return null;
 
-  const size = appearance === "link" ? "clear" : sizeFromProps;
   const newTabProps = newTab
     ? { rel: "noopener noreferrer", target: "_blank" }
     : {};
 
-  /* Ensure we don't break any styles set by richText */
-  if (appearance === "inline") {
+  if (!sizeFromProps) {
     return (
       <Link className={cn(className)} href={href || url || ""} {...newTabProps}>
         {label && label}
@@ -60,7 +56,7 @@ export const CMSLink: React.FC<CMSLinkType> = (props) => {
   }
 
   return (
-    <Button variant={appearance}>
+    <Button size={sizeFromProps}>
       <Link className={cn(className)} href={href || url || ""} {...newTabProps}>
         {label && label}
         {children && children}


### PR DESCRIPTION
### TL;DR

Simplified the `CMSLink` component by removing the `appearance` prop and adjusting the rendering logic.

### What changed?

- Removed the `appearance` prop from the `CMSLinkType` interface.
- Eliminated the `appearance` parameter from the `CMSLink` component.
- Adjusted the rendering logic to use `sizeFromProps` directly instead of deriving a `size` variable.
- Modified the conditional rendering to check for `sizeFromProps` instead of `appearance === "inline"`.
- Updated the `Button` component to use `size={sizeFromProps}` instead of `variant={appearance}`.

### How to test?

1. Verify that existing links in the application still render correctly.
2. Test links with different `sizeFromProps` values to ensure they display as expected.
3. Confirm that links without a specified size render as inline links.
4. Check that buttons with links maintain their functionality and appearance.

### Why make this change?

This change simplifies the `CMSLink` component by removing the redundant `appearance` prop and streamlining the rendering logic. It reduces complexity and improves maintainability by relying solely on the `sizeFromProps` to determine the link's appearance. This modification aligns the component's behavior more closely with the Button component's props, creating a more consistent API across the application.