### PR TITLE
fix(nav): update image import for broken logos in header and footer

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -181,7 +181,7 @@ export default async function Footer() {
             unbounded{" "}
             <span className="-mr-3 -mt-11 inline-block align-middle">
               <Image
-                src="/images/brewww-mark.png"
+                src="/images/brewww-mark-white.png"
                 alt="Brewww Mark"
                 width={135}
                 height={135}

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -92,7 +92,7 @@ export default function Header() {
               <Link href="/home">
                 <Image
                   className="w-36 max-w-full cursor-pointer"
-                  src="/brewww-logotype-gold.png"
+                  src="/images/brewww-logotype-gold.png"
                   alt="Brewww Logo"
                   width={144}
                   height={40}


### PR DESCRIPTION
### TL;DR
Updated image paths for Brewww logo assets

### What changed?
- Updated footer logo path to use white version: `/images/brewww-mark-white.png`
- Fixed header logo path by adding `/images/` directory prefix to `brewww-logotype-gold.png`

### How to test?
1. Navigate to any page with the header
2. Verify the gold logotype appears correctly
3. Scroll to the footer
4. Confirm the white Brewww mark is visible

### Why make this change?
Standardizes image asset paths by ensuring all logo files are properly referenced from the `/images/` directory and uses the correct white version of the mark in the footer for better visibility