### PR TITLE
feat(work): add growth image to as the project hero image

### DIFF
--- a/src/app/(frontend)/(inner)/work/[slug]/HeroImageGrow/index.tsx
+++ b/src/app/(frontend)/(inner)/work/[slug]/HeroImageGrow/index.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import React, { useEffect } from "react";
+import Image from "next/image";
+import { gsap } from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+
+interface ImageGrowProps {
+  imageSrc: string;
+  altText?: string;
+}
+
+export const ImageGrow: React.FC<ImageGrowProps> = ({
+  imageSrc,
+  altText = "Background",
+}) => {
+  useEffect(() => {
+    gsap.registerPlugin(ScrollTrigger);
+
+    gsap.set("#growthImageMask", { scale: 0.75 });
+    gsap.set("#growthImage", { scale: 2 });
+
+    gsap.to("#growthImageMask, #growthImage", {
+      scale: 1,
+      duration: 1,
+      ease: "power2.out",
+      scrollTrigger: {
+        trigger: "#growthImageContainer",
+        start: "top bottom",
+        end: "center center",
+        scrub: true,
+      },
+    });
+  }, []);
+
+  return (
+    <section
+      className="relative h-[60vh] w-full overflow-hidden bg-brand-dark-bg px-2 py-2 text-white"
+      id="growthImageContainer"
+    >
+      <div className="h-full w-full" id="growthImageWrap">
+        <div
+          className="h-full w-full overflow-hidden rounded-md"
+          id="growthImageMask"
+        >
+          <Image
+            src={imageSrc}
+            alt={altText}
+            fill
+            className="rounded-md object-cover"
+            style={{
+              objectPosition: "50% 30%",
+            }}
+            id="growthImage"
+          />
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ImageGrow;

--- a/src/app/(frontend)/(inner)/work/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/work/[slug]/page.tsx
@@ -17,6 +17,8 @@ import AudioImageSeven from "/public/images/audio-seven.jpg";
 import AudioImageEight from "/public/images/audio-eight.jpg";
 import { BeforeAfter } from "./BeforeAfter";
 import { Service } from "@/payload-types";
+import { ImageGrow } from "./HeroImageGrow";
+
 export async function generateStaticParams() {
   const payload = await getPayloadHMR({ config: configPromise });
   const projects = await payload.find({
@@ -97,6 +99,14 @@ export default async function WorkPage({
               </div>
             </div>
           </div>
+          <ImageGrow
+            imageSrc={
+              typeof project.image === "string"
+                ? project.image
+                : project.image?.url || ""
+            }
+            altText="Project header image"
+          />
         </div>
       </section>
 

--- a/src/app/(frontend)/(inner)/work/page.tsx
+++ b/src/app/(frontend)/(inner)/work/page.tsx
@@ -3,6 +3,7 @@ import configPromise from "@payload-config";
 import { WorkCard } from "@/components/WorkCard";
 import Link from "next/link";
 import Image from "next/image";
+import { ImageGrow } from "./[slug]/HeroImageGrow";
 
 export default async function WorkPage() {
   const payload = await getPayloadHMR({ config: configPromise });


### PR DESCRIPTION
### TL;DR

Added a new ImageGrow component for project pages and integrated it into the work page layout.

### What changed?

- Created a new `HeroImageGrow` component that uses GSAP for image scaling animation on scroll.
- Integrated the `ImageGrow` component into the individual work project page (`[slug]/page.tsx`).
- Added the `ImageGrow` component to the main work page (`work/page.tsx`).

### How to test?

1. Navigate to a specific work project page.
2. Scroll down and observe the hero image growing and scaling as you scroll.
3. Check the main work page to ensure the `ImageGrow` component is rendering correctly.
4. Verify that the animation is smooth and responsive on different screen sizes.

### Why make this change?

This change enhances the visual appeal of the work project pages by adding an engaging, animated hero image. The growing effect as users scroll creates a more dynamic and interactive experience, potentially increasing user engagement and making the project showcase more memorable.