### PR TITLE
feat(cms): add PayloadRedirects component

### DIFF
--- a/src/app/(frontend)/(inner)/blog/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/blog/[slug]/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from "next";
+
 import configPromise from "@payload-config";
 import { getPayloadHMR } from "@payloadcms/next/utilities";
 import React from "react";

--- a/src/components/PayloadRedirects/index.tsx
+++ b/src/components/PayloadRedirects/index.tsx
@@ -1,0 +1,55 @@
+import type React from "react";
+import type { Page, Post } from "@/payload-types";
+
+import { getCachedDocument } from "@/utilities/getDocument";
+import { getCachedRedirects } from "@/utilities/getRedirects";
+import { notFound, redirect } from "next/navigation";
+
+interface Props {
+  disableNotFound?: boolean;
+  url: string;
+}
+
+/* This component helps us with SSR based dynamic redirects */
+export const PayloadRedirects: React.FC<Props> = async ({
+  disableNotFound,
+  url,
+}) => {
+  const slug = url.startsWith("/") ? url : `${url}`;
+
+  const redirects = await getCachedRedirects()();
+
+  const redirectItem = redirects.find((redirect) => redirect.from === slug);
+
+  if (redirectItem) {
+    if (redirectItem.to?.url) {
+      redirect(redirectItem.to.url);
+    }
+
+    let redirectUrl: string;
+
+    if (typeof redirectItem.to?.reference?.value === "string") {
+      const collection = redirectItem.to?.reference?.relationTo;
+      const id = redirectItem.to?.reference?.value;
+
+      const document = (await getCachedDocument(collection, id)()) as
+        | Page
+        | Post;
+      redirectUrl = `${redirectItem.to?.reference?.relationTo !== "pages" ? `/${redirectItem.to?.reference?.relationTo}` : ""}/${
+        document?.slug
+      }`;
+    } else {
+      redirectUrl = `${redirectItem.to?.reference?.relationTo !== "pages" ? `/${redirectItem.to?.reference?.relationTo}` : ""}/${
+        typeof redirectItem.to?.reference?.value === "object"
+          ? redirectItem.to?.reference?.value?.slug
+          : ""
+      }`;
+    }
+
+    if (redirectUrl) redirect(redirectUrl);
+  }
+
+  if (disableNotFound) return null;
+
+  notFound();
+};

--- a/src/utilities/generatePreviewPath.ts
+++ b/src/utilities/generatePreviewPath.ts
@@ -1,6 +1,7 @@
 import { CollectionSlug } from "payload";
 
 const collectionPrefixMap: Partial<Record<CollectionSlug, string>> = {
+  work: "/work",
   posts: "/blog",
   pages: "",
 };
@@ -11,13 +12,12 @@ type Props = {
 };
 
 export const generatePreviewPath = ({ collection, slug }: Props) => {
-  const prefix = collectionPrefixMap[collection] || "";
-  const actualPath = prefix ? `${prefix}/${slug}` : `/${slug}`;
+  const path = `${collectionPrefixMap[collection]}/${slug}`;
 
   const params = {
     slug,
     collection,
-    path: actualPath,
+    path,
   };
 
   const encodedParams = new URLSearchParams();

--- a/src/utilities/getDocuments.ts
+++ b/src/utilities/getDocuments.ts
@@ -1,0 +1,35 @@
+import type { Config } from "src/payload-types";
+
+import configPromise from "@payload-config";
+import { getPayloadHMR } from "@payloadcms/next/utilities";
+import { unstable_cache } from "next/cache";
+
+type Collection = keyof Config["collections"];
+
+async function getDocument(collection: Collection, slug: string, depth = 0) {
+  const payload = await getPayloadHMR({ config: configPromise });
+
+  const page = await payload.find({
+    collection,
+    depth,
+    where: {
+      slug: {
+        equals: slug,
+      },
+    },
+  });
+
+  return page.docs[0];
+}
+
+/**
+ * Returns a unstable_cache function mapped with the cache tag for the slug
+ */
+export const getCachedDocument = (collection: Collection, slug: string) =>
+  unstable_cache(
+    async () => getDocument(collection, slug),
+    [collection, slug],
+    {
+      tags: [`${collection}_${slug}`],
+    },
+  );

--- a/src/utilities/getRedirects.ts
+++ b/src/utilities/getRedirects.ts
@@ -1,0 +1,26 @@
+import configPromise from "@payload-config";
+import { getPayloadHMR } from "@payloadcms/next/utilities";
+import { unstable_cache } from "next/cache";
+
+export async function getRedirects(depth = 1) {
+  const payload = await getPayloadHMR({ config: configPromise });
+
+  const { docs: redirects } = await payload.find({
+    collection: "redirects",
+    depth,
+    limit: 0,
+    pagination: false,
+  });
+
+  return redirects;
+}
+
+/**
+ * Returns a unstable_cache function mapped with the cache tag for 'redirects'.
+ *
+ * Cache all redirects together to avoid multiple fetches.
+ */
+export const getCachedRedirects = () =>
+  unstable_cache(async () => getRedirects(), ["redirects"], {
+    tags: ["redirects"],
+  });


### PR DESCRIPTION
### TL;DR
Added support for dynamic redirects and document caching in Next.js application.

### What changed?
- Introduced a new `PayloadRedirects` component for handling SSR-based dynamic redirects
- Created utility functions for caching documents and redirects using `unstable_cache`
- Added work collection prefix to preview path generation
- Simplified path generation logic in `generatePreviewPath`

### How to test?
1. Create a redirect in the CMS
2. Visit the "from" URL path
3. Verify redirection to the specified "to" URL
4. Test different redirect types:
   - Direct URL redirects
   - Page/Post reference redirects
   - Work collection redirects

### Why make this change?
To implement a robust redirection system that:
- Handles dynamic redirects server-side
- Improves performance through document caching
- Supports multiple collection types
- Maintains consistent URL structures across the application