### PR TITLE
feat(cms): add Industries to Payload CMS

### DIFF
--- a/src/collections/Industries/config.ts
+++ b/src/collections/Industries/config.ts
@@ -1,0 +1,128 @@
+import type { CollectionConfig } from "payload";
+import { isAdmin } from "@/access/isAdmin";
+import { publishedOnly } from "@/access/publishedOnly";
+import { slugField } from "@/fields/slug";
+import {
+  MetaDescriptionField,
+  MetaImageField,
+  MetaTitleField,
+  OverviewField,
+  PreviewField,
+} from "@payloadcms/plugin-seo/fields";
+
+export const Industries: CollectionConfig = {
+  slug: "industries",
+
+  access: {
+    create: isAdmin,
+    delete: isAdmin,
+    read: publishedOnly,
+    readVersions: isAdmin,
+    update: isAdmin,
+  },
+
+  //* Collection Fields
+  fields: [
+    {
+      name: "title",
+      type: "text",
+      label: "Title",
+      required: true,
+      unique: true,
+      admin: {
+        description: "Add the title of the industry here.",
+      },
+    },
+    {
+      name: "tagline",
+      type: "text",
+      label: "Tagline",
+      required: false,
+      admin: {
+        description: "Add the tagline for the industry here.",
+      },
+    },
+    ...slugField(),
+    {
+      name: "description",
+      type: "textarea",
+      label: "Description",
+      required: false,
+      admin: {
+        description: "Add the description of the industry here.",
+      },
+    },
+    {
+      type: "tabs",
+      tabs: [
+        {
+          name: "content",
+          label: "Content",
+          fields: [],
+        },
+        {
+          name: "metadata",
+          label: "Meta",
+          fields: [
+            {
+              name: "services",
+              type: "relationship",
+              relationTo: "services",
+              label: "Services",
+              required: false,
+              admin: {
+                description: "Add the services for the industry here.",
+              },
+            },
+          ],
+        },
+        {
+          name: "seo",
+          label: "SEO",
+          fields: [
+            OverviewField({
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+              imagePath: "meta.image",
+            }),
+            MetaImageField({
+              relationTo: "media",
+            }),
+            MetaTitleField({
+              hasGenerateFn: true,
+            }),
+            MetaDescriptionField({}),
+            PreviewField({
+              hasGenerateFn: true,
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+            }),
+          ],
+        },
+      ],
+    },
+  ],
+
+  //* Admin Settings
+
+  admin: {
+    description: "Industries of Brewww",
+    defaultColumns: ["title", "updatedAt"],
+    group: "Service",
+    listSearchableFields: ["title", "description"],
+    pagination: {
+      defaultLimit: 25,
+      limits: [25, 50, 100],
+    },
+    useAsTitle: "title",
+  },
+  defaultSort: "title",
+  labels: {
+    singular: "Industry",
+    plural: "Industries",
+  },
+  versions: {
+    drafts: true,
+    maxPerDoc: 25,
+  },
+};

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -28,6 +28,7 @@ export interface Config {
     results: Result;
     team: Team;
     users: User;
+    industries: Industry;
     forms: Form;
     'form-submissions': FormSubmission;
     'payload-locked-documents': PayloadLockedDocument;
@@ -677,6 +678,30 @@ export interface User {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "industries".
+ */
+export interface Industry {
+  id: string;
+  title: string;
+  tagline?: string | null;
+  slug: string;
+  slugLock?: boolean | null;
+  description?: string | null;
+  content?: {};
+  metadata?: {
+    services?: (string | null) | Service;
+  };
+  seo?: {
+    image?: (string | null) | Media;
+    title?: string | null;
+    description?: string | null;
+  };
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "form-submissions".
  */
 export interface FormSubmission {
@@ -766,6 +791,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'users';
         value: string | User;
+      } | null)
+    | ({
+        relationTo: 'industries';
+        value: string | Industry;
       } | null)
     | ({
         relationTo: 'forms';

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -35,6 +35,7 @@ import { Footer } from "./globals/Footer/index";
 
 //* Import Types
 import { Page, Post } from "@/payload-types";
+import { Industries } from "./collections/Industries/config";
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
@@ -134,6 +135,7 @@ export default buildConfig({
     Results,
     Team,
     Users,
+    Industries,
   ],
   globals: [Header, Footer],
   editor: lexicalEditor({}),


### PR DESCRIPTION
### TL;DR

Added a new Industries collection to the CMS.

### What changed?

- Created a new `Industries` collection configuration in `src/collections/Industries/config.ts`
- Updated `src/payload-types.ts` to include the new Industry interface
- Added the Industries collection to the main Payload configuration in `src/payload.config.ts`

### How to test?

1. Start the CMS application
2. Navigate to the admin panel
3. Verify that a new "Industries" section is available under the "Service" group
4. Attempt to create, read, update, and delete industry entries
5. Check that the fields (title, tagline, slug, description, services, and SEO metadata) are present and functioning correctly

### Why make this change?

This change introduces a new Industries collection to better organize and manage industry-specific content within the CMS. It allows for the creation of industry pages with associated services, improving the overall structure and flexibility of the content management system.