### PR TITLE
fix(blog): add proper types for CategoryFilter count

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://brewww.studio</loc><lastmod>2024-10-16T18:24:13.755Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio</loc><lastmod>2024-10-16T20:20:17.603Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/app/(frontend)/(inner)/blog/page.tsx
+++ b/src/app/(frontend)/(inner)/blog/page.tsx
@@ -2,6 +2,7 @@ import { getPayloadHMR } from "@payloadcms/next/utilities";
 import configPromise from "@payload-config";
 import { BlogCard } from "@/components/BlogCard/index";
 import { CategoryFilter } from "@/components/CategoryFilter/index";
+import { Category, Post } from "@/payload-types";
 
 export default async function BlogPage() {
   const payload = await getPayloadHMR({ config: configPromise });
@@ -21,14 +22,22 @@ export default async function BlogPage() {
   const categoryCounts = categories.docs.reduce(
     (acc, category) => {
       acc[category.id] = posts.docs.filter((post) =>
-        post.metadata.categories.includes(category.id),
+        post.metadata?.categories?.some((cat) => {
+          if (typeof cat === "string") {
+            return cat === category.id;
+          }
+          return (cat as Category).id === category.id;
+        }),
       ).length;
       return acc;
     },
     {} as Record<string, number>,
   );
 
+  console.log("Posts:", posts.docs.length);
+  console.log("Categories:", categories.docs.length);
   console.log("Category Counts:", categoryCounts);
+  console.log("Sample post metadata:", posts.docs[0]?.metadata);
 
   return (
     <>


### PR DESCRIPTION
### TL;DR

Updated sitemap timestamp and improved blog page functionality with better type handling and debugging.

### What changed?

- Updated the `lastmod` timestamp in `sitemap.xml`
- Added import for `Category` and `Post` types from `@/payload-types`
- Improved category filtering logic in `BlogPage` component to handle both string and object category references
- Added console logging statements for debugging purposes

### How to test?

1. Check the `sitemap.xml` file to ensure the `lastmod` timestamp has been updated
2. Navigate to the blog page and verify that posts are correctly filtered by categories
3. Review the console logs to ensure the correct number of posts and categories are being displayed
4. Test with various post and category configurations to ensure the filtering works as expected

### Why make this change?

This change addresses potential type issues when handling category references in blog posts. It improves the robustness of the category filtering logic by accommodating both string IDs and object references. The added console logging statements will help with debugging and ensure that the correct data is being processed and displayed on the blog page.