### PR TITLE
feat(cms): add Preview and LivePreview to BlogPosts

### DIFF
--- a/src/app/(frontend)/(inner)/layout.tsx
+++ b/src/app/(frontend)/(inner)/layout.tsx
@@ -48,8 +48,8 @@ export default async function InnerLayout({
       suppressHydrationWarning
     >
       <body className="bg-gray-950 text-gray-50 antialiased">
+        <AdminBar adminBarProps={{ preview: isEnabled }} />
         <Grain>
-          <AdminBar adminBarProps={{ preview: isEnabled }} />
           <LivePreviewListener />
           <Header />
           <main className="min-h-[80vh]">{children}</main>

--- a/src/collections/BlogPosts/config.ts
+++ b/src/collections/BlogPosts/config.ts
@@ -191,17 +191,21 @@ export const BlogPosts: CollectionConfig = {
     listSearchableFields: ["title"],
     livePreview: {
       url: ({ data }) => {
-        return generatePreviewPath({
-          collection: "posts",
+        const path = generatePreviewPath({
           slug: typeof data?.slug === "string" ? data.slug : "",
+          collection: "posts",
         });
+
+        return `${process.env.NEXT_PUBLIC_SERVER_URL}${path}`;
       },
     },
     preview: (data) => {
-      return generatePreviewPath({
-        collection: "posts",
+      const path = generatePreviewPath({
         slug: typeof data?.slug === "string" ? data.slug : "",
+        collection: "posts",
       });
+
+      return `${process.env.NEXT_PUBLIC_SERVER_URL}${path}`;
     },
 
     pagination: {

--- a/src/components/AdminBar/index.tsx
+++ b/src/components/AdminBar/index.tsx
@@ -48,8 +48,8 @@ export const AdminBar: React.FC<{
           className="py-2 text-white"
           classNames={{
             controls: "font-medium text-white",
-            logo: "text-white",
-            user: "text-white",
+            logo: "text-black",
+            user: "text-black",
           }}
           cmsURL={process.env.NEXT_PUBLIC_SERVER_URL}
           collection={collection}


### PR DESCRIPTION
### TL;DR

Improved admin bar visibility and preview URL handling for blog posts.

### What changed?

- Moved the AdminBar component outside of the Grain wrapper to ensure better visibility
- Added full server URL to blog post preview paths
- Updated AdminBar text colors to improve contrast (logo and user text now black)

### How to test?

1. Log in as an admin user
2. Navigate to different pages and verify the admin bar is clearly visible
3. Create or edit a blog post
4. Test the preview functionality and ensure URLs are correctly formed with the full server path
5. Verify the admin bar text is readable with proper contrast

### Why make this change?

The admin bar was previously difficult to see due to being wrapped in the Grain component. Adding the full server URL to preview paths ensures proper routing functionality. The text color adjustments improve visibility and usability for administrators.