### PR TITLE
chore(cms): organize all collections and update BlogPosts to utilize populatePublishedOn

### DIFF
--- a/src/collections/BlogCategories/config.ts
+++ b/src/collections/BlogCategories/config.ts
@@ -1,14 +1,12 @@
+// Payload Imports
 import type { CollectionConfig } from "payload";
+
+// Access Control
 import { isAdmin } from "@/access/isAdmin";
 import { publishedOnly } from "@/access/publishedOnly";
+
+// Fields
 import { slugField } from "@/fields/slug";
-import {
-  MetaDescriptionField,
-  MetaImageField,
-  MetaTitleField,
-  OverviewField,
-  PreviewField,
-} from "@payloadcms/plugin-seo/fields";
 
 export const BlogCategories: CollectionConfig = {
   slug: "categories",

--- a/src/collections/BlogPosts/config.ts
+++ b/src/collections/BlogPosts/config.ts
@@ -1,11 +1,18 @@
+// Payload Imports
 import type { CollectionConfig } from "payload";
+
+// Access Control
 import { isAdmin } from "@/access/isAdmin";
 import { publishedOnly } from "@/access/publishedOnly";
-import { slugField } from "@/fields/slug";
-import { revalidatePost } from "./hooks/revalidatePost";
 
+// Fields
 import { seoTab } from "@/fields/seoFields";
-import { generatePreviewPath } from "@root/utilities/generatePreviewPath";
+import { slugField } from "@/fields/slug";
+
+// Utilities & Hooks
+import { generatePreviewPath } from "@/utilities/generatePreviewPath";
+import { populatePublishedOn } from "@/hooks/populatePublishedOn";
+import { revalidatePost } from "./hooks/revalidatePost";
 
 import {
   BlocksFeature,
@@ -216,6 +223,7 @@ export const BlogPosts: CollectionConfig = {
     maxPerDoc: 25,
   },
   hooks: {
+    beforeChange: [populatePublishedOn],
     afterChange: [revalidatePost],
   },
 };

--- a/src/collections/Brands/config.ts
+++ b/src/collections/Brands/config.ts
@@ -1,5 +1,7 @@
+// Payload Imports
 import type { CollectionConfig } from "payload";
 
+// Access Control
 import { isAdmin } from "@/access/isAdmin";
 import { publishedOnly } from "@/access/publishedOnly";
 

--- a/src/collections/FAQ/config.ts
+++ b/src/collections/FAQ/config.ts
@@ -1,4 +1,7 @@
+// Payload Imports
 import type { CollectionConfig } from "payload";
+
+// Access Control
 import { isAdmin } from "@/access/isAdmin";
 import { publishedOnly } from "@/access/publishedOnly";
 

--- a/src/collections/Industries/config.ts
+++ b/src/collections/Industries/config.ts
@@ -1,7 +1,14 @@
+// Payload Imports
 import type { CollectionConfig } from "payload";
+
+// Access Control
 import { isAdmin } from "@/access/isAdmin";
 import { publishedOnly } from "@/access/publishedOnly";
+
+// Fields
 import { slugField } from "@/fields/slug";
+
+// SEO Fields
 import {
   MetaDescriptionField,
   MetaImageField,

--- a/src/collections/Journeys/config.ts
+++ b/src/collections/Journeys/config.ts
@@ -1,7 +1,14 @@
+// Payload Imports
 import type { CollectionConfig } from "payload";
+
+// Access Control
 import { isAdmin } from "@/access/isAdmin";
 import { publishedOnly } from "@/access/publishedOnly";
+
+// Fields
 import { slugField } from "@/fields/slug";
+
+// SEO Fields
 import {
   MetaDescriptionField,
   MetaImageField,

--- a/src/collections/Locations/config.ts
+++ b/src/collections/Locations/config.ts
@@ -1,6 +1,11 @@
+// Payload Imports
 import type { CollectionConfig } from "payload";
+
+// Access Control
 import { isAdmin } from "@/access/isAdmin";
 import { publishedOnly } from "@/access/publishedOnly";
+
+// Fields
 import { slugField } from "@/fields/slug";
 
 export const Location: CollectionConfig = {

--- a/src/collections/Media/config.ts
+++ b/src/collections/Media/config.ts
@@ -1,5 +1,10 @@
+// Payload Imports
 import type { CollectionConfig } from "payload";
+
+// Access Control
 import { isAdmin } from "@/access/isAdmin";
+
+// Lexical Editor
 import {
   FixedToolbarFeature,
   InlineToolbarFeature,

--- a/src/collections/Pillars/config.ts
+++ b/src/collections/Pillars/config.ts
@@ -1,7 +1,14 @@
+// Payload Imports
 import type { CollectionConfig } from "payload";
+
+// Access Control
 import { isAdmin } from "@/access/isAdmin";
 import { publishedOnly } from "@/access/publishedOnly";
+
+// Fields
 import { slugField } from "@/fields/slug";
+
+// SEO Fields
 import {
   MetaDescriptionField,
   MetaImageField,

--- a/src/collections/Play/config.ts
+++ b/src/collections/Play/config.ts
@@ -1,7 +1,14 @@
+// Payload Imports
 import type { CollectionConfig } from "payload";
+
+// Access Control
 import { isAdmin } from "@/access/isAdmin";
 import { publishedOnly } from "@/access/publishedOnly";
+
+// Fields
 import { slugField } from "@/fields/slug";
+
+// SEO Fields
 import {
   MetaDescriptionField,
   MetaImageField,

--- a/src/collections/Results/config.ts
+++ b/src/collections/Results/config.ts
@@ -1,4 +1,7 @@
+// Payload Imports
 import type { CollectionConfig } from "payload";
+
+// Access Control
 import { isAdmin } from "@/access/isAdmin";
 import { publishedOnly } from "@/access/publishedOnly";
 

--- a/src/collections/Services/config.ts
+++ b/src/collections/Services/config.ts
@@ -1,7 +1,14 @@
+// Payload Imports
 import type { CollectionConfig } from "payload";
+
+// Access Control
 import { isAdmin } from "@/access/isAdmin";
 import { publishedOnly } from "@/access/publishedOnly";
+
+// Fields
 import { slugField } from "@/fields/slug";
+
+// SEO Fields
 import {
   MetaDescriptionField,
   MetaImageField,

--- a/src/collections/Team/config.ts
+++ b/src/collections/Team/config.ts
@@ -1,7 +1,12 @@
+// Payload Imports
+import type { CollectionConfig } from "payload";
+
+// Access Control
 import { isAdmin } from "@/access/isAdmin";
 import { publishedOnly } from "@/access/publishedOnly";
+
+// Fields
 import { slugField } from "@/fields/slug";
-import type { CollectionConfig } from "payload";
 
 export const Team: CollectionConfig = {
   slug: "team",

--- a/src/collections/Technologies/config.ts
+++ b/src/collections/Technologies/config.ts
@@ -1,4 +1,7 @@
+// Payload Imports
 import type { CollectionConfig } from "payload";
+
+// Access Control
 import { isAdmin } from "@/access/isAdmin";
 import { publishedOnly } from "@/access/publishedOnly";
 

--- a/src/collections/Testimonials/config.ts
+++ b/src/collections/Testimonials/config.ts
@@ -1,4 +1,7 @@
+// Payload Imports
 import type { CollectionConfig } from "payload";
+
+// Access Control
 import { isAdmin } from "@/access/isAdmin";
 import { publishedOnly } from "@/access/publishedOnly";
 

--- a/src/collections/Users/config.ts
+++ b/src/collections/Users/config.ts
@@ -1,5 +1,7 @@
+// Payload Imports
 import type { CollectionConfig } from "payload";
 
+// Access Control
 import { isAdmin, isAdminFieldLevel } from "@/access/isAdmin";
 import { isAdminOrSelf, isAdminOrSelfFieldLevel } from "@/access/isAdminOrSelf";
 

--- a/src/collections/Work/config.ts
+++ b/src/collections/Work/config.ts
@@ -1,8 +1,14 @@
+// Payload Imports
 import type { CollectionConfig } from "payload";
+
+// Access Control
 import { isAdmin } from "@/access/isAdmin";
 import { publishedOnly } from "@/access/publishedOnly";
+
+// Fields
 import { slugField } from "@/fields/slug";
 
+// SEO Fields
 import {
   MetaDescriptionField,
   MetaImageField,

--- a/src/hooks/populatePublishedOn.ts
+++ b/src/hooks/populatePublishedOn.ts
@@ -1,0 +1,19 @@
+import type { CollectionBeforeChangeHook } from "payload";
+
+export const populatePublishedOn: CollectionBeforeChangeHook = ({
+  data,
+  operation,
+  req,
+}) => {
+  if (operation === "create" || operation === "update") {
+    if (req.data && !req.data.publishedOn) {
+      const now = new Date();
+      return {
+        ...data,
+        publishedOn: now,
+      };
+    }
+  }
+
+  return data;
+};


### PR DESCRIPTION
### TL;DR
Added automatic population of `publishedOn` dates for blog posts and organized imports across collection configurations.

### What changed?
- Created a new `populatePublishedOn` hook to automatically set publication dates for blog posts
- Added organized import groupings with clear section headers across all collection configurations
- Implemented the `populatePublishedOn` hook in the BlogPosts collection
- Removed unused SEO field imports from BlogCategories

### How to test?
1. Create a new blog post without setting a `publishedOn` date
2. Verify that the `publishedOn` field is automatically populated with the current date
3. Update an existing blog post and confirm the `publishedOn` date remains unchanged
4. Verify all collections still function as expected with the reorganized imports

### Why make this change?
To ensure consistent publication date tracking for blog posts and improve code organization through better import management. This helps maintain a clear record of when content was published and makes the codebase more maintainable through structured import groupings.