### PR TITLE
feat(fields): update formatSlug to prevent double dashes

### DIFF
--- a/src/fields/slug/formatSlug.ts
+++ b/src/fields/slug/formatSlug.ts
@@ -4,6 +4,7 @@ export const formatSlug = (val: string): string =>
   val
     .replace(/ /g, "-")
     .replace(/[^\w-]+/g, "")
+    .replace(/-+/g, "-") // Replace multiple dashes with single dash
     .toLowerCase();
 
 export const formatSlugHook =


### PR DESCRIPTION
### TL;DR

Added handling for multiple consecutive dashes in slug formatting

### What changed?

Added a new regex replacement that converts multiple consecutive dashes into a single dash when formatting slugs

### How to test?

1. Create a slug with multiple spaces or special characters in sequence
2. Verify that the output contains only single dashes between words
3. Test cases:
   - "hello   world" → "hello-world"
   - "hello---world" → "hello-world"
   - "hello   ---   world" → "hello-world"

### Why make this change?

Multiple consecutive dashes in URLs can look unprofessional and may cause confusion. This change ensures a cleaner, more consistent URL structure by normalizing multiple dashes into a single dash.