### PR TITLE
feat(cms): update generatePreviewPath to display SEO preview in BlogPosts

### DIFF
--- a/src/utils/generatePreviewPath.ts
+++ b/src/utils/generatePreviewPath.ts
@@ -1,2 +1,47 @@
-export const generatePreviewPath = ({ path }: { path: string }) =>
-  `/next/preview?path=${encodeURIComponent(path)}`;
+import { CollectionSlug } from "payload";
+
+// TODO: Add the remaining collections
+
+// Maps collection slugs to their corresponding URL prefixes
+const collectionPrefixMap: Partial<Record<CollectionSlug, string>> = {
+  posts: "/blog",
+  work: "/work",
+  team: "/team",
+  services: "/services",
+  pages: "", // No prefix for pages since they're at root level
+};
+
+// Props type for the generatePreviewPath function
+type Props = {
+  collection: keyof typeof collectionPrefixMap; // The collection type (e.g. 'posts', 'work')
+  slug: string; // The slug of the specific document
+};
+
+/**
+ * Generates a preview URL path for a given collection item
+ * @param collection - The collection the item belongs to
+ * @param slug - The slug of the specific item
+ * @returns A preview URL with encoded parameters
+ */
+export const generatePreviewPath = ({ collection, slug }: Props) => {
+  // Combine the collection prefix with the slug to create the full path
+  const path = `${collectionPrefixMap[collection]}/${slug}`;
+
+  // Create an object with all the parameters needed for the preview
+  const params = {
+    slug,
+    collection,
+    path,
+  };
+
+  // Create a URLSearchParams instance to properly encode the parameters
+  const encodedParams = new URLSearchParams();
+
+  // Add each parameter to the URLSearchParams instance
+  Object.entries(params).forEach(([key, value]) => {
+    encodedParams.append(key, value);
+  });
+
+  // Return the complete preview URL with encoded parameters
+  return `/next/preview?${encodedParams.toString()}`;
+};


### PR DESCRIPTION
### TL;DR
Enhanced the preview URL generation to support multiple collection types with proper path prefixes.

### What changed?
- Introduced a collection prefix mapping system for different content types (posts, work, team, services, pages)
- Added TypeScript types for better type safety and documentation
- Implemented proper URL parameter encoding using URLSearchParams
- Added support for collection-specific routing patterns

### How to test?
1. Generate preview URLs for different collections:
```typescript
generatePreviewPath({ collection: 'posts', slug: 'example-post' })
generatePreviewPath({ collection: 'work', slug: 'example-work' })
generatePreviewPath({ collection: 'pages', slug: 'example-page' })
```
2. Verify that the generated URLs include:
   - Correct collection prefix (e.g., `/blog` for posts)
   - Properly encoded parameters
   - Collection and slug information

### Why make this change?
The previous implementation only supported basic path encoding. This update provides a more robust solution that handles different content types with their specific routing patterns while ensuring proper URL parameter encoding.