### PR TITLE
fix(work): add proper types for image in work individual page

### DIFF
--- a/src/app/(frontend)/(inner)/work/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/work/[slug]/page.tsx
@@ -113,7 +113,11 @@ export default async function WorkPage({
             <div className="relative w-full">
               <div className="relative w-full overflow-hidden rounded-3xl bg-zinc-900 pb-[75%] lg:pb-[56.25%]">
                 <Image
-                  src={project.image.url}
+                  src={
+                    typeof project.image === "string"
+                      ? project.image
+                      : project.image?.url || ""
+                  }
                   alt="Project header image"
                   fill
                   style={{ objectFit: "cover" }}


### PR DESCRIPTION
### TL;DR

Updated image source handling in WorkPage component

### What changed?

Modified the `src` attribute of the `Image` component in the WorkPage to handle different types of `project.image` data. The change now checks if `project.image` is a string or an object with a `url` property, providing a fallback empty string if neither condition is met.

### How to test?

1. Navigate to a work page with various types of project image data:
   - A string URL
   - An object with a `url` property
   - A project without an image
2. Verify that the image displays correctly in all scenarios
3. Check that no errors occur when loading the page with different image data types

### Why make this change?

This change improves the robustness of the image rendering logic, ensuring that the component can handle different data structures for project images. It prevents potential errors that could occur if the `project.image` data is inconsistent across different projects, enhancing the overall stability of the work page display.