### PR TITLE
feat(location: add schedule section to location page

### DIFF
--- a/src/app/(frontend)/(inner)/location/individual/page.tsx
+++ b/src/app/(frontend)/(inner)/location/individual/page.tsx
@@ -354,6 +354,172 @@ export default function Page() {
           </div>
         </div>
       </section>
+      <section className="bg-brand-dark-bg px-2 py-10 text-black sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20 min-[1800px]:pl-40 min-[1800px]:pr-40 min-[2100px]:pl-60 min-[2100px]:pr-60">
+        <div className="flex w-full flex-col lg:flex-row lg:justify-between">
+          <div className="relative mb-10 inline-flex w-full px-2 lg:mb-0 lg:w-2/4 lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
+            <div className="relative w-full pb-[100%] md:pb-[56.25%] lg:h-full lg:pb-0">
+              <div className="absolute bottom-0 right-0 z-20 h-14 w-32 rounded-tl-3xl text-neutral-950 lg:h-20">
+                <svg
+                  className="absolute right-0 top-[0.13rem] h-10 w-10 lg:h-12 lg:w-12"
+                  fill="rgb(14, 15, 17)"
+                  version="1.1"
+                  viewBox="0 0 100 100"
+                  x="0"
+                  xmlSpace="preserve"
+                  xmlns="http://www.w3.org/2000/svg"
+                  y="0"
+                >
+                  <path
+                    d="M51.9 0v1.9c-27.6 0-50 22.4-50 50H0V0h51.9z"
+                    fill="rgb(14, 15, 17)"
+                  />
+                </svg>
+                <svg
+                  className="absolute bottom-0 left-[0.13rem] h-10 w-10 lg:h-12 lg:w-12"
+                  fill="rgb(14, 15, 17)"
+                  version="1.1"
+                  viewBox="0 0 100 100"
+                  x="0"
+                  xmlSpace="preserve"
+                  xmlns="http://www.w3.org/2000/svg"
+                  y="0"
+                >
+                  <path
+                    d="M51.9 0v1.9c-27.6 0-50 22.4-50 50H0V0h51.9z"
+                    fill="rgb(14, 15, 17)"
+                  />
+                </svg>
+              </div>
+              <div className="absolute left-0 top-0 h-full w-full overflow-hidden rounded-3xl bg-zinc-900">
+                <img
+                  className="absolute left-0 top-0 h-full w-full max-w-full object-cover"
+                  src="/bg-contact.1200.jpg"
+                />
+              </div>
+            </div>
+          </div>
+          <div className="inline-flex w-full items-center px-2 lg:min-h-[35.00rem] lg:w-2/4 lg:justify-center lg:pb-20 lg:pl-3 lg:pr-3 lg:pt-20 xl:pl-4 xl:pr-4 min-[1800px]:min-h-[40.00rem] min-[2100px]:w-[43.75%]">
+            <div className="w-full lg:max-w-xl min-[2100px]:max-w-3xl">
+              <div className="flex flex-col items-start">
+                <div className="inline-flex items-center">
+                  <div className="h-1.5 w-1.5 rounded-full bg-white" />
+                  <div className="ml-2 font-light text-white">
+                    We’re the real sh*t
+                  </div>
+                </div>
+                <h2 className="mb-0 mt-3 text-[2.50rem] leading-none text-white lg:mb-0 lg:mt-5">
+                  We know it’s hard for brands to setup an online experience,
+                  and budgets can be tight.
+                </h2>
+              </div>
+              <div className="mt-8 w-full text-lg font-light text-zinc-400">
+                <p className="mb-6">
+                  We like to help new brands grow and work in a long-term
+                  relationship.
+                </p>
+                <p className="mb-6">
+                  We also have experience designing, building, testing, and
+                  launching websites for large global organisations. We can be
+                  an extension of your in-house marketing team. Take advantage
+                  of our expert team to be your complete digital arm.
+                </p>
+              </div>
+              <div className="mt-8 flex w-full flex-wrap">
+                <div className="mb-3.5 w-full">
+                  <div className="flex">
+                    <div className="mt-0 flex h-5 w-5 items-center justify-center rounded-full bg-lime-300 min-[2100px]:h-6 min-[2100px]:w-6">
+                      <svg
+                        className="h-3 w-3 min-[2100px]:h-3.5 min-[2100px]:w-3.5"
+                        fill="rgb(1, 2, 2)"
+                        height="16"
+                        viewBox="0 0 448 512"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M447.9 142.5l-23.2 22L181 395.3l-22 20.8-22-20.8L23.2 287.6 0 265.6l44-46.5 23.2 22L159 328l221.7-210 23.2-22 44 46.5z"
+                          fill="rgb(1, 2, 2)"
+                        />
+                      </svg>
+                    </div>
+                    <div className="ml-5 font-light text-white">
+                      Here since 2010
+                    </div>
+                  </div>
+                </div>
+                <div className="mb-3.5 w-full">
+                  <div className="flex">
+                    <div className="mt-0 flex h-5 w-5 items-center justify-center rounded-full bg-lime-300 min-[2100px]:h-6 min-[2100px]:w-6">
+                      <svg
+                        className="h-3 w-3 min-[2100px]:h-3.5 min-[2100px]:w-3.5"
+                        fill="rgb(1, 2, 2)"
+                        height="16"
+                        viewBox="0 0 448 512"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M447.9 142.5l-23.2 22L181 395.3l-22 20.8-22-20.8L23.2 287.6 0 265.6l44-46.5 23.2 22L159 328l221.7-210 23.2-22 44 46.5z"
+                          fill="rgb(1, 2, 2)"
+                        />
+                      </svg>
+                    </div>
+                    <div className="ml-5 font-light text-white">
+                      Next JS Verified Partner
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className="relative mt-8 inline-flex items-center">
+                <a
+                  className="inline-flex"
+                  href="https://madebyshape.co.uk/contact/"
+                  style={{
+                    outlineOffset: "2px",
+                    outlineStyle: "solid",
+                    outlineWidth: "2px",
+                  }}
+                >
+                  <div className="inline-flex w-auto cursor-pointer items-center justify-center overflow-hidden rounded-full bg-lime-300 px-5 py-2">
+                    <div className="inline-flex">
+                      Schedule a call with our team
+                    </div>
+                  </div>
+                  <div className="-ml-1 flex h-9 w-9 cursor-pointer items-center justify-center overflow-hidden rounded-full bg-lime-300" />
+                </a>
+                <div className="absolute right-0 top-0 z-20 flex h-9 w-9 items-center justify-center">
+                  <div className="relative overflow-hidden">
+                    <div>
+                      <svg
+                        className="h-3 w-3"
+                        fill="rgb(1, 2, 2)"
+                        viewBox="0 0 384 512"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M328 96h24v288h-48V177.9L81 401l-17 17-33.9-34 17-17 223-223H64V96h264z"
+                          fill="rgb(1, 2, 2)"
+                        />
+                      </svg>
+                    </div>
+                    <div className="absolute left-0 top-0">
+                      <svg
+                        className="h-3 w-3"
+                        fill="rgb(1, 2, 2)"
+                        viewBox="0 0 384 512"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M328 96h24v288h-48V177.9L81 401l-17 17-33.9-34 17-17 223-223H64V96h264z"
+                          fill="rgb(1, 2, 2)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
     </>
   );
 }


### PR DESCRIPTION
### TL;DR

Added a new section to the individual location page showcasing the company's expertise and offering a call-to-action.

### What changed?

- Introduced a new section with a background image and content about the company's experience
- Added highlights about the company's history and partnerships
- Included a call-to-action button for scheduling a call with the team
- Implemented responsive design elements for various screen sizes

### How to test?

1. Navigate to the individual location page
2. Scroll down to the newly added section
3. Verify the background image loads correctly
4. Check that the content is displayed properly, including the company highlights
5. Ensure the "Schedule a call with our team" button is functional
6. Test the responsiveness of the section on different screen sizes (mobile, tablet, desktop)

### Why make this change?

This addition aims to:
- Showcase the company's expertise and longevity in the industry
- Build trust with potential clients by highlighting key achievements
- Provide an easy way for interested parties to get in touch
- Improve the overall user experience and engagement on the individual location page