### PR TITLE
feat(cms): upload Team collection with role and image fields

### DIFF
--- a/src/collections/Team/config.ts
+++ b/src/collections/Team/config.ts
@@ -24,6 +24,24 @@ export const Team: CollectionConfig = {
       label: "Full Name",
     },
     ...slugField(),
+    {
+      name: "role",
+      type: "text",
+      required: true,
+      label: "Role",
+      admin: {
+        position: "sidebar",
+      },
+    },
+    {
+      name: "image",
+      type: "upload",
+      relationTo: "media",
+      label: "Featured Image",
+      admin: {
+        position: "sidebar",
+      },
+    },
   ],
 
   //* Admin Settings

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -589,6 +589,8 @@ export interface Team {
   title: string;
   slug: string;
   slugLock?: boolean | null;
+  role: string;
+  image?: (string | null) | Media;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;


### PR DESCRIPTION
### TL;DR

Added role and image fields to the Team collection.

### What changed?

- Added a required 'role' text field to the Team collection config
- Added an optional 'image' upload field to the Team collection config, related to media
- Updated the Team interface in payload-types.ts to include the new 'role' and 'image' properties

### How to test?

1. Navigate to the Team collection in the admin panel
2. Create or edit a Team member
3. Verify that the 'Role' field is required and appears in the sidebar
4. Check that the 'Featured Image' field is optional and allows uploading an image
5. Save the Team member and confirm that the new fields are properly stored and displayed

### Why make this change?

This change enhances the Team collection by adding important information about each team member. The role field allows for better organization and categorization of team members, while the image field enables visual representation, improving the overall presentation of the team on the website or in the admin panel.