### PR TITLE
feat(ui): migrate home page services section to a dynamic database structure

### DIFF
--- a/src/app/(frontend)/(inner)/home/ServicesSection/index.tsx
+++ b/src/app/(frontend)/(inner)/home/ServicesSection/index.tsx
@@ -1,4 +1,7 @@
-export function ServicesSection() {
+import { ServiceCard } from "@/components/ServiceCard/index";
+import { Service } from "@/payload-types";
+
+export function ServicesSection({ services }: { services: Service[] }) {
   return (
     <section className="w-full rounded-3xl bg-zinc-900 py-20 text-black lg:pb-24 lg:pt-24 min-[1450px]:pb-32 min-[1450px]:pt-32 min-[2100px]:pb-40 min-[2100px]:pt-40">
       <div className="px-2 sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20 min-[1800px]:pl-40 min-[1800px]:pr-40 min-[2100px]:pl-60 min-[2100px]:pr-60">
@@ -115,61 +118,9 @@ export function ServicesSection() {
             </div>
           </div>
           <div className="order-2 w-full px-2 lg:w-[68.75%] lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
-            <div className="w-full border-b-2 border-solid border-neutral-700">
-              <a
-                className="flex w-full items-center py-4 lg:pb-6 lg:pt-6"
-                href=""
-              >
-                <div className="inline-flex h-16 w-20 cursor-pointer items-center justify-center overflow-hidden rounded-2xl bg-neutral-950 md:h-28 md:w-36 lg:w-0 min-[1800px]:h-40" />
-                <div className="inline-flex cursor-pointer text-[7.50rem] leading-none text-white">
-                  <div>Brand Identity</div>
-                </div>
-              </a>
-            </div>
-            <div className="w-full border-b-2 border-solid border-neutral-700">
-              <a
-                className="flex w-full items-center py-4 lg:pb-6 lg:pt-6"
-                href=""
-              >
-                <div className="inline-flex h-16 w-20 cursor-pointer items-center justify-center overflow-hidden rounded-2xl bg-neutral-950 md:h-28 md:w-36 lg:w-0 min-[1800px]:h-40" />
-                <div className="inline-flex cursor-pointer text-[7.50rem] leading-none text-white">
-                  <div>Websites</div>
-                </div>
-              </a>
-            </div>
-            <div className="w-full border-b-2 border-solid border-neutral-700">
-              <a
-                className="flex w-full items-center py-4 lg:pb-6 lg:pt-6"
-                href=""
-              >
-                <div className="inline-flex h-16 w-20 cursor-pointer items-center justify-center overflow-hidden rounded-2xl bg-neutral-950 md:h-28 md:w-36 lg:w-0 min-[1800px]:h-40" />
-                <div className="inline-flex cursor-pointer text-[7.50rem] leading-none text-white">
-                  <div>SEO</div>
-                </div>
-              </a>
-            </div>
-            <div className="w-full border-b-2 border-solid border-neutral-700">
-              <a
-                className="flex w-full items-center py-4 lg:pb-6 lg:pt-6"
-                href=""
-              >
-                <div className="inline-flex h-16 w-20 cursor-pointer items-center justify-center overflow-hidden rounded-2xl bg-neutral-950 md:h-28 md:w-36 lg:w-0 min-[1800px]:h-40" />
-                <div className="inline-flex cursor-pointer text-[7.50rem] leading-none text-white">
-                  <div>Craft CMS</div>
-                </div>
-              </a>
-            </div>
-            <div className="w-full border-b-2 border-solid border-neutral-700">
-              <a
-                className="flex w-full items-center py-4 lg:pb-6 lg:pt-6"
-                href=""
-              >
-                <div className="inline-flex h-16 w-20 cursor-pointer items-center justify-center overflow-hidden rounded-2xl bg-neutral-950 md:h-28 md:w-36 lg:w-0 min-[1800px]:h-40" />
-                <div className="inline-flex cursor-pointer text-[7.50rem] leading-none text-white">
-                  <div>Shopify</div>
-                </div>
-              </a>
-            </div>
+            {services.map((service) => (
+              <ServiceCard key={service.id} service={service} />
+            ))}
           </div>
         </div>
       </div>

--- a/src/app/(frontend)/(inner)/home/page.tsx
+++ b/src/app/(frontend)/(inner)/home/page.tsx
@@ -38,13 +38,18 @@ export default async function Home() {
     },
   });
 
+  const services = await payload.find({
+    collection: "services",
+    limit: 1000,
+  });
+
   return (
     <>
       <HomeHeroSection />
       <WorkGridSection projects={projects.docs} />
       <ImageGrow />
       <BlogGridSection posts={posts.docs} />
-      <ServicesSection />
+      <ServicesSection services={services.docs} />
 
       <section className="bg-brand-dark-bg text-zinc-50">
         <div className="container mx-auto px-4">

--- a/src/components/ServiceCard/index.tsx
+++ b/src/components/ServiceCard/index.tsx
@@ -2,7 +2,7 @@ import { Service } from "@/payload-types";
 import Image from "next/image";
 import Link from "next/link";
 
-export function ServicesCard({ service }: { service: Service }) {
+export function ServiceCard({ service }: { service: Service }) {
   return (
     <>
       {" "}


### PR DESCRIPTION
### TL;DR

Refactored the ServicesSection component to dynamically render service cards using data from the backend.

### What changed?

- Updated `ServicesSection` to accept a `services` prop of type `Service[]`.
- Replaced hardcoded service items with a map function that renders `ServiceCard` components for each service.
- Modified the `Home` page to fetch services data from the backend and pass it to `ServicesSection`.
- Renamed `ServicesCard` component to `ServiceCard` for consistency.

### How to test?

1. Ensure the backend is properly configured with service data.
2. Navigate to the home page and verify that the Services section displays dynamically loaded service cards.
3. Check that each service card correctly displays the service name and image (if available).
4. Confirm that the number of service cards matches the number of services fetched from the backend.

### Why make this change?

This change improves the maintainability and flexibility of the Services section. By dynamically rendering service cards based on backend data, it becomes easier to update and manage services without modifying the frontend code. This approach also ensures consistency between the displayed services and the actual data stored in the backend.