### PR TITLE
chore(cms): move testimonial and related case studies from Work collection to sidebar for simplicity

### DIFF
--- a/src/collections/BlogPosts/config.ts
+++ b/src/collections/BlogPosts/config.ts
@@ -86,6 +86,15 @@ export const BlogPosts: CollectionConfig = {
         seoTab,
       ],
     },
+    {
+      name: "featured",
+      type: "checkbox",
+      label: "Featured",
+      defaultValue: false,
+      admin: {
+        position: "sidebar",
+      },
+    },
     ...slugField(),
     {
       name: "publishedOn",
@@ -125,15 +134,7 @@ export const BlogPosts: CollectionConfig = {
         position: "sidebar",
       },
     },
-    {
-      name: "featured",
-      type: "checkbox",
-      label: "Featured",
-      defaultValue: false,
-      admin: {
-        position: "sidebar",
-      },
-    },
+
     {
       name: "readTime",
       type: "number",
@@ -148,8 +149,6 @@ export const BlogPosts: CollectionConfig = {
       type: "relationship",
       admin: {
         position: "sidebar",
-        description:
-          "Add the post categories here. This is used to group the articles.",
       },
       hasMany: true,
       relationTo: "categories",

--- a/src/collections/Work/config.ts
+++ b/src/collections/Work/config.ts
@@ -75,40 +75,7 @@ export const Work: CollectionConfig = {
             },
           ],
         },
-        {
-          name: "metadata",
-          label: "Meta",
-          fields: [
-            {
-              name: "testimonial",
-              type: "relationship",
-              relationTo: "testimonials",
-              hasMany: false,
-              required: false,
-              admin: {
-                description: "If a testimonial exists, add it here.",
-              },
-            },
-            {
-              name: "relatedWorks",
-              type: "relationship",
-              label: "Related Case Studies",
-              admin: {
-                position: "sidebar",
-              },
-              filterOptions: ({ id }) => {
-                return {
-                  id: {
-                    not_in: [id],
-                  },
-                };
-              },
-              hasMany: true,
-              required: false,
-              relationTo: "work",
-            },
-          ],
-        },
+
         {
           name: "seo",
           label: "SEO",
@@ -183,6 +150,34 @@ export const Work: CollectionConfig = {
       admin: {
         position: "sidebar",
       },
+    },
+    {
+      name: "testimonial",
+      type: "relationship",
+      relationTo: "testimonials",
+      hasMany: false,
+      required: false,
+      admin: {
+        position: "sidebar",
+      },
+    },
+    {
+      name: "relatedWorks",
+      type: "relationship",
+      label: "Related Case Studies",
+      admin: {
+        position: "sidebar",
+      },
+      filterOptions: ({ id }) => {
+        return {
+          id: {
+            not_in: [id],
+          },
+        };
+      },
+      hasMany: true,
+      required: false,
+      relationTo: "work",
     },
   ],
 

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -340,12 +340,12 @@ export interface Post {
     image?: (string | null) | Media;
     description?: string | null;
   };
+  featured?: boolean | null;
   slug: string;
   slugLock?: boolean | null;
   publishedOn: string;
   image: string | Media;
   status?: ('not started' | 'needs rewrite' | 'needs polish' | 'needs photos' | 'ready') | null;
-  featured?: boolean | null;
   readTime: number;
   categories: (string | Category)[];
   relatedPosts?: (string | Post)[] | null;
@@ -391,10 +391,6 @@ export interface Work {
     };
     [k: string]: unknown;
   } | null;
-  metadata?: {
-    testimonial?: (string | null) | Testimonial;
-    relatedWorks?: (string | Work)[] | null;
-  };
   seo?: {
     title?: string | null;
     image?: (string | null) | Media;
@@ -407,35 +403,8 @@ export interface Work {
   featured?: boolean | null;
   services?: (string | Service)[] | null;
   projectYear?: number | null;
-  updatedAt: string;
-  createdAt: string;
-  _status?: ('draft' | 'published') | null;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "testimonials".
- */
-export interface Testimonial {
-  id: string;
-  title: string;
-  callout: string;
-  testimonial: {
-    root: {
-      type: string;
-      children: {
-        type: string;
-        version: number;
-        [k: string]: unknown;
-      }[];
-      direction: ('ltr' | 'rtl') | null;
-      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
-      indent: number;
-      version: number;
-    };
-    [k: string]: unknown;
-  };
-  brand: string | Brand;
-  author: string;
+  testimonial?: (string | null) | Testimonial;
+  relatedWorks?: (string | Work)[] | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -488,6 +457,35 @@ export interface Service {
     image?: (string | null) | Media;
     description?: string | null;
   };
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "testimonials".
+ */
+export interface Testimonial {
+  id: string;
+  title: string;
+  callout: string;
+  testimonial: {
+    root: {
+      type: string;
+      children: {
+        type: string;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  };
+  brand: string | Brand;
+  author: string;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;


### PR DESCRIPTION
### TL;DR
Reorganized field positions in BlogPosts and Work collections to improve the admin interface layout.

### What changed?
- Moved the "featured" checkbox field higher up in BlogPosts collection
- Removed description from categories field in BlogPosts
- Relocated testimonial and relatedWorks fields from metadata group to root level in Work collection
- Moved testimonial and relatedWorks to sidebar position in Work collection

### How to test?
1. Open the admin panel
2. Create a new Blog Post and verify the featured checkbox appears at the top of the sidebar
3. Create a new Work item and confirm testimonial and related works fields appear in the sidebar
4. Verify all fields are still functional and saving correctly

### Why make this change?
The reorganization improves the admin interface usability by:
- Placing frequently used fields in more accessible locations
- Reducing nested field complexity
- Creating a more intuitive sidebar layout
- Making important fields more immediately visible to content editors