### PR TITLE
chore(deps): add jwt to project deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "clsx": "^2.1.1",
     "eslint-plugin-react-compiler": "0.0.0-experimental-75b9fd4-20240912",
     "graphql": "^16.9.0",
+    "jsonwebtoken": "9.0.2",
     "gsap": "^3.12.5",
     "lexical": "0.17.0",
     "lucide-react": "^0.380.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       gsap:
         specifier: ^3.12.5
         version: 3.12.5
+      jsonwebtoken:
+        specifier: 9.0.2
+        version: 9.0.2
       lexical:
         specifier: 0.17.0
         version: 0.17.0
@@ -2154,6 +2157,9 @@ packages:
     resolution: {integrity: sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==}
     engines: {node: '>=6.9.0'}
 
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
   buffer@4.9.2:
     resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
 
@@ -2415,6 +2421,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   editorconfig@1.0.4:
     resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
@@ -3297,9 +3306,19 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonwebtoken@9.0.2:
+    resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
+    engines: {node: '>=12', npm: '>=6'}
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  jwa@1.4.1:
+    resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
+
+  jws@3.2.2:
+    resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
 
   kareem@2.5.1:
     resolution: {integrity: sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==}
@@ -3359,11 +3378,29 @@ packages:
   lodash.castarray@4.4.0:
     resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}
 
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
   lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
 
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -7407,6 +7444,8 @@ snapshots:
     dependencies:
       buffer: 5.7.1
 
+  buffer-equal-constant-time@1.0.1: {}
+
   buffer@4.9.2:
     dependencies:
       base64-js: 1.5.1
@@ -7660,6 +7699,10 @@ snapshots:
       domhandler: 5.0.3
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   editorconfig@1.0.4:
     dependencies:
@@ -8777,12 +8820,36 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonwebtoken@9.0.2:
+    dependencies:
+      jws: 3.2.2
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.6.3
+
   jsx-ast-utils@3.3.5:
     dependencies:
       array-includes: 3.1.8
       array.prototype.flat: 1.3.2
       object.assign: 4.1.5
       object.values: 1.2.0
+
+  jwa@1.4.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@3.2.2:
+    dependencies:
+      jwa: 1.4.1
+      safe-buffer: 5.2.1
 
   kareem@2.5.1: {}
 
@@ -8831,9 +8898,21 @@ snapshots:
 
   lodash.castarray@4.4.0: {}
 
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
   lodash.isplainobject@4.0.6: {}
 
+  lodash.isstring@4.0.1: {}
+
   lodash.merge@4.6.2: {}
+
+  lodash.once@4.1.1: {}
 
   lodash@4.17.21: {}
 

--- a/src/app/(frontend)/(inner)/layout.tsx
+++ b/src/app/(frontend)/(inner)/layout.tsx
@@ -7,11 +7,8 @@ import { LivePreviewListener } from "@/components/LivePreviewListener";
 import { GridGuide } from "@/components/GridGuide/index";
 import { Grain } from "@/components/Grain/index";
 import { AdminBar } from "@/components/AdminBar";
-
-export const metadata: Metadata = {
-  title: "Inner Pages",
-  description: "Inner pages of Brewww Studio",
-};
+import { mergeOpenGraph } from "@/utilities/mergeOpenGraph";
+import { draftMode } from "next/headers";
 
 const DMSans = localFont({
   variable: "--font-dm-sans",
@@ -39,9 +36,11 @@ const BebasNeue = localFont({
 
 export default async function InnerLayout({
   children,
-}: Readonly<{
+}: {
   children: React.ReactNode;
-}>) {
+}) {
+  const { isEnabled } = await draftMode();
+
   return (
     <html
       lang="en"
@@ -61,3 +60,14 @@ export default async function InnerLayout({
     </html>
   );
 }
+
+export const metadata: Metadata = {
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_SERVER_URL || "https://brewww.studio",
+  ),
+  openGraph: mergeOpenGraph(),
+  twitter: {
+    card: "summary_large_image",
+    creator: "@brewwwstudio",
+  },
+};

--- a/src/app/(frontend)/next/preview/route.ts
+++ b/src/app/(frontend)/next/preview/route.ts
@@ -1,0 +1,96 @@
+import jwt from "jsonwebtoken";
+import { draftMode } from "next/headers";
+import { redirect } from "next/navigation";
+import { getPayloadHMR } from "@payloadcms/next/utilities";
+import configPromise from "@payload-config";
+import { CollectionSlug } from "payload";
+
+const payloadToken = "payload-token";
+
+export async function GET(
+  req: Request & {
+    cookies: {
+      get: (name: string) => {
+        value: string;
+      };
+    };
+  },
+): Promise<Response> {
+  const payload = await getPayloadHMR({ config: configPromise });
+  const token = req.cookies.get(payloadToken)?.value;
+  const { searchParams } = new URL(req.url);
+  const path = searchParams.get("path");
+  const collection = searchParams.get("collection") as CollectionSlug;
+  const slug = searchParams.get("slug");
+
+  const previewSecret = searchParams.get("previewSecret");
+
+  if (previewSecret) {
+    return new Response("You are not allowed to preview this page", {
+      status: 403,
+    });
+  } else {
+    if (!path) {
+      return new Response("No path provided", { status: 404 });
+    }
+
+    if (!collection) {
+      return new Response("No path provided", { status: 404 });
+    }
+
+    if (!slug) {
+      return new Response("No path provided", { status: 404 });
+    }
+
+    if (!token) {
+      new Response("You are not allowed to preview this page", { status: 403 });
+    }
+
+    if (!path.startsWith("/")) {
+      new Response("This endpoint can only be used for internal previews", {
+        status: 500,
+      });
+    }
+
+    let user;
+
+    try {
+      user = jwt.verify(token, payload.secret);
+    } catch (error) {
+      payload.logger.error("Error verifying token for live preview:", error);
+    }
+
+    const draft = await draftMode();
+
+    // You can add additional checks here to see if the user is allowed to preview this page
+    if (!user) {
+      draft.disable();
+      return new Response("You are not allowed to preview this page", {
+        status: 403,
+      });
+    }
+
+    // Verify the given slug exists
+    try {
+      const docs = await payload.find({
+        collection: collection,
+        draft: true,
+        where: {
+          slug: {
+            equals: slug,
+          },
+        },
+      });
+
+      if (!docs.docs.length) {
+        return new Response("Document not found", { status: 404 });
+      }
+    } catch (error) {
+      payload.logger.error("Error verifying token for live preview:", error);
+    }
+
+    draft.enable();
+
+    redirect(path);
+  }
+}

--- a/src/utilities/mergeOpenGraph.ts
+++ b/src/utilities/mergeOpenGraph.ts
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+
+const defaultOpenGraph: Metadata["openGraph"] = {
+  type: "website",
+  description: "A marketing studio for the modern age.",
+  images: [
+    {
+      url: process.env.NEXT_PUBLIC_SERVER_URL
+        ? `${process.env.NEXT_PUBLIC_SERVER_URL}/website-template-OG.webp`
+        : "/website-template-OG.webp",
+    },
+  ],
+  siteName: "Brewww Studio",
+  title: "Brewww Studio",
+};
+
+export const mergeOpenGraph = (
+  og?: Metadata["openGraph"],
+): Metadata["openGraph"] => {
+  return {
+    ...defaultOpenGraph,
+    ...og,
+    images: og?.images ? og.images : defaultOpenGraph.images,
+  };
+};


### PR DESCRIPTION
### TL;DR

Added JWT authentication and preview functionality for draft content with OpenGraph metadata support.

### What changed?

- Added JWT authentication for secure content preview
- Created a new preview route handler for draft content viewing
- Implemented OpenGraph metadata utilities with default configurations
- Updated inner layout with dynamic metadata and draft mode support
- Added Twitter card metadata configuration

### How to test?

1. Log in to the admin panel
2. Navigate to any content piece
3. Click the preview button to view draft content
4. Verify the preview shows the latest unpublished changes
5. Check page metadata in browser dev tools to confirm OpenGraph and Twitter card presence

### Why make this change?

This change enables content editors to preview draft content securely before publishing while ensuring proper social media sharing metadata is present across all pages. The JWT authentication ensures that only authorized users can access draft content, maintaining content security.