### PR TITLE
chore(logs): add console logs to next route for the LiveListener

### DIFF
--- a/src/app/(frontend)/(inner)/home/HomeHeroSection/index.tsx
+++ b/src/app/(frontend)/(inner)/home/HomeHeroSection/index.tsx
@@ -117,8 +117,8 @@ export function HomeHeroSection() {
           className="mx-auto mb-6 max-w-5xl text-center text-display-medium font-bold leading-[0.9] tracking-tighter"
           id="hero-message"
         >
-          <span className="opacity-30">From pencils to pixels</span>
-          <span> we craft unbounded brands.</span>
+          <span className="opacity-30"></span>
+          <span>we craft brands beyond tomorrow.</span>
         </h1>
         <p className="mx-auto mt-6 max-w-3xl text-center text-body-medium opacity-70 md:text-2xl">
           Brewww is the talent, tools, and deliverables to move you from today's

--- a/src/app/(frontend)/next/exit-preview/GET.ts
+++ b/src/app/(frontend)/next/exit-preview/GET.ts
@@ -1,7 +1,9 @@
 import { draftMode } from "next/headers";
 
 export async function GET(): Promise<Response> {
+  console.log("[exit-preview/GET.ts] Disabling draft mode...");
   const draft = await draftMode();
   draft.disable();
+  console.log("[exit-preview/GET.ts] Draft mode disabled successfully");
   return new Response("Draft mode is disabled");
 }

--- a/src/app/(frontend)/next/exit-preview/route.ts
+++ b/src/app/(frontend)/next/exit-preview/route.ts
@@ -1,7 +1,9 @@
 import { draftMode } from "next/headers";
 
 export async function GET(): Promise<Response> {
+  console.log("[exit-preview/route.ts] Disabling draft mode...");
   const draft = await draftMode();
   draft.disable();
+  console.log("[exit-preview/route.ts] Draft mode disabled successfully");
   return new Response("Draft mode is disabled");
 }

--- a/src/app/(frontend)/next/preview/route.ts
+++ b/src/app/(frontend)/next/preview/route.ts
@@ -16,6 +16,7 @@ export async function GET(
     };
   },
 ): Promise<Response> {
+  console.log("[preview/route.ts] Starting preview request...");
   const payload = await getPayloadHMR({ config: configPromise });
   const token = req.cookies.get(payloadToken)?.value;
   const { searchParams } = new URL(req.url);
@@ -26,27 +27,33 @@ export async function GET(
   const previewSecret = searchParams.get("previewSecret");
 
   if (previewSecret) {
+    console.log("[preview/route.ts] Preview secret provided - access denied");
     return new Response("You are not allowed to preview this page", {
       status: 403,
     });
   } else {
     if (!path) {
+      console.log("[preview/route.ts] No path provided");
       return new Response("No path provided", { status: 404 });
     }
 
     if (!collection) {
+      console.log("[preview/route.ts] No collection provided");
       return new Response("No path provided", { status: 404 });
     }
 
     if (!slug) {
+      console.log("[preview/route.ts] No slug provided");
       return new Response("No path provided", { status: 404 });
     }
 
     if (!token) {
+      console.log("[preview/route.ts] No token provided");
       new Response("You are not allowed to preview this page", { status: 403 });
     }
 
     if (!path.startsWith("/")) {
+      console.log("[preview/route.ts] Invalid path - must start with /");
       new Response("This endpoint can only be used for internal previews", {
         status: 500,
       });
@@ -56,7 +63,9 @@ export async function GET(
 
     try {
       user = jwt.verify(token, payload.secret);
+      console.log("[preview/route.ts] Token verified successfully");
     } catch (error) {
+      console.log("[preview/route.ts] Error verifying token:", error);
       payload.logger.error("Error verifying token for live preview:", error);
     }
 
@@ -64,6 +73,7 @@ export async function GET(
 
     // You can add additional checks here to see if the user is allowed to preview this page
     if (!user) {
+      console.log("[preview/route.ts] No user found - disabling draft mode");
       draft.disable();
       return new Response("You are not allowed to preview this page", {
         status: 403,
@@ -72,6 +82,9 @@ export async function GET(
 
     // Verify the given slug exists
     try {
+      console.log(
+        `[preview/route.ts] Searching for document in collection: ${collection}, slug: ${slug}`,
+      );
       const docs = await payload.find({
         collection: collection,
         draft: true,
@@ -83,12 +96,19 @@ export async function GET(
       });
 
       if (!docs.docs.length) {
+        console.log("[preview/route.ts] Document not found");
         return new Response("Document not found", { status: 404 });
       }
+      console.log("[preview/route.ts] Document found successfully");
     } catch (error) {
+      console.log("[preview/route.ts] Error finding document:", error);
       payload.logger.error("Error verifying token for live preview:", error);
     }
 
+    console.log(
+      "[preview/route.ts] Enabling draft mode and redirecting to:",
+      path,
+    );
     draft.enable();
 
     redirect(path);

--- a/src/collections/Pages/config.ts
+++ b/src/collections/Pages/config.ts
@@ -40,7 +40,7 @@ export const Pages: CollectionConfig = {
               name: "layout",
               type: "blocks",
               label: "Layout",
-              required: true,
+              required: false,
               blocks: [Cover, FormBlock],
             },
           ],

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -108,16 +108,18 @@ export interface Media {
 export interface Page {
   id: string;
   title: string;
-  layout: (
-    | {
-        title?: string | null;
-        subtitle?: string | null;
-        id?: string | null;
-        blockName?: string | null;
-        blockType: 'cover';
-      }
-    | FormBlock
-  )[];
+  layout?:
+    | (
+        | {
+            title?: string | null;
+            subtitle?: string | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'cover';
+          }
+        | FormBlock
+      )[]
+    | null;
   seo?: {
     title?: string | null;
     image?: (string | null) | Media;


### PR DESCRIPTION
### TL;DR
Updated hero text and enhanced preview mode logging while making page layouts optional.

### What changed?
- Modified hero text from "From pencils to pixels we craft unbounded brands" to "we craft brands beyond tomorrow"
- Added detailed logging throughout preview and exit-preview routes for better debugging
- Made page layout field optional in Pages collection
- Updated TypeScript types to reflect optional layout field

### How to test?
1. Visit the homepage to verify the new hero text
2. Test preview mode functionality and check logs for new debugging messages
3. Create a new page without a layout to confirm it saves successfully
4. Verify preview/exit-preview routes work as expected with proper error handling

### Why make this change?
- Updated brand messaging to better reflect company vision
- Enhanced debugging capabilities for preview mode to help troubleshoot issues
- Made page layouts optional to support simpler page structures and improve content flexibility