### PR TITLE
feat(posts): add generateMeta to BlogPosts to handle meta generation

### DIFF
--- a/src/app/(frontend)/(inner)/blog/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/blog/[slug]/page.tsx
@@ -1,17 +1,23 @@
-import type { Metadata } from "next";
-
-import configPromise from "@payload-config";
-import { getPayloadHMR } from "@payloadcms/next/utilities";
+// Next Imports
 import React from "react";
-import RichText from "@/components/RichText/index";
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { Post } from "@/payload-types";
 import Image from "next/image";
 import Link from "next/link";
-import { formatDate } from "@root/utilities/dateFormatter";
 
+// Payload Imports
+import { PayloadRedirects } from "@/components/PayloadRedirects";
+import configPromise from "@payload-config";
+import { getPayloadHMR } from "@payloadcms/next/utilities";
+import { Post } from "@/payload-types";
+
+// Components
+import RichText from "@/components/RichText/index";
 import TableOfContents from "@/components/TableOfContents/index";
 import { LexicalNode } from "@/components/RichText/nodeFormat";
+
+// Utilities
+import { formatDate } from "@root/utilities/dateFormatter";
 
 export async function generateStaticParams() {
   const payload = await getPayloadHMR({ config: configPromise });

--- a/src/utilities/generateMeta.ts
+++ b/src/utilities/generateMeta.ts
@@ -1,0 +1,38 @@
+import type { Metadata } from "next";
+
+import type { Page, Post } from "../payload-types";
+
+import { mergeOpenGraph } from "./mergeOpenGraph";
+
+export const generateMeta = async (args: {
+  doc: Page | Post;
+}): Promise<Metadata> => {
+  const { doc } = args || {};
+
+  const ogImage =
+    typeof doc?.meta?.image === "object" &&
+    doc.meta.image !== null &&
+    "url" in doc.meta.image &&
+    `${process.env.NEXT_PUBLIC_SERVER_URL}${doc.meta.image.url}`;
+
+  const title = doc?.meta?.title
+    ? doc?.meta?.title + " | Payload Website Template"
+    : "Payload Website Template";
+
+  return {
+    description: doc?.meta?.description,
+    openGraph: mergeOpenGraph({
+      description: doc?.meta?.description || "",
+      images: ogImage
+        ? [
+            {
+              url: ogImage,
+            },
+          ]
+        : undefined,
+      title,
+      url: Array.isArray(doc?.slug) ? doc?.slug.join("/") : "/",
+    }),
+    title,
+  };
+};


### PR DESCRIPTION
### TL;DR
Added metadata generation utility and reorganized blog page imports for better code organization.

### What changed?
- Created a new `generateMeta.ts` utility to handle metadata generation for pages and posts
- Added structured import organization in the blog page with clear sectioning (Next, Payload, Components, Utilities)
- Introduced PayloadRedirects component import to the blog page
- Implemented OpenGraph metadata handling with image URL processing

### How to test?
1. Navigate to any blog post
2. Inspect the page's metadata in the browser dev tools
3. Verify that OpenGraph tags are properly populated
4. Check that image URLs are correctly formatted with the server URL
5. Validate that the page title follows the format: "[Title] | Payload Website Template"

### Why make this change?
To improve SEO capabilities and maintain consistent metadata across pages while following better code organization practices. The metadata generation utility provides a centralized way to handle meta tags and OpenGraph data, making it easier to maintain and update site-wide metadata.