### PR TITLE
feat(team): add full bleed hero image to team page

### DIFF
--- a/src/app/(frontend)/(inner)/team/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/team/[slug]/page.tsx
@@ -42,7 +42,60 @@ export default async function TeamPage({
   }
   console.log(`Team member found: ${team.title}`);
 
-  return <>{team.title}</>;
+  return (
+    <>
+      <div className="relative h-screen w-full overflow-hidden">
+        <div className="absolute inset-0 z-10">
+          <Image
+            src={team.image?.url || ""}
+            alt={team.title}
+            fill
+            style={{ objectFit: "cover" }}
+            quality={80}
+          />
+        </div>
+        <div className="absolute inset-0 z-20 bg-gradient-to-b from-transparent to-black opacity-70"></div>
+        <div className="absolute inset-0 z-30 flex items-end justify-start">
+          <div className="w-full max-w-xl p-8 lg:p-16">
+            <div className="relative mb-4">
+              <div className="absolute bottom-0 left-0 h-7 w-3 bg-neutral-950"></div>
+              <div className="relative inline-flex w-auto rounded-tl-xl rounded-tr-xl bg-neutral-950 px-4 pt-1 lg:pt-2">
+                <div className="inline-flex items-center">
+                  <div className="h-1.5 w-1.5 rounded-full bg-white"></div>
+                  <div className="ml-2 font-light text-white">
+                    Meet the Team
+                  </div>
+                </div>
+                <svg
+                  className="absolute bottom-[0.13rem] right-0 h-6 w-6 text-neutral-950 lg:h-6 lg:w-6"
+                  fill="rgb(14, 15, 17)"
+                  version="1.1"
+                  viewBox="0 0 100 100"
+                  x="0"
+                  xmlSpace="preserve"
+                  xmlns="http://www.w3.org/2000/svg"
+                  y="0"
+                >
+                  <path
+                    d="M98.1 0h1.9v51.9h-1.9c0-27.6-22.4-50-50-50V0h50z"
+                    fill="rgb(14, 15, 17)"
+                  />
+                </svg>
+              </div>
+            </div>
+            <h2 className="bg-neutral-950 bg-opacity-80 py-2 text-6xl text-white lg:pb-3 lg:pt-3">
+              <span className="block overflow-hidden text-ellipsis pl-3 lg:pl-5">
+                {team.title}
+              </span>
+              <span className="block overflow-hidden text-ellipsis px-3 text-3xl text-zinc-400 lg:pl-5 lg:pr-5">
+                {team.role}
+              </span>
+            </h2>
+          </div>
+        </div>
+      </div>
+    </>
+  );
 }
 
 async function queryPostBySlug({


### PR DESCRIPTION
### TL;DR

Enhanced the TeamPage component with a visually appealing layout and dynamic content display.

### What changed?

- Replaced the simple title display with a full-screen layout
- Added a background image using the team member's image
- Implemented a gradient overlay for better text visibility
- Created a styled header with "Meet the Team" label
- Displayed the team member's title and role in a stylized format

### How to test?

1. Navigate to a team member's page
2. Verify that the full-screen layout is displayed correctly
3. Check if the background image is loaded and properly sized
4. Ensure the gradient overlay is visible
5. Confirm that the "Meet the Team" label appears correctly
6. Verify that the team member's title and role are displayed in the proper format

### Why make this change?

This change significantly improves the visual presentation of individual team member pages. It creates a more engaging and professional look, highlighting each team member's information in an attractive and easily readable format. The full-screen layout with background image and styled text enhances the user experience and provides a more cohesive design with the rest of the application.