### PR TITLE
feat(cms): add technology collection

### DIFF
--- a/src/collections/Technologies/config.ts
+++ b/src/collections/Technologies/config.ts
@@ -1,0 +1,60 @@
+import type { CollectionConfig } from "payload";
+import { isAdmin } from "@/access/isAdmin";
+import { publishedOnly } from "@/access/publishedOnly";
+
+export const Technologies: CollectionConfig = {
+  slug: "technologies",
+
+  //* Access Settings
+  access: {
+    create: isAdmin,
+    delete: isAdmin,
+    read: publishedOnly,
+    readVersions: isAdmin,
+    update: isAdmin,
+  },
+
+  //* Collection Fields
+  fields: [
+    {
+      name: "title",
+      type: "text",
+      label: "Title",
+      required: true,
+      unique: true,
+      admin: {
+        description: "Add the title of the technology here.",
+      },
+    },
+    {
+      name: "image",
+      type: "upload",
+      label: "Logo",
+      required: false,
+      relationTo: "media",
+    },
+  ],
+
+  //* Admin Settings
+
+  admin: {
+    description: "The tools of the trade.",
+    defaultColumns: ["title", "image"],
+    group: "Portfolio",
+    listSearchableFields: ["title"],
+    pagination: {
+      defaultLimit: 25,
+      limits: [10, 25, 50],
+    },
+    useAsTitle: "title",
+  },
+  defaultSort: "title",
+  labels: {
+    singular: "Technology",
+    plural: "Technologies",
+  },
+  versions: {
+    drafts: true,
+    maxPerDoc: 25,
+  },
+};

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -22,6 +22,7 @@ export interface Config {
     brands: Brand;
     pillars: Pillar;
     testimonials: Testimonial;
+    technologies: Technology;
     locations: Location;
     results: Result;
     users: User;
@@ -540,6 +541,18 @@ export interface Pillar {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "technologies".
+ */
+export interface Technology {
+  id: string;
+  title: string;
+  image?: (string | null) | Media;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "locations".
  */
 export interface Location {
@@ -654,6 +667,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'testimonials';
         value: string | Testimonial;
+      } | null)
+    | ({
+        relationTo: 'technologies';
+        value: string | Technology;
       } | null)
     | ({
         relationTo: 'locations';

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -26,6 +26,7 @@ import { Services } from "@/collections/Services/config";
 import { Testimonials } from "@/collections/Testimonials/config";
 import { Users } from "@/collections/Users/config";
 import { Work } from "@/collections/Work/config";
+import { Technologies } from "@/collections/Technologies/config";
 
 //* Import Globals
 import { Header } from "./globals/Header/index";
@@ -126,6 +127,7 @@ export default buildConfig({
     Brands,
     Pillars,
     Testimonials,
+    Technologies,
     Location,
     Results,
     Users,


### PR DESCRIPTION
### TL;DR

Added a new "Technologies" collection to the Payload CMS configuration.

### What changed?

- Created a new `Technologies` collection configuration in `src/collections/Technologies/config.ts`
- Added the `Technologies` collection to the main Payload configuration in `src/payload.config.ts`
- Updated `src/payload-types.ts` to include the new `Technology` interface

### How to test?

1. Start the Payload CMS
2. Navigate to the admin panel
3. Verify that a new "Technologies" section appears under the "Portfolio" group
4. Try creating, reading, updating, and deleting technology entries
5. Confirm that only admin users can perform CRUD operations, while regular users can only read published entries

### Why make this change?

This change introduces a new collection to manage and showcase various technologies used in projects or services. It allows for better organization and presentation of technical skills or tools within the portfolio section of the CMS.