### PR TITLE
feat(work): utilize dynamic categories and project year in individual work page

### DIFF
--- a/src/app/(frontend)/(inner)/work/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/work/[slug]/page.tsx
@@ -16,7 +16,7 @@ import AudioImageSix from "/public/images/audio-six.jpg";
 import AudioImageSeven from "/public/images/audio-seven.jpg";
 import AudioImageEight from "/public/images/audio-eight.jpg";
 import { BeforeAfter } from "./BeforeAfter";
-
+import { Service } from "@/payload-types";
 export async function generateStaticParams() {
   const payload = await getPayloadHMR({ config: configPromise });
   const projects = await payload.find({
@@ -52,59 +52,29 @@ export default async function WorkPage({
         <div className="px-2 sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20 min-[1800px]:pl-40 min-[1800px]:pr-40 min-[2100px]:pl-60 min-[2100px]:pr-60">
           <div className="relative mb-5 flex w-full flex-wrap items-start justify-between lg:mb-10">
             <div className="mb-2 hidden w-full px-2 text-white lg:mb-0 lg:flex lg:w-[37.5%] lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
-              <div className="mb-3 flex flex-wrap items-center lg:mb-20">
-                <div className="mb-2 mr-2 rounded-full bg-zinc-800 px-4 pb-1.5 pt-2 lg:mb-3 lg:mr-3">
-                  Website
+              {project.services && project.services.length > 0 && (
+                <div className="mb-3 flex flex-wrap items-center lg:mb-20">
+                  {project.services.map((service, index) => (
+                    <div
+                      key={index}
+                      className="mb-2 mr-2 rounded-full bg-zinc-800 px-4 pb-1.5 pt-2 lg:mb-3 lg:mr-3 lg:inline-flex"
+                    >
+                      {typeof service === "string" ? service : service.title}
+                    </div>
+                  ))}
                 </div>
-                <div className="mb-2 mr-2 rounded-full bg-zinc-800 px-4 pb-1.5 pt-2 lg:mb-3 lg:mr-3">
-                  SEO
-                </div>
-                <div className="mb-2 mr-2 hidden rounded-full bg-zinc-800 px-4 pb-1.5 pt-2 lg:mb-3 lg:mr-3 lg:inline-flex">
-                  Illustration
-                </div>
-                <div className="mb-2 mr-2 hidden rounded-full bg-zinc-800 px-4 pb-1.5 pt-2 lg:mb-3 lg:mr-3 lg:inline-flex">
-                  Support
-                </div>
-              </div>
+              )}
             </div>
             <div className="w-full px-2 lg:w-[62.5%] lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
               <div className="relative rounded-bl-3xl lg:pb-5 lg:pl-10 lg:pr-10 lg:pt-0">
-                <svg
-                  className="absolute bottom-[0.50rem] left-0 z-30 mb-0 ml-0 h-10 w-10 text-neutral-950 lg:h-12 lg:w-12 xl:bottom-[1.50rem]"
-                  fill="rgb(14, 15, 17)"
-                  version="1.1"
-                  viewBox="0 0 100 100"
-                  x="0"
-                  xmlSpace="preserve"
-                  xmlns="http://www.w3.org/2000/svg"
-                  y="0"
-                >
-                  <path
-                    d="M98.1 0h1.9v51.9h-1.9c0-27.6-22.4-50-50-50V0h50z"
-                    fill="rgb(14, 15, 17)"
-                  />
-                </svg>
-                <svg
-                  className="absolute bottom-0 right-0 z-30 -mr-0 mb-0 h-10 w-10 text-neutral-950 lg:h-12 lg:w-12"
-                  fill="rgb(14, 15, 17)"
-                  version="1.1"
-                  viewBox="0 0 100 100"
-                  x="0"
-                  xmlSpace="preserve"
-                  xmlns="http://www.w3.org/2000/svg"
-                  y="0"
-                >
-                  <path
-                    d="M98.1 0h1.9v51.9h-1.9c0-27.6-22.4-50-50-50V0h50z"
-                    fill="rgb(14, 15, 17)"
-                  />
-                </svg>
                 <div className="mb-3 flex items-center text-zinc-400 xl:mb-5">
-                  <div className="font-light">2021</div>
+                  <div className="font-light">
+                    {project.projectYear || "Add Year"}
+                  </div>
                   <div className="ml-3 h-1.5 w-1.5 rounded-full bg-zinc-400" />
                   <div className="ml-3 font-light">{project.title}</div>
                 </div>
-                <h1 className="text-[4.25rem] leading-none text-white">
+                <h1 className="text-headline-medium leading-none text-white">
                   {project.tagline}
                 </h1>
               </div>
@@ -1469,109 +1439,6 @@ export default async function WorkPage({
           />
         </div>
       </section>
-      <article className="bg-white pt-24 text-black">
-        <div className="container mx-auto px-4 py-4">
-          <div className="flex items-center justify-between">
-            <ul className="hidden list-none flex-wrap gap-4 md:flex">
-              <li>
-                <Link href="/posts" className="hover:underline">
-                  All Posts
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/posts/category/branding"
-                  className="hover:underline"
-                >
-                  Branding
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/posts/category/web-design"
-                  className="hover:underline"
-                >
-                  Web Design
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/posts/category/content"
-                  className="hover:underline"
-                >
-                  Content
-                </Link>
-              </li>
-              <li>
-                <Link href="/posts/category/guides" className="hover:underline">
-                  Guides
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/posts/category/updates"
-                  className="hover:underline"
-                >
-                  Updates
-                </Link>
-              </li>
-            </ul>
-          </div>
-        </div>
-
-        <section className="container mx-auto px-4 pb-12 pt-12">
-          <div className="max-w-5xl">
-            <h1 className="mb-4 text-5xl font-medium leading-tight md:text-6xl">
-              {project.title}
-            </h1>
-            <p className="mb-8 max-w-3xl text-xl text-gray-700">
-              {project.description || "Add a cool description here."}
-            </p>
-            <div className="flex items-center gap-1 text-sm text-gray-500">
-              <span>
-                By{" "}
-                <Link className="text-gray-950" href={""}>
-                  Kevin Wessa
-                </Link>
-              </span>
-            </div>
-          </div>
-        </section>
-
-        <div className="w-full">
-          <div className="px-2">
-            <div className="relative aspect-[3/2] w-full">
-              <Image
-                src={
-                  typeof project.image === "string"
-                    ? project.image
-                    : project.image?.url || ""
-                }
-                fill
-                alt={
-                  typeof project.image === "object" ? project.image?.alt : ""
-                }
-                className="rounded-md object-cover"
-                priority
-              />
-            </div>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-3 gap-8 pt-8">
-          <div></div>
-          <div className="flex flex-col justify-start">
-            <article className="mx-auto pb-24">
-              {/* <RichText
-              content={project.content || ""}
-              className="prose-lg"
-              enableProse={true}
-              enableGutter={false}
-            /> */}
-            </article>
-          </div>
-        </div>
-      </article>
     </>
   );
 }

--- a/src/collections/Work/config.ts
+++ b/src/collections/Work/config.ts
@@ -55,7 +55,6 @@ export const Work: CollectionConfig = {
           "The description of the project as it appears around the site.",
       },
     },
-
     {
       type: "tabs",
       tabs: [
@@ -147,6 +146,26 @@ export const Work: CollectionConfig = {
       name: "featured",
       type: "checkbox",
       label: "Is this a featured project?",
+      required: false,
+      admin: {
+        position: "sidebar",
+      },
+    },
+    {
+      name: "services",
+      type: "relationship",
+      label: "Services",
+      relationTo: "services",
+      hasMany: true,
+      required: false,
+      admin: {
+        position: "sidebar",
+      },
+    },
+    {
+      name: "projectYear",
+      type: "number",
+      label: "Project Year",
       required: false,
       admin: {
         position: "sidebar",

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -396,6 +396,8 @@ export interface Work {
   image: string | Media;
   brand: string | Brand;
   featured?: boolean | null;
+  services?: (string | Service)[] | null;
+  projectYear?: number | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -446,32 +448,6 @@ export interface Brand {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "play".
- */
-export interface Play {
-  id: string;
-  title: string;
-  tagline: string;
-  description?: string | null;
-  content?: {};
-  metadata?: {
-    relatedPlaygrounds?: (string | Play)[] | null;
-  };
-  seo?: {
-    image?: (string | null) | Media;
-    title?: string | null;
-    description?: string | null;
-  };
-  slug: string;
-  slugLock?: boolean | null;
-  publishedOn: string;
-  image: string | Media;
-  updatedAt: string;
-  createdAt: string;
-  _status?: ('draft' | 'published') | null;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "services".
  */
 export interface Service {
@@ -503,6 +479,32 @@ export interface Service {
     image?: (string | null) | Media;
     description?: string | null;
   };
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "play".
+ */
+export interface Play {
+  id: string;
+  title: string;
+  tagline: string;
+  description?: string | null;
+  content?: {};
+  metadata?: {
+    relatedPlaygrounds?: (string | Play)[] | null;
+  };
+  seo?: {
+    image?: (string | null) | Media;
+    title?: string | null;
+    description?: string | null;
+  };
+  slug: string;
+  slugLock?: boolean | null;
+  publishedOn: string;
+  image: string | Media;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;


### PR DESCRIPTION
### TL;DR

Enhanced the Work collection and improved the WorkPage component to display dynamic project details.

### What changed?

- Added 'services' and 'projectYear' fields to the Work collection
- Updated WorkPage component to display services dynamically
- Replaced hardcoded year with dynamic projectYear
- Adjusted headline styling for better responsiveness
- Removed unnecessary SVG elements and article section
- Updated payload-types to reflect new Work collection fields

### How to test?

1. Add services and project year to existing Work entries in the admin panel
2. Navigate to a work project page on the frontend
3. Verify that services are displayed as tags
4. Check if the project year is correctly shown
5. Ensure the headline styling is responsive across different screen sizes

### Why make this change?

This change improves the flexibility and accuracy of project information displayed on the WorkPage. By adding dynamic services and project year, we can provide more relevant and up-to-date information for each project. The removal of unnecessary elements and the adjustment of styling contribute to a cleaner and more maintainable codebase.