### PR TITLE
chore(cms): remove unneeded metadata fields on cards sitewide

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://brewww.studio</loc><lastmod>2024-10-30T18:47:04.527Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://brewww.studio/proposal</loc><lastmod>2024-10-30T18:47:04.527Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio</loc><lastmod>2024-10-30T19:54:31.521Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/proposal</loc><lastmod>2024-10-30T19:54:31.521Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/app/(frontend)/(inner)/blog/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/blog/[slug]/page.tsx
@@ -113,9 +113,7 @@ export default async function PostPage({
             </span>
             <span>•</span>
             <span>
-              {post.metadata.readTime
-                ? `${post.metadata.readTime} min read`
-                : "Add Read Time"}
+              {post.readTime ? `${post.readTime} min read` : "Add Read Time"}
             </span>
           </div>
         </div>

--- a/src/app/(frontend)/(inner)/blog/page.tsx
+++ b/src/app/(frontend)/(inner)/blog/page.tsx
@@ -22,7 +22,7 @@ export default async function BlogPage() {
   const categoryCounts = categories.docs.reduce(
     (acc, category) => {
       acc[category.id] = posts.docs.filter((post) =>
-        post.metadata?.categories?.some((cat) => {
+        post.categories?.some((cat) => {
           if (typeof cat === "string") {
             return cat === category.id;
           }

--- a/src/collections/Journeys/config.ts
+++ b/src/collections/Journeys/config.ts
@@ -42,7 +42,18 @@ export const Journeys: CollectionConfig = {
         description: "Add the tagline for the journey here.",
       },
     },
+
     ...slugField(),
+    {
+      name: "services",
+      type: "relationship",
+      relationTo: "services",
+      label: "Services",
+      required: false,
+      admin: {
+        position: "sidebar",
+      },
+    },
     {
       name: "description",
       type: "textarea",
@@ -60,22 +71,7 @@ export const Journeys: CollectionConfig = {
           label: "Content",
           fields: [],
         },
-        {
-          name: "metadata",
-          label: "Meta",
-          fields: [
-            {
-              name: "services",
-              type: "relationship",
-              relationTo: "services",
-              label: "Services",
-              required: false,
-              admin: {
-                description: "Add the services for the journey here.",
-              },
-            },
-          ],
-        },
+
         {
           name: "seo",
           label: "SEO",

--- a/src/collections/Pillars/config.ts
+++ b/src/collections/Pillars/config.ts
@@ -42,6 +42,16 @@ export const Pillars: CollectionConfig = {
         description: "Add the tagline for the pillar here.",
       },
     },
+    {
+      name: "services",
+      type: "relationship",
+      relationTo: "services",
+      label: "Services",
+      required: false,
+      admin: {
+        position: "sidebar",
+      },
+    },
     ...slugField(),
     {
       name: "description",
@@ -63,18 +73,7 @@ export const Pillars: CollectionConfig = {
         {
           name: "metadata",
           label: "Meta",
-          fields: [
-            {
-              name: "services",
-              type: "relationship",
-              relationTo: "services",
-              label: "Services",
-              required: false,
-              admin: {
-                description: "Add the services for the pillar here.",
-              },
-            },
-          ],
+          fields: [],
         },
         {
           name: "seo",

--- a/src/components/BlogCard/index.tsx
+++ b/src/components/BlogCard/index.tsx
@@ -20,10 +20,9 @@ export const BlogCard = ({ post }: { post: Post }) => {
       <div className="mt-4">
         <p className="mb-2 flex flex-row items-center text-label-medium uppercase">
           <span>
-            {(post.metadata.categories[0] as Category)?.title ||
-              "Uncategorized"}
+            {(post.categories[0] as Category)?.title || "Uncategorized"}
           </span>
-          <span className="ml-2">/ {post.metadata.readTime} min read</span>
+          <span className="ml-2">/ {post.readTime} min read</span>
         </p>
         <h3 className="text-title-medium leading-none">{post.title}</h3>
       </div>

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -548,13 +548,12 @@ export interface Pillar {
   id: string;
   title: string;
   tagline: string;
+  services?: (string | null) | Service;
   slug: string;
   slugLock?: boolean | null;
   description: string;
   content?: {};
-  metadata?: {
-    services?: (string | null) | Service;
-  };
+  metadata?: {};
   seo?: {
     image?: (string | null) | Media;
     title?: string | null;
@@ -586,11 +585,9 @@ export interface Journey {
   tagline?: string | null;
   slug: string;
   slugLock?: boolean | null;
+  services?: (string | null) | Service;
   description?: string | null;
   content?: {};
-  metadata?: {
-    services?: (string | null) | Service;
-  };
   seo?: {
     image?: (string | null) | Media;
     title?: string | null;


### PR DESCRIPTION
### TL;DR
Moved service relationships to root level and fixed read time references in blog components

### What changed?
- Relocated service relationship fields from metadata to root level in Journeys and Pillars collections
- Updated blog components to reference readTime directly instead of through metadata
- Fixed category references in blog components to use direct path
- Updated sitemap timestamps

### How to test?
1. Navigate to the admin panel and verify service relationships are visible in the sidebar for Journeys and Pillars
2. Check blog posts to ensure read time and categories display correctly
3. Verify existing content maintains its service associations after the migration

### Why make this change?
Improves data structure consistency by placing service relationships at the root level, making them more accessible and easier to manage. This also simplifies the code by removing unnecessary nesting of metadata properties and standardizes how we access these fields throughout the application.