### PR TITLE
feat(work): add console logs to HeroImageGrow and opacity

### DIFF
--- a/src/app/(frontend)/(inner)/work/[slug]/HeroImageGrow/index.tsx
+++ b/src/app/(frontend)/(inner)/work/[slug]/HeroImageGrow/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import Image from "next/image";
 import { gsap } from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
@@ -14,44 +14,66 @@ export const ImageGrow: React.FC<ImageGrowProps> = ({
   imageSrc,
   altText = "Background",
 }) => {
+  const [isLoaded, setIsLoaded] = useState(false);
+
   useEffect(() => {
+    console.log("ImageGrow: Component mounted");
     gsap.registerPlugin(ScrollTrigger);
+    console.log("ImageGrow: GSAP ScrollTrigger plugin registered");
 
-    gsap.set("#growthImageMask", { scale: 0.75 });
-    gsap.set("#growthImage", { scale: 2 });
+    if (isLoaded) {
+      console.log("ImageGrow: Image loaded, setting up animations");
+      gsap.set("#growthImageMask", { scale: 0.75, opacity: 0 });
+      gsap.set("#growthImage", { scale: 2, opacity: 0 });
+      console.log("ImageGrow: Initial GSAP settings applied");
 
-    gsap.to("#growthImageMask, #growthImage", {
-      scale: 1,
-      duration: 1,
-      ease: "power2.out",
-      scrollTrigger: {
-        trigger: "#growthImageContainer",
-        start: "top bottom",
-        end: "center center",
-        scrub: true,
-      },
-    });
-  }, []);
+      gsap.to("#growthImageMask, #growthImage", {
+        scale: 1,
+        opacity: 1,
+        duration: 2,
+        ease: "power2.out",
+        scrollTrigger: {
+          trigger: "#growthImageContainer",
+          start: "top 50%",
+          end: "bottom bottom",
+          scrub: true,
+        },
+      });
+      console.log("ImageGrow: Scroll-triggered animation set up");
+
+      gsap.to("#growthImageMask, #growthImage", {
+        opacity: 1,
+        duration: 1,
+        ease: "power2.inOut",
+      });
+      console.log("ImageGrow: Opacity animation set up");
+    }
+  }, [isLoaded]);
 
   return (
     <section
-      className="relative h-[60vh] w-full overflow-hidden bg-brand-dark-bg px-2 py-2 text-white"
+      className="relative h-[80vh] w-full overflow-hidden bg-brand-dark-bg px-2 py-2"
       id="growthImageContainer"
     >
       <div className="h-full w-full" id="growthImageWrap">
         <div
-          className="h-full w-full overflow-hidden rounded-md"
+          className="h-full w-full overflow-hidden rounded-md opacity-0"
           id="growthImageMask"
         >
           <Image
             src={imageSrc}
             alt={altText}
+            priority
             fill
-            className="rounded-md object-cover"
+            className="rounded-md object-cover opacity-0"
             style={{
               objectPosition: "50% 30%",
             }}
             id="growthImage"
+            onLoad={() => {
+              console.log("ImageGrow: Image loaded");
+              setIsLoaded(true);
+            }}
           />
         </div>
       </div>

--- a/src/app/(frontend)/(inner)/work/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/work/[slug]/page.tsx
@@ -50,9 +50,9 @@ export default async function WorkPage({
 
   return (
     <>
-      <section className="w-full bg-brand-dark-bg pt-40 text-black">
+      <section className="w-full bg-brand-dark-bg pb-20 pt-40 text-black">
         <div className="px-2 sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20 min-[1800px]:pl-40 min-[1800px]:pr-40 min-[2100px]:pl-60 min-[2100px]:pr-60">
-          <div className="relative mb-5 flex w-full flex-wrap items-start justify-between lg:mb-10">
+          <div className="relative flex w-full flex-wrap items-start justify-between">
             <div className="mb-2 hidden w-full px-2 text-white lg:mb-0 lg:flex lg:w-[37.5%] lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
               {project.services && project.services.length > 0 && (
                 <div className="mb-3 flex flex-wrap items-center lg:mb-20">
@@ -82,32 +82,18 @@ export default async function WorkPage({
               </div>
             </div>
           </div>
-          <div className="relative w-full px-2 lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
-            <div className="relative w-full">
-              <div className="relative w-full overflow-hidden rounded-3xl bg-zinc-900 pb-[75%] lg:pb-[56.25%]">
-                <Image
-                  src={
-                    typeof project.image === "string"
-                      ? project.image
-                      : project.image?.url || ""
-                  }
-                  alt="Project header image"
-                  fill
-                  style={{ objectFit: "cover" }}
-                  className="absolute left-0 top-0 h-full w-full max-w-full"
-                />
-              </div>
-            </div>
-          </div>
-          <ImageGrow
-            imageSrc={
-              typeof project.image === "string"
-                ? project.image
-                : project.image?.url || ""
-            }
-            altText="Project header image"
-          />
         </div>
+      </section>
+      <section className="bg-brand-dark-bg">
+        {" "}
+        <ImageGrow
+          imageSrc={
+            typeof project.image === "string"
+              ? project.image
+              : project.image?.url || ""
+          }
+          altText="Project header image"
+        />
       </section>
 
       <section className="bg-brand-dark-bg px-2 py-20 text-black sm:px-6 xl:px-12 min-[1450px]:px-20 min-[1800px]:px-40 min-[2100px]:px-60">


### PR DESCRIPTION
### TL;DR

Enhanced the image grow animation and restructured the work page layout.

### What changed?

- Added a loading state for the image in the `ImageGrow` component
- Implemented opacity animations for smoother transitions
- Adjusted GSAP animation settings for better performance
- Increased the height of the image container to 80vh
- Moved the `ImageGrow` component to its own section
- Removed the static image from the work page
- Added console logs for debugging purposes

### How to test?

1. Navigate to a work page
2. Scroll down and observe the image grow animation
3. Check if the image fades in smoothly
4. Verify that the animation triggers at the correct scroll position
5. Ensure the layout looks correct on various screen sizes

### Why make this change?

This change aims to improve the user experience by providing a more polished and visually appealing image animation. The restructured layout allows for better focus on the growing image, while the added loading state and opacity animations ensure smoother transitions. These enhancements contribute to a more engaging and professional presentation of project work.