### PR TITLE
fix(LogoSlider): add proper types for logos

### DIFF
--- a/src/app/(frontend)/(inner)/location/individual/LogoSlider/index.tsx
+++ b/src/app/(frontend)/(inner)/location/individual/LogoSlider/index.tsx
@@ -1,13 +1,7 @@
 import { getPayloadHMR } from "@payloadcms/next/utilities";
 import configPromise from "@payload-config";
 import Image from "next/image";
-
-// TODO: add the animation to the logos
-
-interface Brand {
-  id: string;
-  logoLight?: string;
-}
+import { Brand, Media } from "@/payload-types";
 
 const LogoItem = ({ logo }: { logo: string }) => {
   return (
@@ -159,7 +153,7 @@ export async function LogoSlider() {
                     logo={
                       typeof brand.logoLight === "string"
                         ? brand.logoLight
-                        : brand.logoLight?.url || ""
+                        : (brand.logoLight as Media)?.url || ""
                     }
                   />
                 ))}
@@ -173,7 +167,7 @@ export async function LogoSlider() {
                     logo={
                       typeof brand.logoLight === "string"
                         ? brand.logoLight
-                        : brand.logoLight?.url || ""
+                        : (brand.logoLight as Media)?.url || ""
                     }
                   />
                 ))}


### PR DESCRIPTION
### TL;DR

Updated LogoSlider component to use typed imports and improved type safety.

### What changed?

- Removed the custom `Brand` interface and imported `Brand` and `Media` types from `@/payload-types`.
- Updated type casting for `brand.logoLight` to use the `Media` type.
- Removed TODO comment about adding animation to logos.

### How to test?

1. Navigate to the individual location page where the LogoSlider component is used.
2. Verify that the logos are displayed correctly in the slider.
3. Check the console for any TypeScript-related errors.

### Why make this change?

This change improves type safety and consistency by using imported types from the payload-types file. It reduces the risk of type-related errors and makes the code more maintainable. The removal of the TODO comment suggests that the animation feature has either been implemented or is no longer needed.