### PR TITLE
feat(home): improve styling of header and hero intro to give more space

### DIFF
--- a/src/app/(frontend)/(inner)/home/HomeHeroSection/index.tsx
+++ b/src/app/(frontend)/(inner)/home/HomeHeroSection/index.tsx
@@ -43,7 +43,7 @@ export function HomeHeroSection() {
   }, []);
 
   return (
-    <section className="relative flex min-h-[95vh] items-center justify-center overflow-hidden bg-brand-dark-bg text-zinc-50">
+    <section className="relative flex min-h-[100vh] items-center justify-center overflow-hidden bg-brand-dark-bg text-zinc-50">
       <div className="container mx-auto px-4 py-8 md:px-6">
         <h1
           ref={firstElementRef}
@@ -61,16 +61,6 @@ export function HomeHeroSection() {
           Brewww is the talent, tools, and deliverables to move you from today's
           reality to tomorrow's potential.
         </p>
-
-        <p
-          ref={secondElementRef}
-          className="mx-auto mt-6 max-w-3xl text-center text-body-medium opacity-70 md:text-2xl"
-          id="animate-second"
-        >
-          Brewww is a branding agency with a history of building compelling
-          brands for high-quality products and services.
-        </p>
-
         <div className="mt-10 flex justify-center">
           <div className="relative inline-block h-20 w-3 overflow-hidden md:h-28">
             <div className="absolute left-1/2 top-0 h-full w-px -translate-x-1/2 transform bg-white/35" />

--- a/src/app/(frontend)/(inner)/home/ServicesSection/index.tsx
+++ b/src/app/(frontend)/(inner)/home/ServicesSection/index.tsx
@@ -2,7 +2,6 @@ import ServiceCard from "@/components/ServiceCard/index";
 import { Service } from "@/payload-types";
 
 export function ServicesSection({ services }: { services: Service[] }) {
-  console.log("Rendering ServicesSection component");
   return (
     <section className="w-full rounded-3xl bg-zinc-900 py-20 text-black lg:pb-24 lg:pt-24 min-[1450px]:pb-32 min-[1450px]:pt-32 min-[2100px]:pb-40 min-[2100px]:pt-40">
       <div className="px-2 sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20 min-[1800px]:pl-40 min-[1800px]:pr-40 min-[2100px]:pl-60 min-[2100px]:pr-60">

--- a/src/app/(frontend)/(inner)/home/page.tsx
+++ b/src/app/(frontend)/(inner)/home/page.tsx
@@ -393,57 +393,6 @@ export default async function Home() {
           </div>
         </div>
       </section>
-
-      <section className="relative bg-neutral-800 text-white">
-        <div className="container mx-auto max-w-7xl px-4 py-12 md:py-20 lg:py-28">
-          <div className="grid grid-cols-12 gap-4">
-            <div className="z-10 col-start-1 col-end-9 row-start-1 row-end-3 flex flex-col justify-center">
-              <h3 className="mb-6 text-5xl font-thin leading-tight md:text-6xl lg:text-7xl">
-                Results are everything.
-                <br />
-                It's that <span className="font-bold">simple</span>.
-              </h3>
-              <div className="max-w-lg">
-                <p className="mb-4 text-base">
-                  From award-winning websites to complex web experiences, we've
-                  done it all. We've helped Games Studios use the web to hire,
-                  acquire players, and access new markets.
-                </p>
-                <p className="mb-2 uppercase">
-                  <a
-                    href=""
-                    className="transition-colors hover:text-brand-gold"
-                  >
-                    View Services
-                  </a>
-                </p>
-              </div>
-            </div>
-            <div className="relative col-start-7 col-end-13 row-start-1 row-end-3 h-[50vh] overflow-hidden">
-              <video
-                className="absolute inset-0 h-full w-full object-cover"
-                id="video-1"
-                autoPlay
-                loop
-                muted
-                playsInline
-              >
-                <source
-                  src="https://1minus1-2021.s3.eu-west-2.amazonaws.com/hotwheelz_a7a9952e87.mp4"
-                  type="video/mp4"
-                />
-              </video>
-              <div className="absolute bottom-0 right-0 p-4 text-right">
-                <p className="mb-1 text-[10rem] font-bold leading-none">50%</p>
-                <p className="text-sm">
-                  Increase in prospective <br />
-                  employee engagement.
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
     </>
   );
 }

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -22,7 +22,7 @@ export default function Header() {
 
   return (
     <>
-      <header className="sticky top-0 z-50 w-full bg-brand-dark-bg text-sm text-neutral-400">
+      <header className="fixed top-0 z-50 w-full bg-brand-dark-bg text-sm text-neutral-400">
         <div className="mx-auto max-w-[120rem] px-12">
           <div className="grid grid-cols-3 items-center py-4">
             <nav className="flex items-center space-x-4 font-semibold uppercase text-white">

--- a/src/components/WorkCard/index.tsx
+++ b/src/components/WorkCard/index.tsx
@@ -42,8 +42,8 @@ export function WorkCard({ project }: WorkCardProps) {
                         ? project.image?.alt
                         : ""
                     }
-                    layout="fill"
-                    objectFit="cover"
+                    fill
+                    style={{ objectFit: "cover" }}
                   />
                 </div>
               </div>


### PR DESCRIPTION
### TL;DR
Updated homepage layout and styling, removed redundant content, and fixed header positioning.

### What changed?
- Adjusted hero section height to 100vh and removed secondary description
- Removed console.log from ServicesSection
- Removed the "Results are everything" section from the homepage
- Changed header position from sticky to fixed
- Updated Image component props from legacy layout/objectFit to modern fill/style syntax

### How to test?
1. Navigate to the homepage
2. Verify hero section fills the entire viewport height
3. Check that header remains fixed at the top while scrolling
4. Ensure work card images display correctly
5. Confirm all animations and transitions work smoothly

### Why make this change?
These changes streamline the homepage content, improve visual consistency, and modernize the codebase by removing deprecated Next.js Image properties. The fixed header provides better navigation accessibility, while the adjusted hero section creates a more impactful first impression.