### PR TITLE
feat(ui): add more styles to RichText serialize function

### DIFF
--- a/src/components/RichText/index.tsx
+++ b/src/components/RichText/index.tsx
@@ -37,8 +37,8 @@ const defaultStyles = {
   h4: "text-title-large mb-4 mb-6",
   h5: "text-title-medium mb-4 mb-6",
   h6: "text-title-small mb-4 mb-6",
-  list: "list-disc list-inside mb-4",
-  listItem: "mb-2",
+  list: "list-disc list-inside mb-4 text-body-medium",
+  listItem: "mb-2 ",
   quote: "border-l-4  pl-4 mb-4",
   link: "text-blue-600 hover:text-blue-800 visited:text-purple-600",
 };

--- a/src/components/RichText/serialize.tsx
+++ b/src/components/RichText/serialize.tsx
@@ -139,9 +139,12 @@ export function serializeLexical({ nodes, customClasses }: Props): JSX.Element {
               );
             }
             case "heading": {
-              const HeadingTag = node?.tag as keyof JSX.IntrinsicElements;
+              const HeadingTag = `${node.tag}` as keyof JSX.IntrinsicElements;
               return (
-                <HeadingTag key={index} className={customClasses?.heading}>
+                <HeadingTag
+                  key={index}
+                  className={customClasses?.[`${node.tag}`]}
+                >
                   {serializedChildren}
                 </HeadingTag>
               );
@@ -149,7 +152,7 @@ export function serializeLexical({ nodes, customClasses }: Props): JSX.Element {
             case "list": {
               const Tag = node?.tag as keyof JSX.IntrinsicElements;
               return (
-                <Tag className="list" key={index}>
+                <Tag className={customClasses?.list} key={index}>
                   {serializedChildren}
                 </Tag>
               );
@@ -171,18 +174,30 @@ export function serializeLexical({ nodes, customClasses }: Props): JSX.Element {
                 );
               } else {
                 return (
-                  <li key={index} value={node?.value}>
+                  <li
+                    key={index}
+                    value={node?.value}
+                    className={customClasses?.listItem}
+                  >
                     {serializedChildren}
                   </li>
                 );
               }
             }
             case "quote": {
-              return <blockquote key={index}>{serializedChildren}</blockquote>;
+              return (
+                <blockquote key={index} className={customClasses?.quote}>
+                  {serializedChildren}
+                </blockquote>
+              );
             }
             case "link": {
               // CMS links are hidden for now
-              return <span key={index}>{serializedChildren}</span>;
+              return (
+                <span key={index} className={customClasses?.link}>
+                  {serializedChildren}
+                </span>
+              );
             }
             case "upload": {
               return <RichTextUpload key={index} node={node} />;


### PR DESCRIPTION
### TL;DR

Enhanced RichText component styling and improved serialization logic for various elements.

### What changed?

- Updated default styles for lists and list items in the RichText component
- Improved heading tag serialization to use custom classes dynamically
- Applied custom classes to list, list item, quote, and link elements during serialization
- Fixed type casting for heading tags

### How to test?

1. Render the RichText component with various content types (headings, lists, quotes, links)
2. Verify that the new styles are applied correctly to each element
3. Check that custom classes are properly applied when provided
4. Ensure that headings of different levels (h1-h6) render with the appropriate custom classes

### Why make this change?

This change improves the flexibility and consistency of the RichText component. By applying custom classes more extensively and fixing type issues, it allows for better styling control and ensures that the component can handle a wider range of content types more effectively. The updates also make the component more maintainable and easier to customize for different use cases.