### PR TITLE
fix(types): add proper fallback types to WorkCard

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://brewww.studio</loc><lastmod>2024-10-09T18:20:23.075Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio</loc><lastmod>2024-10-11T13:18:54.333Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/components/WorkCard/index.tsx
+++ b/src/components/WorkCard/index.tsx
@@ -62,8 +62,16 @@ export function WorkCard({ project }: WorkCardProps) {
               <div className="w-full">
                 <div className="relative w-full overflow-hidden pb-[75%]">
                   <Image
-                    src={project.imageMain.url}
-                    alt={project.imageMain.alt}
+                    src={
+                      typeof project.imageMain === "string"
+                        ? project.imageMain
+                        : project.imageMain?.url || ""
+                    }
+                    alt={
+                      typeof project.imageMain === "string"
+                        ? ""
+                        : project.imageMain?.alt || ""
+                    }
                     layout="fill"
                     objectFit="cover"
                   />


### PR DESCRIPTION
### TL;DR

Updated sitemap lastmod date and improved image handling in WorkCard component.

### What changed?

- Updated the lastmod date in the sitemap.xml file to 2024-10-11T13:18:54.333Z.
- Modified the WorkCard component to handle both string and object types for the project.imageMain property.

### How to test?

1. Verify that the sitemap.xml file reflects the updated lastmod date.
2. Test the WorkCard component with projects that have both string and object types for imageMain:
   - Ensure images load correctly when imageMain is a string URL.
   - Confirm images display properly when imageMain is an object with url and alt properties.
   - Check that no errors occur when imageMain is undefined or missing properties.

### Why make this change?

- Updating the sitemap lastmod date helps search engines understand when the content was last modified.
- The changes to the WorkCard component improve its flexibility, allowing it to handle different data structures for project images. This enhancement makes the component more robust and less prone to errors when dealing with varying API responses or data formats.