### PR TITLE
feat(home): create separate ServicesCard for the home page

### DIFF
--- a/src/app/(frontend)/(inner)/home/ServicesCard/index.tsx
+++ b/src/app/(frontend)/(inner)/home/ServicesCard/index.tsx
@@ -1,0 +1,22 @@
+import { Service } from "@/payload-types";
+import Image from "next/image";
+import Link from "next/link";
+
+export function ServicesCard({ service }: { service: Service }) {
+  return (
+    <>
+      {" "}
+      <div className="w-full border-b-2 border-solid border-neutral-700">
+        <a
+          className="flex w-full items-center py-4 lg:pb-6 lg:pt-6"
+          href={`/services/${service.slug}`}
+        >
+          <div className="inline-flex h-16 w-20 cursor-pointer items-center justify-center overflow-hidden rounded-2xl bg-neutral-950 md:h-28 md:w-36 lg:w-0 min-[1800px]:h-40" />
+          <div className="inline-flex cursor-pointer text-[7.50rem] leading-none text-white">
+            <div>{service.title}</div>
+          </div>
+        </a>
+      </div>
+    </>
+  );
+}

--- a/src/app/(frontend)/(inner)/home/ServicesSection/index.tsx
+++ b/src/app/(frontend)/(inner)/home/ServicesSection/index.tsx
@@ -1,3 +1,178 @@
 export function ServicesSection() {
-  return <div>ServicesSection</div>;
+  return (
+    <section className="w-full rounded-3xl bg-zinc-900 py-20 text-black lg:pb-24 lg:pt-24 min-[1450px]:pb-32 min-[1450px]:pt-32 min-[2100px]:pb-40 min-[2100px]:pt-40">
+      <div className="px-2 sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20 min-[1800px]:pl-40 min-[1800px]:pr-40 min-[2100px]:pl-60 min-[2100px]:pr-60">
+        <div className="mb-10 flex w-full flex-wrap justify-between lg:mb-20">
+          <div className="mb-2 w-full px-2 lg:mb-0 lg:w-[31.25%] lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
+            <div className="inline-flex items-center">
+              <div className="h-1.5 w-1.5 rounded-full bg-white" />
+              <div className="ml-2 font-light text-white">Our Expertise</div>
+            </div>
+          </div>
+          <div className="flex w-full flex-wrap lg:w-[68.75%]">
+            <div className="mb-5 w-full px-2 text-5xl text-white lg:mb-0 lg:w-[56.25%] lg:pl-3 lg:pr-3 xl:w-[62.5%] xl:pl-4 xl:pr-4">
+              <h2 className="max-w-xl indent-32 min-[2100px]:max-w-2xl">
+                How we take your business to the next level
+              </h2>
+            </div>
+            <div className="w-full px-2 sm:w-[62.5%] lg:w-[43.75%] lg:pl-3 lg:pr-3 xl:w-[37.5%] xl:pl-4 xl:pr-4">
+              <div className="mb-5 w-full text-lg font-light text-zinc-400">
+                <p className="mb-6">
+                  We are a digital marketing agency with expertise, and we're on
+                  a mission to help you take the next step in your business.
+                </p>
+              </div>
+              <div className="relative inline-flex items-center">
+                <a
+                  className="inline-flex"
+                  href=""
+                  style={{
+                    outlineOffset: "2px",
+                    outlineStyle: "solid",
+                    outlineWidth: "2px",
+                  }}
+                >
+                  <div className="inline-flex w-auto cursor-pointer items-center justify-center overflow-hidden rounded-full bg-brand-gold px-5 py-2">
+                    <div className="inline-flex">See all services</div>
+                  </div>
+                  <div className="-ml-1 flex h-9 w-9 cursor-pointer items-center justify-center overflow-hidden rounded-full bg-brand-gold" />
+                </a>
+                <div className="absolute right-0 top-0 z-20 flex h-9 w-9 items-center justify-center">
+                  <div className="relative overflow-hidden">
+                    <div>
+                      <svg
+                        className="h-3 w-3"
+                        fill="rgb(1, 2, 2)"
+                        viewBox="0 0 384 512"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M328 96h24v288h-48V177.9L81 401l-17 17-33.9-34 17-17 223-223H64V96h264z"
+                          fill="rgb(1, 2, 2)"
+                        />
+                      </svg>
+                    </div>
+                    <div className="absolute left-0 top-0">
+                      <svg
+                        className="h-3 w-3"
+                        fill="rgb(1, 2, 2)"
+                        viewBox="0 0 384 512"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M328 96h24v288h-48V177.9L81 401l-17 17-33.9-34 17-17 223-223H64V96h264z"
+                          fill="rgb(1, 2, 2)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="flex w-full flex-wrap justify-between">
+          <div className="order-1 mt-12 flex h-auto w-full px-2 lg:w-[31.25%] lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
+            <div className="sticky w-full self-end">
+              <a
+                className="relative inline-flex w-auto items-center rounded-full py-1.5 pl-1.5 pr-8"
+                href=""
+              >
+                <div className="absolute left-0 top-0 z-0 h-full w-full cursor-pointer rounded-full bg-neutral-950" />
+                <div className="relative mr-3 flex h-14 w-14 cursor-pointer items-center justify-center overflow-hidden rounded-full">
+                  <svg
+                    className="h-3 w-3 text-white"
+                    fill="rgb(255, 255, 255)"
+                    height="16"
+                    viewBox="0 0 384 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M384 256L0 32v448l384-224z"
+                      fill="rgb(255, 255, 255)"
+                    />
+                  </svg>
+
+                  <picture>
+                    <source
+                      src="https://made-byshape.transforms.svdcdn.com/production/uploads/images/India-2022/Individuals-Black-Wall/Shape-April-2022-HR-186.jpg?w=200&h=200&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=0.5&fp-y=0.5&dm=1651143173&s=be043bcd94bb13283574b35d1df6ee93"
+                      type="image/webp"
+                    />
+
+                    <img
+                      className="absolute left-0 top-0 z-0 h-full w-full max-w-full object-cover"
+                      src="https://made-byshape.transforms.svdcdn.com/production/uploads/images/India-2022/Individuals-Black-Wall/Shape-April-2022-HR-186.jpg?w=200&h=200&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=0.5&fp-y=0.5&dm=1651143173&s=be043bcd94bb13283574b35d1df6ee93"
+                    />
+                  </picture>
+                </div>
+                <div className="cursor-pointer">
+                  <div className="text-white">Hear from Andy</div>
+                  <div className="font-light text-zinc-400">
+                    Co-founder of Shape
+                  </div>
+                </div>
+              </a>
+            </div>
+          </div>
+          <div className="order-2 w-full px-2 lg:w-[68.75%] lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
+            <div className="w-full border-b-2 border-solid border-neutral-700">
+              <a
+                className="flex w-full items-center py-4 lg:pb-6 lg:pt-6"
+                href=""
+              >
+                <div className="inline-flex h-16 w-20 cursor-pointer items-center justify-center overflow-hidden rounded-2xl bg-neutral-950 md:h-28 md:w-36 lg:w-0 min-[1800px]:h-40" />
+                <div className="inline-flex cursor-pointer text-[7.50rem] leading-none text-white">
+                  <div>Brand Identity</div>
+                </div>
+              </a>
+            </div>
+            <div className="w-full border-b-2 border-solid border-neutral-700">
+              <a
+                className="flex w-full items-center py-4 lg:pb-6 lg:pt-6"
+                href=""
+              >
+                <div className="inline-flex h-16 w-20 cursor-pointer items-center justify-center overflow-hidden rounded-2xl bg-neutral-950 md:h-28 md:w-36 lg:w-0 min-[1800px]:h-40" />
+                <div className="inline-flex cursor-pointer text-[7.50rem] leading-none text-white">
+                  <div>Websites</div>
+                </div>
+              </a>
+            </div>
+            <div className="w-full border-b-2 border-solid border-neutral-700">
+              <a
+                className="flex w-full items-center py-4 lg:pb-6 lg:pt-6"
+                href=""
+              >
+                <div className="inline-flex h-16 w-20 cursor-pointer items-center justify-center overflow-hidden rounded-2xl bg-neutral-950 md:h-28 md:w-36 lg:w-0 min-[1800px]:h-40" />
+                <div className="inline-flex cursor-pointer text-[7.50rem] leading-none text-white">
+                  <div>SEO</div>
+                </div>
+              </a>
+            </div>
+            <div className="w-full border-b-2 border-solid border-neutral-700">
+              <a
+                className="flex w-full items-center py-4 lg:pb-6 lg:pt-6"
+                href=""
+              >
+                <div className="inline-flex h-16 w-20 cursor-pointer items-center justify-center overflow-hidden rounded-2xl bg-neutral-950 md:h-28 md:w-36 lg:w-0 min-[1800px]:h-40" />
+                <div className="inline-flex cursor-pointer text-[7.50rem] leading-none text-white">
+                  <div>Craft CMS</div>
+                </div>
+              </a>
+            </div>
+            <div className="w-full border-b-2 border-solid border-neutral-700">
+              <a
+                className="flex w-full items-center py-4 lg:pb-6 lg:pt-6"
+                href=""
+              >
+                <div className="inline-flex h-16 w-20 cursor-pointer items-center justify-center overflow-hidden rounded-2xl bg-neutral-950 md:h-28 md:w-36 lg:w-0 min-[1800px]:h-40" />
+                <div className="inline-flex cursor-pointer text-[7.50rem] leading-none text-white">
+                  <div>Shopify</div>
+                </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
 }


### PR DESCRIPTION
### TL;DR

Implemented the ServicesSection component and added a new ServicesCard component for the home page.

### What changed?

- Created a new `ServicesCard` component to display individual service items.
- Implemented the `ServicesSection` component with a comprehensive layout for showcasing services.
- Added responsive design elements using Tailwind CSS classes.
- Incorporated a "Hear from Andy" section with an image and play button.
- Implemented service links with large text displays.

### How to test?

1. Navigate to the home page.
2. Scroll to the Services section.
3. Verify that the section displays correctly with the following elements:
   - "Our Expertise" header
   - "How we take your business to the next level" title
   - "See all services" button
   - "Hear from Andy" card with image and play button
   - List of services with large text (Brand Identity, Websites, SEO, Craft CMS, Shopify)
4. Check responsiveness by resizing the browser window.
5. Ensure all links and buttons are clickable and lead to the correct destinations.

### Why make this change?

This change enhances the home page by adding a visually appealing and informative Services section. It provides visitors with a clear overview of the company's expertise and offerings, potentially increasing engagement and conversions.