### PR TITLE
feat(ui): update RichText to utilize custom Tailwind classes

### DIFF
--- a/src/app/(frontend)/(inner)/blog/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/blog/[slug]/page.tsx
@@ -13,15 +13,12 @@ import TableOfContents from "@/components/TableOfContents/index";
 import { LexicalNode } from "@/components/RichText/nodeFormat";
 
 export async function generateStaticParams() {
-  console.log("Generating static params for blog posts");
   const payload = await getPayloadHMR({ config: configPromise });
-  console.log("Fetching blog posts from payload");
   const posts = await payload.find({
     collection: "posts",
     limit: 1000,
     overrideAccess: false,
   });
-  console.log(`Found ${posts.docs?.length || 0} blog posts`);
   return (
     posts.docs?.map(({ slug }) => ({
       params: { slug },
@@ -35,21 +32,14 @@ export default async function PostPage({
   params: Promise<{ slug: string }>;
 }) {
   const resolvedParams = await params;
-  console.log("Rendering PostPage");
-  console.log(`Params: ${JSON.stringify(resolvedParams)}`);
   if (!resolvedParams.slug) {
-    console.log("No slug found in params, redirecting to 404");
     notFound();
   }
 
-  console.log(`Querying blog post with slug: ${resolvedParams.slug}`);
   const post = await queryPostBySlug({ slug: resolvedParams.slug });
   if (!post) {
-    console.log("Blog post not found, redirecting to 404");
     notFound();
   }
-
-  console.log(`Blog post found: ${post.title}`);
 
   return (
     <article className="bg-white pt-24 text-black">
@@ -156,9 +146,9 @@ export default async function PostPage({
           <article className="prose mx-auto pb-24">
             <RichText
               content={post.content || ""}
-              className="prose-lg"
               enableProse={true}
               enableGutter={false}
+              theme="light"
             />
           </article>
         </div>
@@ -174,7 +164,6 @@ async function queryPostBySlug({
 }): Promise<Post | null> {
   const payload = await getPayloadHMR({ config: configPromise });
   try {
-    console.log("Executing payload.find query");
     const result = await payload.find({
       collection: "posts",
       limit: 1,
@@ -184,10 +173,8 @@ async function queryPostBySlug({
         },
       },
     });
-    console.log("Query result:", result);
     return result.docs[0] || null;
   } catch (error) {
-    console.error("Error querying blog post:", error);
     return null;
   }
 }

--- a/src/app/(frontend)/(inner)/services/page.tsx
+++ b/src/app/(frontend)/(inner)/services/page.tsx
@@ -16,7 +16,8 @@ export default function ServicesPage() {
                 </div>
               </div>
               <h1 className="max-w-5xl indent-32 text-display-small leading-none text-white">
-                Talent, tools, and deliverables to spark action for your brand.
+                The talent, tools, and deliverables to spark action for your
+                brand.
               </h1>
             </div>
           </div>

--- a/src/components/RichText/index.tsx
+++ b/src/components/RichText/index.tsx
@@ -16,17 +16,38 @@ const richTextVariants = cva("", {
       true: "prose mx-auto",
       false: "",
     },
+    theme: {
+      light: "text-black",
+      dark: "text-white",
+    },
   },
   defaultVariants: {
     colorLinks: true,
     enableGutter: true,
     enableProse: true,
+    theme: "dark",
   },
 });
+
+const defaultStyles = {
+  paragraph: "text-body-medium mb-4",
+  h1: "text-headline-large mb-4 mb-6",
+  h2: "text-headline-medium mb-4 mb-6",
+  h3: "text-headline-small mb-4 mb-6",
+  h4: "text-title-large mb-4 mb-6",
+  h5: "text-title-medium mb-4 mb-6",
+  h6: "text-title-small mb-4 mb-6",
+  list: "list-disc list-inside mb-4",
+  listItem: "mb-2",
+  quote: "border-l-4  pl-4 mb-4",
+  link: "text-blue-600 hover:text-blue-800 visited:text-purple-600",
+};
 
 type RichTextProps = VariantProps<typeof richTextVariants> & {
   className?: string;
   content: any;
+  theme?: "light" | "dark";
+  customClasses?: Partial<typeof defaultStyles>;
 };
 
 export const RichText: React.FC<RichTextProps> = ({
@@ -35,16 +56,10 @@ export const RichText: React.FC<RichTextProps> = ({
   colorLinks,
   enableGutter,
   enableProse,
+  theme,
+  customClasses = {},
 }) => {
-  console.log("[RichText/index.tsx] Rendering RichText component", {
-    className,
-    content,
-  });
-
   if (!content) {
-    console.warn(
-      "[RichText/index.tsx] No content provided to RichText component",
-    );
     return null;
   }
 
@@ -53,27 +68,27 @@ export const RichText: React.FC<RichTextProps> = ({
     typeof content !== "object" ||
     !("root" in content)
   ) {
-    console.error("[RichText/index.tsx] Invalid content structure", content);
     return null;
   }
+
+  const mergedClasses = { ...defaultStyles, ...customClasses };
 
   try {
     return (
       <div
         className={cn(
-          richTextVariants({ colorLinks, enableGutter, enableProse }),
+          richTextVariants({ colorLinks, enableGutter, enableProse, theme }),
           "first:mt-0 last:mb-0 [&_span]:whitespace-pre-wrap",
           className,
         )}
       >
-        {serializeLexical({ nodes: content?.root?.children })}
+        {serializeLexical({
+          nodes: content?.root?.children,
+          customClasses: mergedClasses,
+        })}
       </div>
     );
   } catch (error) {
-    console.error(
-      "[RichText/index.tsx] Error rendering RichText component",
-      error,
-    );
     return null;
   }
 };

--- a/src/components/RichText/serialize.tsx
+++ b/src/components/RichText/serialize.tsx
@@ -21,9 +21,10 @@ export type NodeTypes = DefaultNodeTypes | SerializedBlockNode<MediaTestProps>;
 
 type Props = {
   nodes: NodeTypes[];
+  customClasses?: Record<string, string>;
 };
 
-export function serializeLexical({ nodes }: Props): JSX.Element {
+export function serializeLexical({ nodes, customClasses }: Props): JSX.Element {
   return (
     <Fragment>
       {nodes?.map((node, index): JSX.Element | null => {
@@ -131,11 +132,19 @@ export function serializeLexical({ nodes }: Props): JSX.Element {
               return <br key={index} />;
             }
             case "paragraph": {
-              return <p key={index}>{serializedChildren}</p>;
+              return (
+                <p key={index} className={customClasses?.paragraph}>
+                  {serializedChildren}
+                </p>
+              );
             }
             case "heading": {
-              const Tag = node?.tag as keyof JSX.IntrinsicElements;
-              return <Tag key={index}>{serializedChildren}</Tag>;
+              const HeadingTag = node?.tag as keyof JSX.IntrinsicElements;
+              return (
+                <HeadingTag key={index} className={customClasses?.heading}>
+                  {serializedChildren}
+                </HeadingTag>
+              );
             }
             case "list": {
               const Tag = node?.tag as keyof JSX.IntrinsicElements;


### PR DESCRIPTION
### TL;DR

Improved RichText component with theme support and custom styling options.

### What changed?

- Removed console.log statements from blog post page
- Updated services page headline text
- Enhanced RichText component:
  - Added theme support (light/dark)
  - Introduced customizable styles for different text elements
  - Implemented default styles for paragraphs, headings, lists, and links
- Modified serializeLexical function to apply custom classes

### How to test?

1. Navigate to the blog post page and verify it renders correctly without console logs
2. Check the services page for the updated headline text
3. Test the RichText component with different themes and custom styles:
   - Use the `theme` prop to switch between light and dark themes
   - Pass custom classes via the `customClasses` prop to override default styles
4. Verify that the serialized content in RichText applies the correct classes to paragraphs and headings

### Why make this change?

This change improves the flexibility and customization options of the RichText component, allowing for better integration with different design requirements. It also enhances code cleanliness by removing unnecessary console logs and improves the services page messaging.