### PR TITLE
fix(play): update images to use Next image to clear warning

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://brewww.studio</loc><lastmod>2024-10-22T18:06:47.397Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://brewww.studio/proposal</loc><lastmod>2024-10-22T18:06:47.398Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio</loc><lastmod>2024-10-22T18:16:10.981Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/proposal</loc><lastmod>2024-10-22T18:16:10.982Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/app/(frontend)/(inner)/about/page.tsx
+++ b/src/app/(frontend)/(inner)/about/page.tsx
@@ -229,9 +229,10 @@ export default function About() {
             </div>
           </div>
           <div className="mt-7 flex gap-6 text-2xl lg:mt-12">
-            <img
+            <Image
               className="h-auto w-28 max-w-full lg:w-28"
               src="https://showandtell.agency/stars.svg"
+              alt="Stars"
             />
             <span>
               Rated 4.6 Stars on{" "}
@@ -296,11 +297,12 @@ export default function About() {
           >
             <figure>
               <span className="relative inline-block h-36 w-60 overflow-hidden">
-                <img
+                <Image
                   className="h-full w-full object-cover"
                   src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%27440%27%20height=%27248%27/%3e"
+                  alt="Placeholder"
                 />
-                <img
+                <Image
                   className="absolute inset-0 h-full w-full object-cover"
                   src={AboutImageEight.src}
                   alt="Kevin Wessa"
@@ -519,9 +521,10 @@ export default function About() {
           </div>
           <div className="flex flex-wrap justify-between px-12 py-24">
             <div className="flex basis-[48%] flex-col pb-20">
-              <img
+              <Image
                 className="h-auto w-[47.57rem] max-w-full pb-8"
                 src="https://grainandmortar.com/wp-content/themes/gm/_assets/additions/2022-Kristin-23.jpg"
+                alt="Kristin"
               />
               <h3 className="mb-3 text-[2.38rem] leading-none">
                 Christine Wessa
@@ -537,9 +540,10 @@ export default function About() {
               </p>
             </div>
             <div className="flex basis-[48%] flex-col pb-20">
-              <img
+              <Image
                 className="h-auto w-[47.57rem] max-w-full pb-8"
                 src="https://grainandmortar.com/wp-content/themes/gm/_assets/additions/2022-Michael-10.jpg"
+                alt="Michael"
               />
               <h3 className="mb-3 text-[2.38rem] leading-none">Kevin Wessa</h3>
               <h4 className="mb-3.5 font-semibold">
@@ -602,9 +606,10 @@ export default function About() {
               style={{ flexGrow: "0.7" }}
             >
               <div className="rounded-xl">
-                <img
+                <Image
                   className="h-96 w-80 rounded-xl object-cover"
                   src="https://framerusercontent.com/images/h4avZwD33gi1xDttcLVC1zjWvBA.jpg"
+                  alt="Placeholder"
                 />
               </div>
             </div>
@@ -615,9 +620,10 @@ export default function About() {
           >
             <div className="relative w-full rounded-xl">
               <div className="rounded-xl">
-                <img
+                <Image
                   className="h-96 w-full rounded-xl object-cover"
                   src="https://framerusercontent.com/images/mg9Dkmv1bZMO6mM2tX4EUwkcR7A.jpg"
+                  alt="Placeholder"
                 />
               </div>
             </div>
@@ -1099,7 +1105,7 @@ export default function About() {
             </div>
             <div className="relative mt-8 w-full lg:mt-0 lg:w-1/2 lg:pl-16">
               <div className="aspect-w-16 aspect-h-9" style={{ height: "70%" }}>
-                <img
+                <Image
                   className="h-full w-full object-cover"
                   src="https://www.datocms-assets.com/63464/1661347408-stuurmen-office-interior.jpg?auto=format&h=1080&w=1920"
                   alt="Stuurmen office interior"
@@ -1119,7 +1125,7 @@ export default function About() {
             <div className="relative flex w-2/3 flex-col">
               <div className="relative mb-4 h-[57.11rem]">
                 <div className="absolute inset-0">
-                  <img
+                  <Image
                     className="h-full w-full object-cover"
                     src="https://www.datocms-assets.com/63464/1661347918-stuurmen-visual-2.png?auto=format&h=965&w=760"
                     alt="Think before you ink"
@@ -1138,7 +1144,7 @@ export default function About() {
               </div>
               <div className="relative mb-4 h-[57.11rem]">
                 <div className="absolute inset-0">
-                  <img
+                  <Image
                     className="h-full w-full object-cover"
                     src="https://www.datocms-assets.com/63464/1661347908-stuurmen-visual-1.png?auto=format&h=965&w=760"
                     alt="No guts, no glory"
@@ -1157,7 +1163,7 @@ export default function About() {
               </div>
               <div className="relative mb-4 h-[57.11rem]">
                 <div className="absolute inset-0">
-                  <img
+                  <Image
                     className="h-full w-full object-cover"
                     src="https://www.datocms-assets.com/63464/1661347903-stuurmen-visual-4.png?auto=format&h=965&w=760"
                     alt="No bullshit bingo"
@@ -1175,7 +1181,7 @@ export default function About() {
               </div>
               <div className="relative mb-4 h-[57.11rem]">
                 <div className="absolute inset-0">
-                  <img
+                  <Image
                     className="h-full w-full object-cover"
                     src="https://www.datocms-assets.com/63464/1661347890-stuurmen-visual-3.png?auto=format&h=965&w=760"
                     alt="A touch of wit"
@@ -1192,7 +1198,7 @@ export default function About() {
               </div>
               <div className="relative h-[57.11rem]">
                 <div className="absolute inset-0">
-                  <img
+                  <Image
                     className="h-full w-full object-cover"
                     src="https://www.datocms-assets.com/63464/1661347872-stuurmen-visual-5.png?auto=format&h=965&w=760"
                     alt="Lead by example"

--- a/src/app/(frontend)/(inner)/home/ServicesSection/index.tsx
+++ b/src/app/(frontend)/(inner)/home/ServicesSection/index.tsx
@@ -106,6 +106,7 @@ export function ServicesSection({ services }: { services: Service[] }) {
                     <img
                       className="absolute left-0 top-0 z-0 h-full w-full max-w-full object-cover"
                       src="https://made-byshape.transforms.svdcdn.com/production/uploads/images/India-2022/Individuals-Black-Wall/Shape-April-2022-HR-186.jpg?w=200&h=200&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=0.5&fp-y=0.5&dm=1651143173&s=be043bcd94bb13283574b35d1df6ee93"
+                      alt="Shape"
                     />
                   </picture>
                 </div>

--- a/src/app/(frontend)/(inner)/home/WorkGridSection/index.tsx
+++ b/src/app/(frontend)/(inner)/home/WorkGridSection/index.tsx
@@ -76,6 +76,7 @@ export async function WorkGridSection({ projects }: { projects: Work[] }) {
                         <img
                           className="mt-3 h-auto w-full max-w-full"
                           src="https://made-byshape.transforms.svdcdn.com/production/uploads/images/google-reviews-badge.png?w=400&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=0.5&fp-y=0.5&dm=1702301485&s=a559fc5608bf902cd329da89be5a9b01"
+                          alt="Google Reviews Badge"
                         />
                       </picture>
                     </div>

--- a/src/app/(frontend)/(inner)/play/page.tsx
+++ b/src/app/(frontend)/(inner)/play/page.tsx
@@ -104,9 +104,10 @@ export default async function PlayPage() {
                   href=""
                 >
                   <div className="flex w-full cursor-pointer overflow-hidden rounded-md">
-                    <img
+                    <Image
                       className="inline-block h-full w-full max-w-full object-contain align-middle"
                       src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10dcd8842ec2b57b28cb6_63c9187126433a43129cc944_image-ueno-template-02.jpeg"
+                      alt="Square"
                     />
                   </div>
                   <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1 text-black">
@@ -132,9 +133,10 @@ export default async function PlayPage() {
                   href=""
                 >
                   <div className="flex w-full cursor-pointer overflow-hidden rounded-md">
-                    <img
+                    <Image
                       className="inline-block h-full w-full max-w-full object-contain align-middle"
                       src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10dfd80f1f22872630cce_63c91c81185e3416e7ba7960_image-ueno-template-06-p-2000.jpeg"
+                      alt="Castro Capital"
                     />
                   </div>
                   <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1 text-black">
@@ -160,9 +162,10 @@ export default async function PlayPage() {
                 >
                   <div className="relative flex w-full cursor-pointer overflow-hidden rounded-md">
                     <div className="relative w-full pt-[56.25%]">
-                      <img
+                      <Image
                         className="absolute bottom-0 left-0 top-0 inline-block h-full w-full max-w-full object-cover align-middle"
                         src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10e2f8842ec5dcab29324_63c91907a7ce6182b053ba02_image-ueno-template-03.jpeg"
+                        alt="Rucksack Magazine"
                       />
                     </div>
                   </div>
@@ -193,9 +196,10 @@ export default async function PlayPage() {
                   href=""
                 >
                   <div className="flex w-full cursor-pointer overflow-hidden rounded-md">
-                    <img
+                    <Image
                       className="inline-block h-full w-full max-w-full object-contain align-middle"
                       src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10e81559654d00360030b_63c91be70da88459ac7b5a3a_image-ueno-template-05.jpeg"
+                      alt="Romans"
                     />
                   </div>
                   <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1 text-black">
@@ -223,9 +227,10 @@ export default async function PlayPage() {
                   href=""
                 >
                   <div className="flex w-full cursor-pointer overflow-hidden rounded-md">
-                    <img
+                    <Image
                       className="inline-block h-full w-full max-w-full object-contain align-middle"
                       src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d1162e150c60446a56cadd_63c91d6bd8d50020d6d274c0_image-ueno-template-07-p-2000.jpeg"
+                      alt="Hakuha"
                     />
                   </div>
                   <div className="mt-3.5 flex cursor-pointer flex-col items-start pl-1 text-black">
@@ -251,9 +256,10 @@ export default async function PlayPage() {
                 >
                   <div className="relative flex w-full cursor-pointer overflow-hidden rounded-md">
                     <div className="relative w-full pt-[56.25%]">
-                      <img
+                      <Image
                         className="absolute bottom-0 left-0 top-0 inline-block h-full w-full max-w-full object-cover align-middle"
                         src="https://cdn.prod.website-files.com/63d10b7a4b5c9a525e3a297e/63d10ee4ad83658d2bc97c5a_63c91ec109d76d3e7e34327f_image-ueno-template-08-p-2000.jpeg"
+                        alt="Café de especialidad"
                       />
                     </div>
                   </div>


### PR DESCRIPTION
### TL;DR

Updated image handling and accessibility across multiple pages.

### What changed?

- Replaced `<img>` tags with Next.js `<Image>` components for better performance and optimization.
- Added missing `alt` attributes to images for improved accessibility.
- Updated the `sitemap.xml` file with new `lastmod` timestamps.

### How to test?

1. Navigate through the affected pages (About, Home, Play) and ensure all images load correctly.
2. Use a screen reader or accessibility tool to verify that all images have appropriate alt text.
3. Check the sitemap.xml file to confirm the updated timestamps.

### Why make this change?

This change enhances the website's performance by leveraging Next.js image optimization features. It also improves accessibility by providing alternative text for screen readers and search engines. The sitemap update ensures search engines have the most recent information about page modifications.