### PR TITLE
feat(cms): simplify BlogPosts data structure by removing items nested in metadata tab

### DIFF
--- a/src/collections/BlogPosts/config.ts
+++ b/src/collections/BlogPosts/config.ts
@@ -83,51 +83,6 @@ export const BlogPosts: CollectionConfig = {
             },
           ],
         },
-        {
-          name: "metadata",
-          label: "Meta",
-          fields: [
-            {
-              name: "relatedPosts",
-              type: "relationship",
-              admin: {
-                position: "sidebar",
-              },
-              filterOptions: ({ id }) => {
-                return {
-                  id: {
-                    not_in: [id],
-                  },
-                };
-              },
-              hasMany: true,
-              relationTo: "posts",
-            },
-            {
-              name: "categories",
-              type: "relationship",
-              admin: {
-                position: "sidebar",
-                description:
-                  "Add the post categories here. This is used to group the articles.",
-              },
-              hasMany: true,
-              relationTo: "categories",
-              required: true,
-            },
-            {
-              name: "readTime",
-              type: "number",
-              required: true,
-              label: "Read Time",
-              admin: {
-                description:
-                  "The estimated time it takes to read the article in minutes. Every 200 words is approximately one minute.",
-                position: "sidebar",
-              },
-            },
-          ],
-        },
         seoTab,
       ],
     },
@@ -178,6 +133,43 @@ export const BlogPosts: CollectionConfig = {
       admin: {
         position: "sidebar",
       },
+    },
+    {
+      name: "readTime",
+      type: "number",
+      required: true,
+      label: "Read Time",
+      admin: {
+        position: "sidebar",
+      },
+    },
+    {
+      name: "categories",
+      type: "relationship",
+      admin: {
+        position: "sidebar",
+        description:
+          "Add the post categories here. This is used to group the articles.",
+      },
+      hasMany: true,
+      relationTo: "categories",
+      required: true,
+    },
+    {
+      name: "relatedPosts",
+      type: "relationship",
+      admin: {
+        position: "sidebar",
+      },
+      filterOptions: ({ id }) => {
+        return {
+          id: {
+            not_in: [id],
+          },
+        };
+      },
+      hasMany: true,
+      relationTo: "posts",
     },
   ],
 

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -335,11 +335,6 @@ export interface Post {
     };
     [k: string]: unknown;
   };
-  metadata: {
-    relatedPosts?: (string | Post)[] | null;
-    categories: (string | Category)[];
-    readTime: number;
-  };
   seo?: {
     title?: string | null;
     image?: (string | null) | Media;
@@ -351,6 +346,9 @@ export interface Post {
   image: string | Media;
   status?: ('not started' | 'needs rewrite' | 'needs polish' | 'needs photos' | 'ready') | null;
   featured?: boolean | null;
+  readTime: number;
+  categories: (string | Category)[];
+  relatedPosts?: (string | Post)[] | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;


### PR DESCRIPTION
### TL;DR
Restructured blog post fields by moving metadata fields to the root level of the schema.

### What changed?
- Removed the nested `metadata` object structure
- Moved `relatedPosts`, `categories`, and `readTime` fields to the root level
- Updated payload types to reflect the new structure

### How to test?
1. Create a new blog post
2. Verify that related posts, categories, and read time fields are visible in the sidebar
3. Confirm that all fields can be populated and saved correctly
4. Check that existing blog posts maintain their data after the migration

### Why make this change?
Flattening the schema structure simplifies data access and makes the fields more accessible in the admin interface. This change reduces unnecessary nesting while maintaining all functionality.