### PR TITLE
feat(cms): modify three payload collections for better image field placement and naming

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://brewww.studio</loc><lastmod>2024-10-11T13:18:54.333Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio</loc><lastmod>2024-10-11T19:43:43.087Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/app/(frontend)/(inner)/blog/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/blog/[slug]/page.tsx
@@ -119,14 +119,14 @@ export default async function PostPage({
           <div className="relative aspect-[3/2] w-full">
             <Image
               src={
-                typeof post.imageMain === "string"
-                  ? post.imageMain
-                  : post.imageMain?.url || aboutImage.src
+                typeof post.image === "string"
+                  ? post.image
+                  : post.image?.url || aboutImage.src
               }
               fill
               alt={
-                typeof post.imageMain === "object"
-                  ? post.imageMain?.alt || ""
+                typeof post.image === "object"
+                  ? post.image?.alt || ""
                   : "Featured image for blog post"
               }
               className="rounded-md object-cover"

--- a/src/app/(frontend)/(inner)/blog/page.tsx
+++ b/src/app/(frontend)/(inner)/blog/page.tsx
@@ -40,14 +40,12 @@ export default async function BlogPage() {
                     <div className="group relative w-full overflow-hidden rounded bg-zinc-500/[0.2] pt-[80%]">
                       <Image
                         src={
-                          typeof post.imageMain === "string"
-                            ? post.imageMain
-                            : (post.imageMain as { url: string })?.url || ""
+                          typeof post.image === "string"
+                            ? post.image
+                            : (post.image as { url: string })?.url || ""
                         }
                         alt={
-                          typeof post.imageMain === "object"
-                            ? post.imageMain.alt
-                            : ""
+                          typeof post.image === "object" ? post.image.alt : ""
                         }
                         fill
                         className="object-cover transition-transform duration-500 group-hover:scale-105"

--- a/src/app/(frontend)/(inner)/play/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/play/[slug]/page.tsx
@@ -26,12 +26,10 @@ export default async function PlayPage({
 
   const fallbackDescription = "Add a cool description here.";
   const imageUrl =
-    typeof play.content.imageMain === "string"
-      ? play.content.imageMain
-      : play.content.imageMain?.url || "";
+    typeof play.image === "string" ? play.image : play.image?.url || "";
   const imageAlt =
-    typeof play.content.imageMain === "object"
-      ? play.content.imageMain?.alt
+    typeof play.image === "object"
+      ? play.image?.alt
       : "Featured image for play project";
 
   return (

--- a/src/app/(frontend)/(inner)/play/page.tsx
+++ b/src/app/(frontend)/(inner)/play/page.tsx
@@ -42,9 +42,9 @@ export default async function PlayPage() {
             <div className="grid auto-rows-auto grid-cols-2 gap-8">
               {projects.docs.map((project) => {
                 const imageSrc =
-                  typeof project.content.imageMain === "string"
-                    ? project.content.imageMain
-                    : project.content.imageMain?.url ||
+                  typeof project.image === "string"
+                    ? project.image
+                    : project.image?.url ||
                       "https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10ccaad8365d669c95e70_63c91a92dc0c340932978b8f_image-ueno-template-04-p-3200.jpeg";
 
                 return (
@@ -58,9 +58,9 @@ export default async function PlayPage() {
                         <Image
                           className="absolute inset-0 h-full w-full"
                           src={
-                            typeof project.content.imageMain === "string"
-                              ? project.content.imageMain
-                              : project.content.imageMain?.url ||
+                            typeof project.image === "string"
+                              ? project.image
+                              : project.image?.url ||
                                 "https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10ccaad8365d669c95e70_63c91a92dc0c340932978b8f_image-ueno-template-04-p-3200.jpeg"
                           }
                           alt={"Project Thumbnail"}

--- a/src/app/(frontend)/(inner)/work/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/work/[slug]/page.tsx
@@ -818,15 +818,13 @@ export default async function WorkPage({
             <div className="relative aspect-[3/2] w-full">
               <Image
                 src={
-                  typeof project.imageMain === "string"
-                    ? project.imageMain
-                    : project.imageMain?.url || ""
+                  typeof project.image === "string"
+                    ? project.image
+                    : project.image?.url || ""
                 }
                 fill
                 alt={
-                  typeof project.imageMain === "object"
-                    ? project.imageMain?.alt || ""
-                    : "Featured image for blog post"
+                  typeof project.image === "object" ? project.image?.alt : ""
                 }
                 className="rounded-md object-cover"
                 priority

--- a/src/app/(frontend)/(inner)/work/page.tsx
+++ b/src/app/(frontend)/(inner)/work/page.tsx
@@ -264,10 +264,10 @@ export default async function WorkPage() {
                               <Image
                                 className="cursor-pointer object-cover"
                                 src={
-                                  typeof project.imageMain === "string"
-                                    ? project.imageMain
-                                    : (project.imageMain as { url: string })
-                                        ?.url || ""
+                                  typeof project.image === "string"
+                                    ? project.image
+                                    : (project.image as { url: string })?.url ||
+                                      ""
                                 }
                                 alt={project.title}
                                 fill

--- a/src/collections/BlogPosts/config.ts
+++ b/src/collections/BlogPosts/config.ts
@@ -144,10 +144,10 @@ export const BlogPosts: CollectionConfig = {
       },
     },
     {
-      name: "imageMain",
+      name: "image",
       type: "upload",
       relationTo: "media",
-      label: "Main Image",
+      label: "Featured Image",
       required: true,
       admin: {
         position: "sidebar",
@@ -160,7 +160,7 @@ export const BlogPosts: CollectionConfig = {
   admin: {
     description:
       "Writing brings clarity. Writing is a way to make sense of the world.",
-    defaultColumns: ["title", "imageMain", "publishedOn", "updatedAt"],
+    defaultColumns: ["title", "publishedOn", "updatedAt"],
     group: "Blog Posts",
     listSearchableFields: ["title"],
     pagination: {

--- a/src/collections/Play/config.ts
+++ b/src/collections/Play/config.ts
@@ -52,50 +52,14 @@ export const Playground: CollectionConfig = {
         description: "Add the description for the playground here.",
       },
     },
-    // TODO: make sure the slug locks after being published
-    ...slugField(),
-    {
-      name: "publishedOn",
-      type: "date",
-      required: true,
-      label: "Published On",
-      admin: {
-        description:
-          "The date the Play Case Study was published. This is used to sort the Play Case Studies.",
-        position: "sidebar",
-        date: {
-          pickerAppearance: "dayAndTime",
-        },
-      },
-      hooks: {
-        beforeChange: [
-          ({ siblingData, value }) => {
-            if (siblingData._status === "published" && !value) {
-              return new Date();
-            }
-            return value;
-          },
-        ],
-      },
-    },
+
     {
       type: "tabs",
       tabs: [
         {
           name: "content",
           label: "Content",
-          fields: [
-            {
-              name: "imageMain",
-              type: "upload",
-              relationTo: "media",
-              label: "Main Image",
-              required: true,
-              admin: {
-                description: "Add the main image for the playground here.",
-              },
-            },
-          ],
+          fields: [],
         },
         {
           name: "metadata",
@@ -145,6 +109,40 @@ export const Playground: CollectionConfig = {
           ],
         },
       ],
+    },
+    // TODO: make sure the slug locks after being published
+    ...slugField(),
+    {
+      name: "publishedOn",
+      type: "date",
+      required: true,
+      label: "Published On",
+      admin: {
+        position: "sidebar",
+        date: {
+          pickerAppearance: "dayAndTime",
+        },
+      },
+      hooks: {
+        beforeChange: [
+          ({ siblingData, value }) => {
+            if (siblingData._status === "published" && !value) {
+              return new Date();
+            }
+            return value;
+          },
+        ],
+      },
+    },
+    {
+      name: "image",
+      type: "upload",
+      relationTo: "media",
+      label: "Featured Image",
+      required: true,
+      admin: {
+        position: "sidebar",
+      },
     },
   ],
 

--- a/src/collections/Work/config.ts
+++ b/src/collections/Work/config.ts
@@ -55,28 +55,6 @@ export const Work: CollectionConfig = {
           "The description of the project as it appears around the site.",
       },
     },
-    {
-      name: "imageMain",
-      type: "upload",
-      label: "Main Image",
-      required: true,
-      relationTo: "media",
-      admin: {
-        description: "This image appears on the site.",
-      },
-    },
-    ...slugField(),
-    {
-      name: "brand",
-      type: "relationship",
-      relationTo: "brands",
-      hasMany: false,
-      required: true,
-      admin: {
-        position: "sidebar",
-        description: "Add the name of the brand here.",
-      },
-    },
 
     {
       type: "tabs",
@@ -143,6 +121,27 @@ export const Work: CollectionConfig = {
           ],
         },
       ],
+    },
+    ...slugField(),
+    {
+      name: "image",
+      type: "upload",
+      label: "Featured Image",
+      required: true,
+      relationTo: "media",
+      admin: {
+        position: "sidebar",
+      },
+    },
+    {
+      name: "brand",
+      type: "relationship",
+      relationTo: "brands",
+      hasMany: false,
+      required: true,
+      admin: {
+        position: "sidebar",
+      },
     },
   ],
 

--- a/src/components/WorkCard/index.tsx
+++ b/src/components/WorkCard/index.tsx
@@ -63,14 +63,14 @@ export function WorkCard({ project }: WorkCardProps) {
                 <div className="relative w-full overflow-hidden pb-[75%]">
                   <Image
                     src={
-                      typeof project.imageMain === "string"
-                        ? project.imageMain
-                        : project.imageMain?.url || ""
+                      typeof project.image === "string"
+                        ? project.image
+                        : project.image?.url || ""
                     }
                     alt={
-                      typeof project.imageMain === "string"
-                        ? ""
-                        : project.imageMain?.alt || ""
+                      typeof project.image === "object"
+                        ? project.image?.alt
+                        : ""
                     }
                     layout="fill"
                     objectFit="cover"

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -353,7 +353,7 @@ export interface Post {
   slug: string;
   slugLock?: boolean | null;
   publishedOn: string;
-  imageMain: string | Media;
+  image: string | Media;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -380,10 +380,6 @@ export interface Work {
   title: string;
   tagline: string;
   description?: string | null;
-  imageMain: string | Media;
-  slug: string;
-  slugLock?: boolean | null;
-  brand: string | Brand;
   metadata?: {
     testimonial?: (string | null) | Testimonial;
     relatedWorks?: (string | Work)[] | null;
@@ -393,21 +389,10 @@ export interface Work {
     image?: (string | null) | Media;
     description?: string | null;
   };
-  updatedAt: string;
-  createdAt: string;
-  _status?: ('draft' | 'published') | null;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "brands".
- */
-export interface Brand {
-  id: string;
-  title: string;
-  logoLight?: (string | null) | Media;
-  logoDark?: (string | null) | Media;
-  city: string;
-  state: string;
+  slug: string;
+  slugLock?: boolean | null;
+  image: string | Media;
+  brand: string | Brand;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -443,6 +428,21 @@ export interface Testimonial {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "brands".
+ */
+export interface Brand {
+  id: string;
+  title: string;
+  logoLight?: (string | null) | Media;
+  logoDark?: (string | null) | Media;
+  city: string;
+  state: string;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "play".
  */
 export interface Play {
@@ -450,12 +450,7 @@ export interface Play {
   title: string;
   tagline: string;
   description?: string | null;
-  slug: string;
-  slugLock?: boolean | null;
-  publishedOn: string;
-  content: {
-    imageMain: string | Media;
-  };
+  content?: {};
   metadata?: {
     relatedPlaygrounds?: (string | Play)[] | null;
   };
@@ -464,6 +459,10 @@ export interface Play {
     title?: string | null;
     description?: string | null;
   };
+  slug: string;
+  slugLock?: boolean | null;
+  publishedOn: string;
+  image: string | Media;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;


### PR DESCRIPTION
### TL;DR

Refactored image handling across multiple components and collections.

### What changed?

- Renamed `imageMain` to `image` in BlogPosts, Play, and Work collections
- Updated image field configurations in collection schemas
- Modified image rendering logic in various components and pages
- Adjusted TypeScript interfaces to reflect the new image field structure

### How to test?

1. Verify that existing images are displayed correctly on blog posts, work projects, and play projects
2. Create new entries in each collection and ensure images can be uploaded and displayed properly
3. Check that image alt text is correctly rendered where applicable
4. Confirm that responsive image loading and optimization still function as expected

### Why make this change?

This change standardizes the image field naming convention across collections, simplifying the codebase and improving consistency. It also streamlines the image handling process, making it easier to maintain and extend image-related functionality in the future.