### PR TITLE
feat(ui): add initial card style for proposal page case study section

### DIFF
--- a/src/app/(frontend)/(inner)/proposal/page.tsx
+++ b/src/app/(frontend)/(inner)/proposal/page.tsx
@@ -326,6 +326,37 @@ export default function ProposalPage() {
           </div>
         </div>
       </section>
+      <section className="bg-white py-20 font-light text-zinc-900">
+        <div className="container mx-auto">
+          <div className="flex items-center">
+            <div className="mr-4 h-3 w-3 rounded-full bg-red-500"></div>
+            <h2 className="text-5xl">Case Studies</h2>
+          </div>
+        </div>
+      </section>
+      <section className="bg-white py-20">
+        <div className="container mx-auto">
+          <div className="flex overflow-hidden rounded-lg shadow-lg">
+            <div className="w-1/2 bg-black p-8 text-white">
+              <h3 className="mb-4 text-3xl font-bold">
+                Vintage Broncos Website Redesign
+              </h3>
+              <div className="space-y-2 text-sm">
+                <p>Client: Denver Broncos</p>
+                <p>Duration: 3 months</p>
+                <p>Services: UX/UI Design, Web Development</p>
+              </div>
+            </div>
+            <div className="w-1/2">
+              <img
+                src="/path-to-your-image.jpg"
+                alt="Vintage Broncos Website Redesign"
+                className="h-full w-full object-cover"
+              />
+            </div>
+          </div>
+        </div>
+      </section>
     </>
   );
 }


### PR DESCRIPTION
### TL;DR

Added a new Case Studies section to the Proposal page.

### What changed?

- Introduced a new "Case Studies" section with a red dot indicator and a large heading.
- Added a showcase for a specific case study: "Vintage Broncos Website Redesign".
- The case study is presented in a split layout with project details on the left and an image placeholder on the right.

### How to test?

1. Navigate to the Proposal page.
2. Scroll down to find the new "Case Studies" section.
3. Verify the presence of the red dot indicator and the "Case Studies" heading.
4. Check the case study showcase for the "Vintage Broncos Website Redesign".
5. Ensure the layout is split with project details on the left and an image placeholder on the right.
6. Confirm that the project details include client name, duration, and services provided.

### Why make this change?

This addition enhances the Proposal page by showcasing previous work through case studies. It provides potential clients with concrete examples of the company's capabilities and successful projects, which can increase credibility and help in securing new business opportunities.