### PR TITLE
feat(ui): add new hero to services page

### DIFF
--- a/src/app/(frontend)/(inner)/services/page.tsx
+++ b/src/app/(frontend)/(inner)/services/page.tsx
@@ -5,6 +5,37 @@ import Link from "next/link";
 export default function ServicesPage() {
   return (
     <>
+      <section className="w-full bg-brand-dark-bg pb-10 pt-20 text-black lg:pb-16 lg:pt-32 xl:pt-40">
+        <div className="px-2 sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20 min-[1800px]:pl-40 min-[1800px]:pr-40 min-[2100px]:pl-60 min-[2100px]:pr-60">
+          <div className="mb-3 flex flex-wrap justify-between md:mb-5 lg:mb-0">
+            <div className="w-full px-2 lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
+              <div className="mb-3 inline-flex w-auto items-center">
+                <div className="h-1.5 w-1.5 rounded-full bg-white" />
+                <div className="ml-2 text-lg font-light text-white">
+                  Services
+                </div>
+              </div>
+              <h1 className="indent-32 text-display-small leading-none text-white">
+                We're a digital <br className="indent-32" />
+                marketing agency
+                <br className="indent-32" />
+                with expertise
+              </h1>
+            </div>
+          </div>
+          <div className="flex w-full flex-wrap text-[2.50rem] leading-none text-white md:justify-end">
+            <div className="px-2 lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
+              <div className="w-full max-w-xl pr-10 lg:max-w-2xl lg:pl-10 lg:pr-0">
+                <h2 className="mb-3">
+                  We bring our passion for good design to brave brands and
+                  deliver something you can shout about.
+                </h2>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <section className="flex bg-white text-stone-950">
         <div className="relative flex h-[50.46rem] w-full">
           <Image

--- a/src/collections/Journeys/config.ts
+++ b/src/collections/Journeys/config.ts
@@ -37,7 +37,7 @@ export const Journeys: CollectionConfig = {
       name: "tagline",
       type: "text",
       label: "Tagline",
-      required: true,
+      required: false,
       admin: {
         description: "Add the tagline for the journey here.",
       },
@@ -47,7 +47,7 @@ export const Journeys: CollectionConfig = {
       name: "description",
       type: "textarea",
       label: "Description",
-      required: true,
+      required: false,
       admin: {
         description: "Add the description of the journey here.",
       },

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -594,10 +594,10 @@ export interface Technology {
 export interface Journey {
   id: string;
   title: string;
-  tagline: string;
+  tagline?: string | null;
   slug: string;
   slugLock?: boolean | null;
-  description: string;
+  description?: string | null;
   content?: {};
   metadata?: {
     services?: (string | null) | Service;


### PR DESCRIPTION
### TL;DR

Added a new hero section to the Services page and made tagline and description fields optional for Journeys.

### What changed?

- Added a new hero section to the Services page with a title, subtitle, and background styling.
- Made the tagline and description fields optional in the Journeys collection configuration.
- Updated the Journey interface in payload-types.ts to reflect the optional nature of tagline and description.

### How to test?

1. Navigate to the Services page and verify the new hero section is displayed correctly.
2. Create a new Journey in the admin panel and confirm that tagline and description fields are no longer required.
3. Update an existing Journey, leaving the tagline and description fields empty, and ensure it saves successfully.

### Why make this change?

The new hero section on the Services page enhances the visual appeal and provides a clear introduction to the agency's services. Making tagline and description optional for Journeys allows for more flexibility in content creation, accommodating cases where these fields may not be necessary or available for all journeys.