### PR TITLE
feat(cms): add Team collection to Payload

### DIFF
--- a/src/app/(frontend)/(inner)/blog/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/blog/[slug]/page.tsx
@@ -13,12 +13,15 @@ import TableOfContents from "@/components/TableOfContents/index";
 import { LexicalNode } from "@/components/RichText/nodeFormat";
 
 export async function generateStaticParams() {
+  console.log("Generating static params for blog posts");
   const payload = await getPayloadHMR({ config: configPromise });
+  console.log("Fetching blog posts from payload");
   const posts = await payload.find({
     collection: "posts",
     limit: 1000,
     overrideAccess: false,
   });
+  console.log(`Found ${posts.docs?.length || 0} blog posts`);
   return (
     posts.docs?.map(({ slug }) => ({
       params: { slug },
@@ -32,14 +35,21 @@ export default async function PostPage({
   params: Promise<{ slug: string }>;
 }) {
   const resolvedParams = await params;
+  console.log("Rendering PostPage");
+  console.log(`Params: ${JSON.stringify(resolvedParams)}`);
   if (!resolvedParams.slug) {
+    console.log("No slug found in params, redirecting to 404");
     notFound();
   }
 
+  console.log(`Querying blog post with slug: ${resolvedParams.slug}`);
   const post = await queryPostBySlug({ slug: resolvedParams.slug });
   if (!post) {
+    console.log("Blog post not found, redirecting to 404");
     notFound();
   }
+
+  console.log(`Blog post found: ${post.title}`);
 
   return (
     <article className="bg-white pt-24 text-black">
@@ -164,6 +174,7 @@ async function queryPostBySlug({
 }): Promise<Post | null> {
   const payload = await getPayloadHMR({ config: configPromise });
   try {
+    console.log("Executing payload.find query");
     const result = await payload.find({
       collection: "posts",
       limit: 1,
@@ -173,8 +184,10 @@ async function queryPostBySlug({
         },
       },
     });
+    console.log("Query result:", result);
     return result.docs[0] || null;
   } catch (error) {
+    console.error("Error querying blog post:", error);
     return null;
   }
 }

--- a/src/app/(frontend)/(inner)/team/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/team/[slug]/page.tsx
@@ -1,0 +1,82 @@
+import Image from "next/image";
+import { getPayloadHMR } from "@payloadcms/next/utilities";
+import configPromise from "@payload-config";
+import { notFound } from "next/navigation";
+import { Team } from "@/payload-types";
+
+export async function generateStaticParams() {
+  console.log("Generating static params for team members");
+  const payload = await getPayloadHMR({ config: configPromise });
+  console.log("Fetching team members from payload");
+  const teams = await payload.find({
+    collection: "team",
+    limit: 1000,
+    overrideAccess: false,
+  });
+  console.log(`Found ${teams.docs?.length || 0} team members`);
+  return (
+    teams.docs?.map(({ slug }) => ({
+      slug,
+    })) || []
+  );
+}
+
+export default async function TeamPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const resolvedParams = await params;
+  console.log("Rendering TeamPage");
+  console.log(`Params: ${JSON.stringify(resolvedParams)}`);
+  if (!resolvedParams.slug) {
+    console.log("No slug found in params, redirecting to 404");
+    notFound();
+  }
+
+  console.log(`Querying team member with slug: ${resolvedParams.slug}`);
+  const team = await queryPostBySlug({ slug: resolvedParams.slug });
+  if (!team) {
+    console.log("Team member not found, redirecting to 404");
+    notFound();
+  }
+  console.log(`Team member found: ${team.title}`);
+
+  return <>{team.title}</>;
+}
+
+async function queryPostBySlug({
+  slug,
+}: {
+  slug: string;
+}): Promise<Team | null> {
+  console.log(`Querying team member with slug: ${slug}`);
+  const payload = await getPayloadHMR({ config: configPromise });
+  try {
+    console.log("Executing payload.find query");
+    const result = await payload.find({
+      collection: "team",
+      limit: 1,
+      where: {
+        and: [
+          {
+            slug: {
+              equals: slug,
+            },
+          },
+        ],
+      },
+    });
+    console.log("Query result:", result);
+    if (result.docs[0]) {
+      console.log("Team member found");
+      return result.docs[0];
+    } else {
+      console.log("No team member found with the given slug");
+      return null;
+    }
+  } catch (error) {
+    console.error("Error querying team member:", error);
+    return null;
+  }
+}

--- a/src/app/(frontend)/(inner)/team/individual/page.tsx
+++ b/src/app/(frontend)/(inner)/team/individual/page.tsx
@@ -1,5 +1,0 @@
-export default function Page() {
-  return (
-    
-  );
-}

--- a/src/collections/Team/config.ts
+++ b/src/collections/Team/config.ts
@@ -1,0 +1,51 @@
+import { isAdmin } from "@/access/isAdmin";
+import { publishedOnly } from "@/access/publishedOnly";
+import { slugField } from "@/fields/slug";
+import type { CollectionConfig } from "payload";
+
+export const Team: CollectionConfig = {
+  slug: "team",
+
+  //* Access Settings
+  access: {
+    create: isAdmin,
+    delete: isAdmin,
+    read: publishedOnly,
+    readVersions: isAdmin,
+    update: isAdmin,
+  },
+
+  fields: [
+    {
+      name: "title",
+      type: "text",
+      required: true,
+      unique: true,
+      label: "Full Name",
+    },
+    ...slugField(),
+  ],
+
+  //* Admin Settings
+
+  admin: {
+    description: "Our team of experts.",
+    defaultColumns: ["title"],
+    group: "Company",
+    listSearchableFields: ["title"],
+    pagination: {
+      defaultLimit: 25,
+      limits: [10, 25, 50],
+    },
+    useAsTitle: "title",
+  },
+  defaultSort: "-title",
+  labels: {
+    singular: "Team Member",
+    plural: "Team Members",
+  },
+  versions: {
+    drafts: true,
+    maxPerDoc: 25,
+  },
+};

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -25,6 +25,7 @@ export interface Config {
     technologies: Technology;
     locations: Location;
     results: Result;
+    team: Team;
     users: User;
     forms: Form;
     'form-submissions': FormSubmission;
@@ -581,6 +582,19 @@ export interface Result {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "team".
+ */
+export interface Team {
+  id: string;
+  title: string;
+  slug: string;
+  slugLock?: boolean | null;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {
@@ -679,6 +693,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'results';
         value: string | Result;
+      } | null)
+    | ({
+        relationTo: 'team';
+        value: string | Team;
       } | null)
     | ({
         relationTo: 'users';

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -27,6 +27,7 @@ import { Testimonials } from "@/collections/Testimonials/config";
 import { Users } from "@/collections/Users/config";
 import { Work } from "@/collections/Work/config";
 import { Technologies } from "@/collections/Technologies/config";
+import { Team } from "@/collections/Team/config";
 
 //* Import Globals
 import { Header } from "./globals/Header/index";
@@ -130,6 +131,7 @@ export default buildConfig({
     Technologies,
     Location,
     Results,
+    Team,
     Users,
   ],
   globals: [Header, Footer],


### PR DESCRIPTION
### TL;DR

Added a new Team collection and implemented a dynamic page for individual team members.

### What changed?

- Created a new Team collection with fields for title and slug
- Implemented a dynamic page for individual team members at `/team/[slug]`
- Added console logging for better debugging in blog post and team member pages
- Removed the unused `team/individual/page.tsx` file
- Updated payload types to include the new Team collection

### How to test?

1. Add team members through the Payload CMS admin panel
2. Navigate to `/team/[slug]` where `[slug]` is the slug of a team member
3. Verify that the team member's title is displayed on the page
4. Check the console logs for debugging information during page generation and rendering

### Why make this change?

This change introduces a new Team collection and associated pages to showcase individual team members on the website. It allows for dynamic content creation and improved management of team member information through the CMS.