### PR TITLE
feat(home): add ServicesSection to home page

### DIFF
--- a/src/app/(frontend)/(inner)/blog/page.tsx
+++ b/src/app/(frontend)/(inner)/blog/page.tsx
@@ -34,35 +34,12 @@ export default async function BlogPage() {
     {} as Record<string, number>,
   );
 
-  console.log("Posts:", posts.docs.length);
-  console.log("Categories:", categories.docs.length);
-  console.log("Category Counts:", categoryCounts);
-  console.log("Sample post metadata:", posts.docs[0]?.metadata);
-
   return (
     <>
-      <section className="bg-brand-dark-bg text-white">
-        <div className="container mx-auto px-6 py-24">
-          <div className="mx-auto flex max-w-4xl flex-col items-center justify-center text-center">
-            <div className="mb-4 font-bold uppercase">+ Insights</div>
-            <h1 className="mb-6 text-6xl font-bold leading-tight sm:text-7xl lg:text-8xl">
-              Their insights are simply...brilliant.
-            </h1>
-            <div className="uppercase text-neutral-400">
-              - Our Moms (probably)
-            </div>
-          </div>
-        </div>
-      </section>
-
       <section className="flex w-full flex-wrap bg-brand-dark-bg px-2 py-4 text-black lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
-        <div className="w-full lg:w-[93.75%]">
-          <h1 className="mb-2 inline-flex w-auto items-center lg:absolute lg:left-[1.00rem] lg:top-[0.75rem] lg:mb-0">
-            <div className="h-1.5 w-1.5 rounded-full bg-white" />
-            <div className="ml-2 font-light text-white">The Blog</div>
-          </h1>
-          <ul className="flex list-none flex-wrap">
-            <li className="mr-4 list-item lg:mr-10">
+        <div className="container mx-auto w-full">
+          <ul className="flex list-none flex-row flex-wrap justify-start">
+            <li className="mb-2 mr-4">
               <CategoryFilter
                 title="Explore All"
                 count={posts.totalDocs}
@@ -70,7 +47,7 @@ export default async function BlogPage() {
               />
             </li>
             {categories.docs.map((category) => (
-              <li key={category.id} className="mr-4 list-item lg:mr-10">
+              <li key={category.id} className="mb-2 mr-4">
                 <CategoryFilter
                   title={category.title}
                   count={categoryCounts[category.id] || 0}
@@ -84,7 +61,6 @@ export default async function BlogPage() {
 
       <section className="bg-brand-dark-bg py-24">
         <div className="container mx-auto">
-          <h1 className="mb-12 text-4xl font-bold text-white">Insights</h1>
           <div className="relative grid auto-rows-auto grid-cols-3 gap-x-8 gap-y-24 text-zinc-100">
             {posts.docs.map((post) => (
               <BlogCard key={post.id} post={post} />
@@ -109,18 +85,6 @@ export default async function BlogPage() {
     </>
   );
 }
-
-// type Post = {
-//   id: string;
-//   slug: string;
-//   name: string;
-//   category?: string | { name: string };
-//   publishedDate: string;
-//   readTime?: string;
-//   url?: string;
-//   imageUrl?: string;
-//   featuredImage?: { url: string };
-// };
 
 // type Guide = {
 //   id: string;

--- a/src/app/(frontend)/(inner)/home/ServicesSection/index.tsx
+++ b/src/app/(frontend)/(inner)/home/ServicesSection/index.tsx
@@ -1,0 +1,3 @@
+export function ServicesSection() {
+  return <div>ServicesSection</div>;
+}

--- a/src/app/(frontend)/(inner)/home/page.tsx
+++ b/src/app/(frontend)/(inner)/home/page.tsx
@@ -6,6 +6,7 @@ import { ImageGrow } from "./ImageGrow/index";
 import { HomeHeroSection } from "./HomeHeroSection/index";
 import { WorkGridSection } from "./WorkGridSection/index";
 import { BlogGridSection } from "./BlogGridSection/index";
+import { ServicesSection } from "./ServicesSection/index";
 
 export default async function Home() {
   const payload = await getPayloadHMR({ config: configPromise });
@@ -43,6 +44,7 @@ export default async function Home() {
       <WorkGridSection projects={projects.docs} />
       <ImageGrow />
       <BlogGridSection posts={posts.docs} />
+      <ServicesSection />
 
       <section className="bg-brand-dark-bg text-zinc-50">
         <div className="container mx-auto px-4">

--- a/src/collections/Services/config.ts
+++ b/src/collections/Services/config.ts
@@ -38,29 +38,29 @@ export const Services: CollectionConfig = {
       name: "tagline",
       type: "text",
       label: "Tagline",
-      required: true,
+      required: false,
       admin: {
         description:
           "The tagline of the service as it appears around the site.",
       },
     },
+
+    ...slugField(),
     {
-      name: "imageMain",
+      name: "image",
       type: "upload",
-      label: "Main Image",
-      required: true,
+      label: "Featured Image",
+      required: false,
       relationTo: "media",
       admin: {
-        description:
-          "The main image of the service as it appears around the site.",
+        position: "sidebar",
       },
     },
-    ...slugField(),
     {
       name: "description",
       type: "textarea",
       label: "Description",
-      required: true,
+      required: false,
       admin: {
         description:
           "The description of the service as it appears around the site.",
@@ -72,7 +72,14 @@ export const Services: CollectionConfig = {
       tabs: [
         {
           label: "Content",
-          fields: [],
+          fields: [
+            {
+              name: "overview",
+              type: "richText",
+              label: "Overview Test",
+              required: false,
+            },
+          ],
         },
         {
           name: "metadata",

--- a/src/components/CategoryFilter/index.tsx
+++ b/src/components/CategoryFilter/index.tsx
@@ -19,7 +19,7 @@ export const CategoryFilter = ({
       href={slug || "#"}
     >
       <div
-        className={`cursor-pointer text-headline-small lowercase leading-none ${title.toLowerCase() === "explore all" ? "indent-48" : ""}`}
+        className={`cursor-pointer text-title-medium lowercase leading-none ${title.toLowerCase() === "explore all" ? "indent-48" : ""}`}
       >
         {title}
       </div>

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -477,11 +477,26 @@ export interface Play {
 export interface Service {
   id: string;
   title: string;
-  tagline: string;
-  imageMain: string | Media;
+  tagline?: string | null;
   slug: string;
   slugLock?: boolean | null;
-  description: string;
+  image?: (string | null) | Media;
+  description?: string | null;
+  overview?: {
+    root: {
+      type: string;
+      children: {
+        type: string;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
   metadata?: {};
   seo?: {
     title?: string | null;


### PR DESCRIPTION
### TL;DR

Simplified blog page layout, added ServicesSection to home page, and updated Services collection configuration.

### What changed?

- Simplified the blog page layout by removing unnecessary sections and adjusting the category filter styling.
- Added a new ServicesSection component to the home page.
- Updated the Services collection configuration:
  - Made tagline, image, and description fields optional.
  - Renamed imageMain to image and moved it to the sidebar.
  - Added a new richText field called "overview" under the Content tab.
- Adjusted the CategoryFilter component styling.

### How to test?

1. Check the blog page for the simplified layout and updated category filter styling.
2. Verify the new ServicesSection component appears on the home page.
3. In the admin panel, create or edit a Service and ensure the new field configuration is correct:
   - Tagline, image, and description should be optional.
   - The image field should appear in the sidebar.
   - An "overview" rich text field should be available under the Content tab.

### Why make this change?

These changes aim to improve the user experience on the blog page, introduce a new section for services on the home page, and provide more flexibility in the Services collection configuration. The updates to the Services collection allow for more diverse content creation and better organization of service information.