### PR TITLE
fix(home): update HTML link to use Next link per Next 15 requirements

### DIFF
--- a/src/app/(frontend)/(inner)/home/page.tsx
+++ b/src/app/(frontend)/(inner)/home/page.tsx
@@ -174,7 +174,7 @@ export default async function Home() {
                   engaging products with real results.
                 </div>
                 <div className="overflow-hidden font-bold">
-                  <a
+                  <Link
                     className="relative mb-1 inline-block max-w-full"
                     href="/capabilities"
                   >
@@ -182,7 +182,7 @@ export default async function Home() {
                       View Capabilities
                     </div>
                     <div className="absolute bottom-0 left-0 right-0 h-0.5 w-1/5 bg-white" />
-                  </a>
+                  </Link>
                 </div>
               </div>
               <div className="col-start-4 col-end-11 row-start-1 grid h-[37.50rem] w-full auto-cols-fr grid-cols-[.25fr_1fr_1fr_1fr_1fr_1fr_1fr_.25fr] grid-rows-[auto_auto_auto_auto_auto_auto_auto_auto] overflow-hidden">


### PR DESCRIPTION
### TL;DR

Updated the "View Capabilities" link on the home page to use Next.js Link component.

### What changed?

- Replaced the `<a>` tag with `<Link>` component for the "View Capabilities" link in the home page.
- The href and content of the link remain unchanged.

### How to test?

1. Navigate to the home page.
2. Locate the "View Capabilities" link in the capabilities section.
3. Click on the link and verify that it navigates to the "/capabilities" page without a full page reload.
4. Check that the link styling and underline effect are preserved.

### Why make this change?

Using the Next.js `Link` component instead of a standard `<a>` tag improves client-side navigation performance. This change enhances the user experience by providing faster page transitions within the application, while maintaining the same visual appearance and functionality of the link.