### PR TITLE
feat(ui): add about us section to the proposal page

### DIFF
--- a/src/app/(frontend)/(inner)/proposal/page.tsx
+++ b/src/app/(frontend)/(inner)/proposal/page.tsx
@@ -221,6 +221,111 @@ export default function ProposalPage() {
           srcSet="https://cdn.prod.website-files.com/66c0fd4751b1d035e8c66e54/66c7ff7f038a61dbecde6b30_Image-2-p-500.avif 500w, https://cdn.prod.website-files.com/66c0fd4751b1d035e8c66e54/66c7ff7f038a61dbecde6b30_Image-2-p-800.avif 800w, https://cdn.prod.website-files.com/66c0fd4751b1d035e8c66e54/66c7ff7f038a61dbecde6b30_Image-2.avif 1440w"
         />
       </section>
+      <section className="relative bg-white py-20 font-light text-zinc-900">
+        <div className="container mx-auto px-4">
+          <div className="grid grid-cols-1 items-center gap-16 lg:grid-cols-2">
+            <div className="max-w-xl">
+              <div className="mb-6 flex items-center">
+                <div className="mr-4 h-4 w-4 rounded-full bg-red-500" />
+                <h2 className="text-4xl lg:text-5xl">About Plymouth</h2>
+              </div>
+              <p className="text-lg text-zinc-900/70">
+                Our dedicated team of experts is passionate about driving your
+                success by combining creativity, cutting-edge technology, and
+                strategic insight. We collaborate to craft innovative solutions
+                tailored to your unique business needs, ensuring that every
+                project we undertake not only meets but exceeds your
+                expectations.
+              </p>
+            </div>
+            <div className="relative grid grid-cols-2 gap-8">
+              <img
+                className="h-96 w-full object-cover"
+                src="https://cdn.prod.website-files.com/66c0fd4751b1d035e8c66e54/66c0fd4751b1d035e8c66f5b_homepage-about-image-2-ar-4-5.avif"
+                srcSet="https://cdn.prod.website-files.com/66c0fd4751b1d035e8c66e54/66c0fd4751b1d035e8c66f5b_homepage-about-image-2-ar-4-5.avif 500w, https://cdn.prod.website-files.com/66c0fd4751b1d035e8c66e54/66c0fd4751b1d035e8c66f5b_homepage-about-image-2-ar-4-5.avif 1200w"
+                alt="About Plymouth image 1"
+              />
+              <img
+                className="mt-16 h-80 w-full object-cover"
+                src="https://cdn.prod.website-files.com/66c0fd4751b1d035e8c66e54/66c0fd4751b1d035e8c66f59_homepage-about-image-3-ar-4-5.avif"
+                srcSet="https://cdn.prod.website-files.com/66c0fd4751b1d035e8c66e54/66c0fd4751b1d035e8c66f59_homepage-about-image-3-ar-4-5.avif 500w, https://cdn.prod.website-files.com/66c0fd4751b1d035e8c66e54/66c0fd4751b1d035e8c66f59_homepage-about-image-3-ar-4-5.avif 1200w"
+                alt="About Plymouth image 2"
+              />
+              <div className="absolute left-1/2 top-1/2 -z-10 flex h-80 w-80 -translate-x-1/2 -translate-y-1/2 transform items-center justify-center rounded-full border-2 border-zinc-900">
+                <p className="text-center text-xl font-bold text-zinc-900">
+                  We craft unbounded brands
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section className="relative bg-white pt-40 font-light text-zinc-900">
+        <div className="container mx-auto px-4">
+          <div className="grid grid-cols-1 gap-16 lg:grid-cols-2">
+            <div>
+              <div className="mb-6 flex items-center">
+                <div className="mr-4 h-4 w-4 rounded-full bg-red-500" />
+                <h2 className="text-4xl lg:text-5xl">The Way We Work</h2>
+              </div>
+              <p className="text-lg text-zinc-900/70">
+                Our streamlined process ensures a seamless journey from strategy
+                to execution, creating a powerful and cohesive brand presence.
+              </p>
+            </div>
+            <div>
+              <div className="relative cursor-pointer border-b-2 border-solid border-b-zinc-900/[0.15] pb-8">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-2xl">
+                    <span className="mr-2 text-red-500">01.</span>Discovery &
+                    Strategy
+                  </h3>
+                  <div className="flex items-center justify-center rounded-full border border-zinc-900/[0.15] p-2">
+                    <img
+                      className="h-1.5 w-3 object-cover"
+                      src="https://cdn.prod.website-files.com/66c0fd4751b1d035e8c66e54/66c0fd4751b1d035e8c66eb3_arrow-down-ember.svg"
+                      alt="Arrow down"
+                    />
+                  </div>
+                </div>
+                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
+              </div>
+              <div className="relative cursor-pointer border-b-2 border-solid border-b-zinc-900/[0.15] py-8">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-2xl">
+                    <span className="mr-2 text-red-500">02.</span>Design &
+                    Development
+                  </h3>
+                  <div className="flex items-center justify-center rounded-full border border-zinc-900/[0.15] p-2">
+                    <img
+                      className="h-1.5 w-3 object-cover"
+                      src="https://cdn.prod.website-files.com/66c0fd4751b1d035e8c66e54/66c0fd4751b1d035e8c66eb3_arrow-down-ember.svg"
+                      alt="Arrow down"
+                    />
+                  </div>
+                </div>
+                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
+              </div>
+              <div className="relative cursor-pointer border-b-2 border-solid border-b-zinc-900/[0.15] py-8">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-2xl">
+                    <span className="mr-2 text-red-500">03.</span>Execution &
+                    Optimization
+                  </h3>
+                  <div className="flex items-center justify-center rounded-full border border-zinc-900/[0.15] p-2">
+                    <img
+                      className="h-1.5 w-3 object-cover"
+                      src="https://cdn.prod.website-files.com/66c0fd4751b1d035e8c66e54/66c0fd4751b1d035e8c66eb3_arrow-down-ember.svg"
+                      alt="Arrow down"
+                    />
+                  </div>
+                </div>
+                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
     </>
   );
 }


### PR DESCRIPTION
### TL;DR

Added "About Us" and "The Way We Work" sections to the proposal page.

### What changed?

- Introduced a new "About Us" section with:
  - A brief description of the company's expertise and approach
  - Two images showcasing the company's work
  - A circular overlay with the text "We craft unbounded brands"

- Added "The Way We Work" section featuring:
  - An overview of the company's process
  - Three expandable steps: Discovery & Strategy, Design & Development, and Execution & Optimization

### How to test?

1. Navigate to the proposal page
2. Scroll down to view the new "About Plymouth" section
3. Verify the content, images, and circular overlay are displayed correctly
4. Continue scrolling to the "The Way We Work" section
5. Check that the three steps are visible and have expandable functionality

### Why make this change?

These additions provide potential clients with more information about Plymouth's expertise and working process. The "About Plymouth" section builds trust by showcasing the company's approach and visual work, while "The Way We Work" outlines the structured process, giving clients a clear understanding of what to expect when working with Plymouth.