### PR TITLE
feat(cms): add autosave to all collections

### DIFF
--- a/src/collections/BlogCategories/config.ts
+++ b/src/collections/BlogCategories/config.ts
@@ -55,7 +55,7 @@ export const BlogCategories: CollectionConfig = {
     plural: "Categories",
   },
   versions: {
-    drafts: true,
+    drafts: { autosave: { interval: 100 } },
     maxPerDoc: 25,
   },
 };

--- a/src/collections/Brands/config.ts
+++ b/src/collections/Brands/config.ts
@@ -88,7 +88,7 @@ export const Brands: CollectionConfig = {
     plural: "Brands",
   },
   versions: {
-    drafts: true,
+    drafts: { autosave: { interval: 100 } },
     maxPerDoc: 25,
   },
 };

--- a/src/collections/FAQ/config.ts
+++ b/src/collections/FAQ/config.ts
@@ -34,11 +34,18 @@ export const FAQ: CollectionConfig = {
 
   admin: {
     description: "Frequently asked questions",
+    defaultColumns: ["title"],
     group: "Company",
+    listSearchableFields: ["title"],
+
     useAsTitle: "title",
   },
   labels: {
     singular: "FAQ",
     plural: "FAQ",
+  },
+  versions: {
+    drafts: { autosave: { interval: 100 } },
+    maxPerDoc: 25,
   },
 };

--- a/src/collections/Industries/config.ts
+++ b/src/collections/Industries/config.ts
@@ -122,7 +122,7 @@ export const Industries: CollectionConfig = {
     plural: "Industries",
   },
   versions: {
-    drafts: true,
+    drafts: { autosave: { interval: 100 } },
     maxPerDoc: 25,
   },
 };

--- a/src/collections/Journeys/config.ts
+++ b/src/collections/Journeys/config.ts
@@ -122,7 +122,7 @@ export const Journeys: CollectionConfig = {
     plural: "Journeys",
   },
   versions: {
-    drafts: true,
+    drafts: { autosave: { interval: 100 } },
     maxPerDoc: 25,
   },
 };

--- a/src/collections/Locations/config.ts
+++ b/src/collections/Locations/config.ts
@@ -43,7 +43,7 @@ export const Location: CollectionConfig = {
     plural: "Locations",
   },
   versions: {
-    drafts: true,
+    drafts: { autosave: { interval: 100 } },
     maxPerDoc: 25,
   },
 };

--- a/src/collections/Pages/config.ts
+++ b/src/collections/Pages/config.ts
@@ -74,11 +74,7 @@ export const Pages: CollectionConfig = {
     },
   },
   versions: {
-    drafts: {
-      autosave: {
-        interval: 100,
-      },
-    },
-    maxPerDoc: 50,
+    drafts: { autosave: { interval: 100 } },
+    maxPerDoc: 25,
   },
 };

--- a/src/collections/Pillars/config.ts
+++ b/src/collections/Pillars/config.ts
@@ -122,7 +122,7 @@ export const Pillars: CollectionConfig = {
     plural: "Pillars",
   },
   versions: {
-    drafts: true,
+    drafts: { autosave: { interval: 100 } },
     maxPerDoc: 25,
   },
 };

--- a/src/collections/Play/config.ts
+++ b/src/collections/Play/config.ts
@@ -179,7 +179,7 @@ export const Playground: CollectionConfig = {
     ],
   },
   versions: {
-    drafts: true,
+    drafts: { autosave: { interval: 100 } },
     maxPerDoc: 25,
   },
 };

--- a/src/collections/Results/config.ts
+++ b/src/collections/Results/config.ts
@@ -57,7 +57,7 @@ export const Results: CollectionConfig = {
     plural: "Results",
   },
   versions: {
-    drafts: true,
+    drafts: { autosave: { interval: 100 } },
     maxPerDoc: 25,
   },
 };

--- a/src/collections/Services/config.ts
+++ b/src/collections/Services/config.ts
@@ -132,7 +132,7 @@ export const Services: CollectionConfig = {
     plural: "Services",
   },
   versions: {
-    drafts: true,
+    drafts: { autosave: { interval: 100 } },
     maxPerDoc: 25,
   },
 };

--- a/src/collections/Team/config.ts
+++ b/src/collections/Team/config.ts
@@ -63,7 +63,7 @@ export const Team: CollectionConfig = {
     plural: "Team",
   },
   versions: {
-    drafts: true,
+    drafts: { autosave: { interval: 100 } },
     maxPerDoc: 25,
   },
 };

--- a/src/collections/Technologies/config.ts
+++ b/src/collections/Technologies/config.ts
@@ -54,7 +54,7 @@ export const Technologies: CollectionConfig = {
     plural: "Technologies",
   },
   versions: {
-    drafts: true,
+    drafts: { autosave: { interval: 100 } },
     maxPerDoc: 25,
   },
 };

--- a/src/collections/Testimonials/config.ts
+++ b/src/collections/Testimonials/config.ts
@@ -102,7 +102,7 @@ export const Testimonials: CollectionConfig = {
     plural: "Testimonials",
   },
   versions: {
-    drafts: true,
+    drafts: { autosave: { interval: 100 } },
     maxPerDoc: 25,
   },
 };

--- a/src/collections/Work/config.ts
+++ b/src/collections/Work/config.ts
@@ -205,7 +205,7 @@ export const Work: CollectionConfig = {
     plural: "Works",
   },
   versions: {
-    drafts: true,
+    drafts: { autosave: { interval: 100 } },
     maxPerDoc: 25,
   },
 };

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -22,7 +22,7 @@ export default function Header() {
 
   return (
     <>
-      <header className="fixed top-0 z-50 w-full bg-brand-dark-bg text-sm text-neutral-400">
+      <header className="top-0 z-50 w-full bg-brand-dark-bg text-sm text-neutral-400">
         <div className="mx-auto max-w-[120rem] px-12">
           <div className="grid grid-cols-3 items-center py-4">
             <nav className="flex items-center space-x-4 font-semibold uppercase text-white">

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -108,18 +108,7 @@ export interface Media {
 export interface Page {
   id: string;
   title: string;
-  layout?:
-    | (
-        | {
-            title?: string | null;
-            subtitle?: string | null;
-            id?: string | null;
-            blockName?: string | null;
-            blockType: 'cover';
-          }
-        | FormBlock
-      )[]
-    | null;
+  layout?: FormBlock[] | null;
   seo?: {
     title?: string | null;
     image?: (string | null) | Media;
@@ -554,6 +543,7 @@ export interface Faq {
   };
   updatedAt: string;
   createdAt: string;
+  _status?: ('draft' | 'published') | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
### TL;DR
Enabled autosave functionality for drafts across collections and adjusted header positioning.

### What changed?
- Added autosave functionality with 100ms interval to all collection drafts
- Added default columns, list searchable fields, and versioning to FAQ collection
- Removed `fixed` positioning from the main header component
- Standardized `maxPerDoc` versions to 25 across all collections

### How to test?
1. Create or edit content in any collection
2. Verify that drafts are automatically saved every 100ms
3. Check that the FAQ collection displays proper columns and search functionality
4. Scroll through pages to ensure header behavior is correct
5. Verify version history is limited to 25 versions per document

### Why make this change?
Implementing autosave functionality helps prevent data loss during content creation and editing. The standardization of version limits helps manage database storage more effectively, while the header positioning change improves overall page layout consistency.