### PR TITLE
chore(cms): migrate relatedPlaygrounds to top level for simplicity

### DIFF
--- a/src/collections/Play/config.ts
+++ b/src/collections/Play/config.ts
@@ -62,30 +62,6 @@ export const Playground: CollectionConfig = {
           fields: [],
         },
         {
-          name: "metadata",
-          label: "Meta",
-          fields: [
-            {
-              name: "relatedPlaygrounds",
-              type: "relationship",
-              label: "Related Playgrounds",
-              admin: {
-                position: "sidebar",
-                description: "Add the related playgrounds here.",
-              },
-              filterOptions: ({ id }) => {
-                return {
-                  id: {
-                    not_in: [id],
-                  },
-                };
-              },
-              hasMany: true,
-              relationTo: "play",
-            },
-          ],
-        },
-        {
           name: "seo",
           label: "SEO",
           fields: [
@@ -143,6 +119,24 @@ export const Playground: CollectionConfig = {
       admin: {
         position: "sidebar",
       },
+    },
+    {
+      name: "relatedPlaygrounds",
+      type: "relationship",
+      label: "Related Playgrounds",
+      admin: {
+        position: "sidebar",
+        description: "Add the related playgrounds here.",
+      },
+      filterOptions: ({ id }) => {
+        return {
+          id: {
+            not_in: [id],
+          },
+        };
+      },
+      hasMany: true,
+      relationTo: "play",
     },
   ],
 

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -500,9 +500,6 @@ export interface Play {
   tagline: string;
   description?: string | null;
   content?: {};
-  metadata?: {
-    relatedPlaygrounds?: (string | Play)[] | null;
-  };
   seo?: {
     image?: (string | null) | Media;
     title?: string | null;
@@ -512,6 +509,7 @@ export interface Play {
   slugLock?: boolean | null;
   publishedOn: string;
   image: string | Media;
+  relatedPlaygrounds?: (string | Play)[] | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;


### PR DESCRIPTION
### TL;DR
Moved the Related Playgrounds field from the metadata tab to the sidebar for improved accessibility.

### What changed?
- Removed the metadata tab that contained only the Related Playgrounds field
- Relocated the Related Playgrounds field directly to the sidebar
- Updated corresponding TypeScript types to reflect the new structure

### How to test?
1. Navigate to any playground in the admin panel
2. Verify that the Related Playgrounds field is now directly visible in the sidebar
3. Confirm that you can still add and remove related playgrounds
4. Ensure the filtering still works (a playground cannot be related to itself)

### Why make this change?
The Related Playgrounds field was buried within a metadata tab, making it less discoverable and requiring extra clicks to access. Moving it directly to the sidebar improves the user experience by making it immediately visible and accessible to content editors.