### PR TITLE
feat(cms): add Journeys collection to the database

### DIFF
--- a/src/app/(frontend)/(inner)/work/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/work/[slug]/page.tsx
@@ -100,57 +100,19 @@ export default async function WorkPage({
         <div className="relative flex flex-wrap items-start justify-between">
           <div className="relative flex w-full flex-wrap px-2 lg:mb-0 lg:w-[56.25%] lg:px-3 xl:px-4 min-[2100px]:w-2/4">
             <div className="order-1 text-5xl text-white">
-              <div className="w-full lg:pr-16">
-                <h2 className="mb-3">Crafting a Unique Brew for Foley</h2>
-              </div>
-            </div>
-            <div className="order-2 mb-5 flex w-full lg:mb-0 lg:mt-5">
-              <div className="relative h-10 w-10 overflow-hidden rounded-lg lg:h-12 lg:w-12">
-                <div className="relative w-full overflow-hidden pt-12">
-                  <img
-                    className="absolute left-0 top-0 h-full w-full max-w-full object-cover"
-                    src="https://made-byshape.transforms.svdcdn.com/production/uploads/images/Ella-MadeByShape.jpg?w=400&h=400&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=0.5&fp-y=0.5&dm=1704886333&s=ce9de567edaa6f19bb050b225410238e"
-                  />
-                </div>
-              </div>
-              <div className="relative ml-2 h-10 w-10 overflow-hidden rounded-lg lg:h-12 lg:w-12">
-                <div className="relative w-full overflow-hidden pt-12">
-                  <img
-                    className="absolute left-0 top-0 h-full w-full max-w-full object-cover"
-                    src="https://made-byshape.transforms.svdcdn.com/production/uploads/images/Jay-MadeByShape.jpg?w=400&h=400&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=0.4724&fp-y=0.5&dm=1704886269&s=479b46a6bc4929c3529500ff225a65e0"
-                  />
-                </div>
-              </div>
-              <div className="relative ml-2 h-10 w-10 overflow-hidden rounded-lg lg:h-12 lg:w-12">
-                <div className="relative w-full overflow-hidden pt-12">
-                  <img
-                    className="absolute left-0 top-0 h-full w-full max-w-full object-cover"
-                    src="https://made-byshape.transforms.svdcdn.com/production/uploads/images/profile-images-2024/square/Natasia-MadeByShape.jpg?w=400&h=400&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=0.5&fp-y=0.5&dm=1704887831&s=f35bf13bbc7bb682624324009583ed8e"
-                  />
-                </div>
-              </div>
-              <div className="relative ml-2 h-10 w-10 overflow-hidden rounded-lg lg:h-12 lg:w-12">
-                <div className="relative w-full overflow-hidden pt-12">
-                  <img
-                    className="absolute left-0 top-0 h-full w-full max-w-full object-cover"
-                    src="https://made-byshape.transforms.svdcdn.com/production/uploads/images/profile-images-2024/portrait/Group-450.jpg?w=400&h=400&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=0.5&fp-y=0.5&dm=1705050207&s=f9998c3bb45322a3ef7f6ef30aa94ec1"
-                  />
-                </div>
-              </div>
+              <h2 className="text-5xl text-white">
+                <span className="mr-4 text-sm font-light">/ The Story</span>
+                {project.storyTitle || "Add Story Title"}
+              </h2>
             </div>
           </div>
           <div className="w-full px-2 lg:w-[43.75%] lg:px-3 xl:px-4">
             <div className="w-full text-lg font-light text-zinc-400 xl:pr-10">
-              <p className="mb-6">
-                Brand Strategy, Visual Identity, and Web Design & Development
-                for Blessed Kettle; Foley, Alabama's first microbrewery. Our
-                challenge was to create a brand that resonates with both local
-                multi-generation families and millennial tourists. We crafted a
-                unique identity that blends traditional brewing values with
-                modern appeal, positioning Blessed Kettle as a cornerstone of
-                the local community and a must-visit destination for craft beer
-                enthusiasts.
-              </p>
+              {project.storyContent ? (
+                <RichText content={project.storyContent} enableProse={true} />
+              ) : (
+                <p className="mb-6">Add storyContent</p>
+              )}
             </div>
             <div className="mt-6 flex w-full max-w-2xl flex-wrap justify-between pr-6 lg:mt-10 lg:pr-0 min-[2100px]:max-w-3xl">
               <div className="mb-3 pr-8 lg:mb-0">
@@ -738,30 +700,6 @@ export default async function WorkPage({
         </div>
       </section>
 
-      <section className="bg-zinc-950 py-40 text-center text-[11.00rem] font-bold uppercase leading-none text-neutral-400">
-        <h1 className="text-white">The Merry Beggars</h1>
-      </section>
-      <section className="mx-auto flex max-w-7xl items-center justify-between bg-zinc-950 px-4 py-2 text-sm text-white">
-        <div className="uppercase">
-          <span>Branding, Design, Development</span>
-        </div>
-        <div>
-          <span>/ 2022</span>
-        </div>
-      </section>
-      <section className="bg-zinc-950">
-        <div className="mx-auto max-w-7xl px-4 py-16">
-          <div className="relative aspect-video w-full overflow-hidden rounded-lg">
-            <Image
-              src={AudioImageSix}
-              alt="The Merry Beggars audio entertainment platform showcase"
-              fill
-              style={{ objectFit: "cover" }}
-              className="cursor-pointer"
-            />
-          </div>
-        </div>
-      </section>
       <section className="bg-zinc-950 py-16">
         <h1 className="text-center text-[7rem] font-bold uppercase leading-none text-white">
           Original Audio Entertainment for the Whole Family

--- a/src/collections/Journeys/config.ts
+++ b/src/collections/Journeys/config.ts
@@ -1,0 +1,128 @@
+import type { CollectionConfig } from "payload";
+import { isAdmin } from "@/access/isAdmin";
+import { publishedOnly } from "@/access/publishedOnly";
+import { slugField } from "@/fields/slug";
+import {
+  MetaDescriptionField,
+  MetaImageField,
+  MetaTitleField,
+  OverviewField,
+  PreviewField,
+} from "@payloadcms/plugin-seo/fields";
+
+export const Journeys: CollectionConfig = {
+  slug: "journeys",
+
+  access: {
+    create: isAdmin,
+    delete: isAdmin,
+    read: publishedOnly,
+    readVersions: isAdmin,
+    update: isAdmin,
+  },
+
+  //* Collection Fields
+  fields: [
+    {
+      name: "title",
+      type: "text",
+      label: "Title",
+      required: true,
+      unique: true,
+      admin: {
+        description: "Add the title of the journey here.",
+      },
+    },
+    {
+      name: "tagline",
+      type: "text",
+      label: "Tagline",
+      required: true,
+      admin: {
+        description: "Add the tagline for the journey here.",
+      },
+    },
+    ...slugField(),
+    {
+      name: "description",
+      type: "textarea",
+      label: "Description",
+      required: true,
+      admin: {
+        description: "Add the description of the journey here.",
+      },
+    },
+    {
+      type: "tabs",
+      tabs: [
+        {
+          name: "content",
+          label: "Content",
+          fields: [],
+        },
+        {
+          name: "metadata",
+          label: "Meta",
+          fields: [
+            {
+              name: "services",
+              type: "relationship",
+              relationTo: "services",
+              label: "Services",
+              required: false,
+              admin: {
+                description: "Add the services for the journey here.",
+              },
+            },
+          ],
+        },
+        {
+          name: "seo",
+          label: "SEO",
+          fields: [
+            OverviewField({
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+              imagePath: "meta.image",
+            }),
+            MetaImageField({
+              relationTo: "media",
+            }),
+            MetaTitleField({
+              hasGenerateFn: true,
+            }),
+            MetaDescriptionField({}),
+            PreviewField({
+              hasGenerateFn: true,
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+            }),
+          ],
+        },
+      ],
+    },
+  ],
+
+  //* Admin Settings
+
+  admin: {
+    description: "Journeys of Brewww",
+    defaultColumns: ["title", "updatedAt"],
+    group: "Service",
+    listSearchableFields: ["title", "description"],
+    pagination: {
+      defaultLimit: 25,
+      limits: [25, 50, 100],
+    },
+    useAsTitle: "title",
+  },
+  defaultSort: "title",
+  labels: {
+    singular: "Journey",
+    plural: "Journeys",
+  },
+  versions: {
+    drafts: true,
+    maxPerDoc: 25,
+  },
+};

--- a/src/collections/Work/config.ts
+++ b/src/collections/Work/config.ts
@@ -60,7 +60,20 @@ export const Work: CollectionConfig = {
       tabs: [
         {
           label: "Content",
-          fields: [],
+          fields: [
+            {
+              name: "storyTitle",
+              type: "text",
+              label: "Story Title",
+              required: false,
+            },
+            {
+              name: "storyContent",
+              type: "richText",
+              label: "Story Content",
+              required: false,
+            },
+          ],
         },
         {
           name: "metadata",

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -23,6 +23,7 @@ export interface Config {
     pillars: Pillar;
     testimonials: Testimonial;
     technologies: Technology;
+    journeys: Journey;
     locations: Location;
     results: Result;
     team: Team;
@@ -382,6 +383,22 @@ export interface Work {
   title: string;
   tagline: string;
   description?: string | null;
+  storyTitle?: string | null;
+  storyContent?: {
+    root: {
+      type: string;
+      children: {
+        type: string;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
   metadata?: {
     testimonial?: (string | null) | Testimonial;
     relatedWorks?: (string | Work)[] | null;
@@ -572,6 +589,30 @@ export interface Technology {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "journeys".
+ */
+export interface Journey {
+  id: string;
+  title: string;
+  tagline: string;
+  slug: string;
+  slugLock?: boolean | null;
+  description: string;
+  content?: {};
+  metadata?: {
+    services?: (string | null) | Service;
+  };
+  seo?: {
+    image?: (string | null) | Media;
+    title?: string | null;
+    description?: string | null;
+  };
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "locations".
  */
 export interface Location {
@@ -705,6 +746,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'technologies';
         value: string | Technology;
+      } | null)
+    | ({
+        relationTo: 'journeys';
+        value: string | Journey;
       } | null)
     | ({
         relationTo: 'locations';

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -28,7 +28,7 @@ import { Users } from "@/collections/Users/config";
 import { Work } from "@/collections/Work/config";
 import { Technologies } from "@/collections/Technologies/config";
 import { Team } from "@/collections/Team/config";
-
+import { Journeys } from "@/collections/Journeys/config";
 //* Import Globals
 import { Header } from "./globals/Header/index";
 import { Footer } from "./globals/Footer/index";
@@ -129,6 +129,7 @@ export default buildConfig({
     Pillars,
     Testimonials,
     Technologies,
+    Journeys,
     Location,
     Results,
     Team,


### PR DESCRIPTION
### TL;DR

Added new "Journeys" collection and enhanced the Work collection with story-related fields.

### What changed?

- Created a new "Journeys" collection with fields for title, tagline, slug, description, services, and SEO metadata.
- Added "storyTitle" and "storyContent" fields to the Work collection.
- Updated the Work page component to display the new story-related content.
- Removed hardcoded content from the Work page component.
- Updated payload types to reflect the new collections and fields.

### How to test?

1. Access the Payload CMS admin panel.
2. Create a new Journey entry and verify all fields are working correctly.
3. Edit an existing Work entry and add content to the new "storyTitle" and "storyContent" fields.
4. View the Work page on the frontend to ensure the new story content is displayed correctly.
5. Verify that the Journeys collection is accessible and functioning as expected in the admin panel.

### Why make this change?

This change introduces a more flexible and dynamic way to manage journey-related content and enhances the storytelling capabilities for work entries. It allows for better content management and provides a more customizable experience for showcasing projects and services.