### PR TITLE
fix(work): add proper types for nested object

### DIFF
--- a/src/app/(frontend)/(inner)/work/page.tsx
+++ b/src/app/(frontend)/(inner)/work/page.tsx
@@ -196,7 +196,12 @@ export default async function WorkPage() {
                           {testimonials.docs[0].author}
                         </div>
                         <div className="text-sm font-light text-zinc-400">
-                          {testimonials.docs[0].brand.title}
+                          {typeof testimonials.docs[0].brand === "object" &&
+                          testimonials.docs[0].brand?.title
+                            ? testimonials.docs[0].brand.title
+                            : typeof testimonials.docs[0].brand === "string"
+                              ? testimonials.docs[0].brand
+                              : null}
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
### TL;DR

Enhanced the display of testimonial brand information on the work page.

### What changed?

Updated the rendering logic for the testimonial brand in the work page. The code now handles different data structures for the brand field, accommodating both object and string types.

### How to test?

1. Navigate to the work page.
2. Verify that testimonials display correctly for different brand data types:
   - When brand is an object with a title property
   - When brand is a string
   - When brand is undefined or null

### Why make this change?

This change improves the robustness of the testimonial display, ensuring that brand information is correctly shown regardless of the data structure. It prevents potential errors and provides a more consistent user experience across different testimonial formats.