### PR TITLE
feat(ui): add intro hero concept to play page

### DIFF
--- a/src/app/(frontend)/(inner)/play/PlayHero/index.tsx
+++ b/src/app/(frontend)/(inner)/play/PlayHero/index.tsx
@@ -1,0 +1,192 @@
+"use client";
+import React, { useState, useEffect } from "react";
+
+interface ImageCardProps {
+  src: string;
+  alt: string;
+  style: React.CSSProperties;
+}
+
+const ImageCard: React.FC<ImageCardProps> = ({ src, alt, style }) => {
+  return (
+    <div className="absolute origin-center" style={style}>
+      <img
+        src={src}
+        alt={alt}
+        className="h-full w-full rounded-3xl object-cover"
+      />
+    </div>
+  );
+};
+
+export function PlayHero() {
+  const [scale, setScale] = useState(1);
+
+  useEffect(() => {
+    const handleResize = () => {
+      const baseWidth = 1440; // Base width for scale 1
+      setScale(Math.min(window.innerWidth / baseWidth, 1));
+    };
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  const images = [
+    "https://made-byshape.transforms.svdcdn.com/production/uploads/images/India-2022/Empty-Studio/Shape-April-2022-HR-200.jpg?w=400&h=400&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=0.5&fp-y=0.5&dm=1651142745&s=babedcc3fa45f9af1a08b9a9062682f7",
+    "https://made-byshape.transforms.svdcdn.com/production/uploads/images/India-2022/Chillout-Area/Shape-April-2022-HR-163.jpg?w=400&h=400&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=0.5&fp-y=0.5&dm=1651142276&s=623a91582904eeaaa558600540e49349",
+    "https://made-byshape.transforms.svdcdn.com/production/uploads/images/India-2022/Empty-Studio/Shape-April-2022-HR-198.jpg?w=400&h=400&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=0.5&fp-y=0.5&dm=1651142740&s=b277c4ce6152387dcd4771b708003cf7",
+    "https://made-byshape.transforms.svdcdn.com/production/uploads/images/India-2022/People-in-Studio/Shape-April-2022-HR-208.jpg?w=400&h=400&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=0.5&fp-y=0.5&dm=1651143487&s=19b949fe09dfe3e0161a0a345a83f057",
+    "https://made-byshape.transforms.svdcdn.com/production/uploads/images/MadeByShape-Studio/Shape-2018-LR-169_200119_175819.jpg?w=400&h=400&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=0.5&fp-y=0.5&dm=1604326504&s=bf17266e2762cabc752c1a107cfd715b",
+    "https://made-byshape.transforms.svdcdn.com/production/uploads/images/India-2022/Empty-Studio/Shape-April-2022-HR-200.jpg?w=400&h=400&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=0.5&fp-y=0.5&dm=1651142745&s=babedcc3fa45f9af1a08b9a9062682f7",
+  ];
+
+  const totalImages = 30; // Increased number of images
+  const trackRadius = 1800 * scale;
+  const imageSize = 300 * scale; // Reduced image size to fit more images
+  const imageAngle = (2 * Math.PI) / totalImages;
+
+  // Create an array with repeated images to match totalImages
+  const extendedImages = Array(totalImages)
+    .fill(null)
+    .map((_, index) => images[index % images.length]);
+
+  return (
+    <div className="relative h-screen w-full overflow-hidden bg-black">
+      <div className="relative inset-0 flex flex-col items-center justify-center">
+        <h1
+          className="z-10 mb-20 text-center text-7xl font-bold text-white"
+          style={{ fontSize: `${7 * scale}rem` }}
+        >
+          Play is a part
+          <br />
+          of our process.
+        </h1>
+        <div
+          className="relative"
+          style={{
+            height: `${trackRadius * 2}px`,
+            width: `${trackRadius * 2}px`,
+          }}
+        >
+          <div className="animate-rotate absolute inset-0">
+            {extendedImages.map((src, index) => {
+              const angle = index * imageAngle - Math.PI / 2; // Start from top
+              const x = Math.cos(angle) * trackRadius;
+              const y = Math.sin(angle) * trackRadius;
+              const rotation = angle + Math.PI / 2; // Rotate image to face outward
+
+              return (
+                <ImageCard
+                  key={index}
+                  src={src}
+                  alt={`Image ${index + 1}`}
+                  style={{
+                    transform: `translate(${x}px, ${y}px) rotate(${rotation}rad) scale(${scale})`,
+                    left: "50%",
+                    top: "50%",
+                    width: `${imageSize}px`,
+                    height: `${imageSize}px`,
+                    marginLeft: `-${imageSize / 2}px`,
+                    marginTop: `-${imageSize / 2}px`,
+                  }}
+                />
+              );
+            })}
+          </div>
+        </div>
+      </div>
+      <style jsx>{`
+        @keyframes rotate {
+          0% {
+            transform: rotate(0deg);
+          }
+          100% {
+            transform: rotate(360deg);
+          }
+        }
+        .animate-rotate {
+          animation: rotate 240s linear infinite;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+// "use client";
+// import React from "react";
+
+// interface ImageCardProps {
+//   src: string;
+//   alt: string;
+//   style: React.CSSProperties;
+// }
+
+// const ImageCard: React.FC<ImageCardProps> = ({ src, alt, style }) => {
+//   return (
+//     <div className="absolute h-[20rem] w-[20rem] origin-center" style={style}>
+//       <img
+//         src={src}
+//         alt={alt}
+//         className="h-full w-full rounded-3xl object-cover"
+//       />
+//     </div>
+//   );
+// };
+
+// export function PlayHero() {
+//   const images = [
+//     "https://made-byshape.transforms.svdcdn.com/production/uploads/images/India-2022/Empty-Studio/Shape-April-2022-HR-200.jpg?w=400&h=400&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=0.5&fp-y=0.5&dm=1651142745&s=babedcc3fa45f9af1a08b9a9062682f7",
+//     "https://made-byshape.transforms.svdcdn.com/production/uploads/images/India-2022/Chillout-Area/Shape-April-2022-HR-163.jpg?w=400&h=400&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=0.5&fp-y=0.5&dm=1651142276&s=623a91582904eeaaa558600540e49349",
+//     "https://made-byshape.transforms.svdcdn.com/production/uploads/images/India-2022/Empty-Studio/Shape-April-2022-HR-198.jpg?w=400&h=400&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=0.5&fp-y=0.5&dm=1651142740&s=b277c4ce6152387dcd4771b708003cf7",
+//     "https://made-byshape.transforms.svdcdn.com/production/uploads/images/India-2022/People-in-Studio/Shape-April-2022-HR-208.jpg?w=400&h=400&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=0.5&fp-y=0.5&dm=1651143487&s=19b949fe09dfe3e0161a0a345a83f057",
+//     "https://made-byshape.transforms.svdcdn.com/production/uploads/images/MadeByShape-Studio/Shape-2018-LR-169_200119_175819.jpg?w=400&h=400&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=0.5&fp-y=0.5&dm=1604326504&s=bf17266e2762cabc752c1a107cfd715b",
+//   ];
+
+//   const totalImages = 6;
+//   const arcWidth = 1900; // Width of the arc
+//   const arcHeight = 300; // Height of the arc (adjust to control curvature)
+
+//   const circleImages = Array(totalImages)
+//     .fill(null)
+//     .map((_, index) => images[index % images.length]);
+
+//   return (
+//     <div className="relative h-screen w-full overflow-hidden bg-black">
+//       <div className="relative inset-0 flex flex-col items-center justify-center pt-24">
+//         <h1 className="z-10 mb-40 text-center text-7xl font-bold text-white">
+//           Play is a part
+//           <br />
+//           of our process.
+//         </h1>
+//         <div className="relative h-[800px] w-[1600px]">
+//           {circleImages.map((src, index) => {
+//             const progress = index / (totalImages - 1);
+//             const x = progress * arcWidth - arcWidth / 2;
+//             const y = -Math.sin(Math.PI * progress) * arcHeight;
+//             const rotation = Math.atan2(
+//               (-Math.cos(Math.PI * progress) * Math.PI * arcHeight) / arcWidth,
+//               1,
+//             );
+
+//             return (
+//               <ImageCard
+//                 key={index}
+//                 src={src}
+//                 alt={`Image ${index + 1}`}
+//                 style={{
+//                   transform: `translate(${x}px, ${y}px) rotate(${rotation}rad)`,
+//                   left: "50%",
+//                   top: "30%",
+//                   marginLeft: "-10rem",
+//                   marginTop: "-10rem",
+//                 }}
+//               />
+//             );
+//           })}
+//         </div>
+//       </div>
+//     </div>
+//   );
+// }

--- a/src/app/(frontend)/(inner)/play/page.tsx
+++ b/src/app/(frontend)/(inner)/play/page.tsx
@@ -2,6 +2,7 @@ import { getPayloadHMR } from "@payloadcms/next/utilities";
 import configPromise from "@payload-config";
 import Link from "next/link";
 import Image from "next/image";
+import { PlayHero } from "./PlayHero";
 export default async function PlayPage() {
   const payload = await getPayloadHMR({ config: configPromise });
   const projects = await payload.find({
@@ -12,6 +13,7 @@ export default async function PlayPage() {
 
   return (
     <>
+      <PlayHero />
       <section className="bg-brand-dark-bg">
         <div className="container mx-auto px-4 py-24">
           <div className="max-w-[82.50rem] text-xl text-neutral-800 min-[480px]:max-w-[84.38rem] min-[720px]:max-w-[86.88rem] min-[720px]:pl-12 min-[720px]:pr-12 min-[1080px]:max-w-[89.38rem] min-[1080px]:pl-16 min-[1080px]:pr-16">


### PR DESCRIPTION
### TL;DR

Added a new PlayHero component to the Play page, featuring a rotating circle of images with responsive scaling.

### What changed?

- Created a new `PlayHero` component in `src/app/(frontend)/(inner)/play/PlayHero/index.tsx`
- The `PlayHero` component displays a rotating circle of images with a centered title
- Implemented responsive scaling based on window width
- Added the `PlayHero` component to the Play page in `src/app/(frontend)/(inner)/play/page.tsx`

### How to test?

1. Navigate to the Play page
2. Verify that the new hero section appears at the top of the page
3. Check that the images rotate in a circular pattern
4. Resize the browser window to ensure the component scales appropriately
5. Confirm that the "Play is a part of our process" text is centered and visible

### Why make this change?

This change enhances the visual appeal of the Play page by adding an engaging, interactive hero section. The rotating images showcase the company's work and reinforce the concept of play being part of the creative process. The responsive design ensures a consistent user experience across different device sizes.