### PR TITLE
fix(about): switch html link to next link per Next 15 requirements

### DIFF
--- a/src/app/(frontend)/(inner)/about/AboutOffsetImageSection/index.tsx
+++ b/src/app/(frontend)/(inner)/about/AboutOffsetImageSection/index.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 
 export function AboutOffsetImageSection() {
   return (
@@ -30,13 +31,13 @@ export function AboutOffsetImageSection() {
                   instant and focuses on the lasting.
                 </strong>
               </p>
-              <a
+              <Link
                 className="relative mb-1 inline-block max-w-full font-bold"
                 href="/services"
               >
                 <span className="uppercase">View Capabilities</span>
                 <span className="absolute bottom-0 left-0 right-0 h-0.5 w-1/5 bg-white" />
-              </a>
+              </Link>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### TL;DR

Updated the "View Capabilities" link in the About page to use Next.js Link component.

### What changed?

- Imported the `Link` component from "next/link"
- Replaced the `<a>` tag with `<Link>` for the "View Capabilities" button in the AboutOffsetImageSection component

### How to test?

1. Navigate to the About page
2. Locate the "View Capabilities" button in the offset image section
3. Click the button and verify that it navigates to the Services page without a full page reload

### Why make this change?

Using Next.js `Link` component instead of a regular `<a>` tag improves performance by enabling client-side navigation. This results in faster page transitions and a smoother user experience within the application.