### PR TITLE
chore(logs): cleanup unneede console logs :

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://brewww.studio</loc><lastmod>2024-10-30T19:54:31.521Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://brewww.studio/proposal</loc><lastmod>2024-10-30T19:54:31.521Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio</loc><lastmod>2024-10-30T21:13:27.338Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://brewww.studio/proposal</loc><lastmod>2024-10-30T21:13:27.339Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/app/(frontend)/next/exit-preview/GET.ts
+++ b/src/app/(frontend)/next/exit-preview/GET.ts
@@ -1,9 +1,7 @@
 import { draftMode } from "next/headers";
 
 export async function GET(): Promise<Response> {
-  console.log("[exit-preview/GET.ts] Disabling draft mode...");
   const draft = await draftMode();
   draft.disable();
-  console.log("[exit-preview/GET.ts] Draft mode disabled successfully");
   return new Response("Draft mode is disabled");
 }

--- a/src/app/(frontend)/next/exit-preview/route.ts
+++ b/src/app/(frontend)/next/exit-preview/route.ts
@@ -1,9 +1,7 @@
 import { draftMode } from "next/headers";
 
 export async function GET(): Promise<Response> {
-  console.log("[exit-preview/route.ts] Disabling draft mode...");
   const draft = await draftMode();
   draft.disable();
-  console.log("[exit-preview/route.ts] Draft mode disabled successfully");
   return new Response("Draft mode is disabled");
 }

--- a/src/app/(frontend)/next/preview/route.ts
+++ b/src/app/(frontend)/next/preview/route.ts
@@ -16,7 +16,6 @@ export async function GET(
     };
   },
 ): Promise<Response> {
-  console.log("[preview/route.ts] Starting preview request...");
   const payload = await getPayloadHMR({ config: configPromise });
   const token = req.cookies.get(payloadToken)?.value;
   const { searchParams } = new URL(req.url);
@@ -27,33 +26,27 @@ export async function GET(
   const previewSecret = searchParams.get("previewSecret");
 
   if (previewSecret) {
-    console.log("[preview/route.ts] Preview secret provided - access denied");
     return new Response("You are not allowed to preview this page", {
       status: 403,
     });
   } else {
     if (!path) {
-      console.log("[preview/route.ts] No path provided");
       return new Response("No path provided", { status: 404 });
     }
 
     if (!collection) {
-      console.log("[preview/route.ts] No collection provided");
       return new Response("No path provided", { status: 404 });
     }
 
     if (!slug) {
-      console.log("[preview/route.ts] No slug provided");
       return new Response("No path provided", { status: 404 });
     }
 
     if (!token) {
-      console.log("[preview/route.ts] No token provided");
       new Response("You are not allowed to preview this page", { status: 403 });
     }
 
     if (!path.startsWith("/")) {
-      console.log("[preview/route.ts] Invalid path - must start with /");
       new Response("This endpoint can only be used for internal previews", {
         status: 500,
       });
@@ -63,28 +56,20 @@ export async function GET(
 
     try {
       user = jwt.verify(token, payload.secret);
-      console.log("[preview/route.ts] Token verified successfully");
     } catch (error) {
-      console.log("[preview/route.ts] Error verifying token:", error);
       payload.logger.error("Error verifying token for live preview:", error);
     }
 
     const draft = await draftMode();
 
-    // You can add additional checks here to see if the user is allowed to preview this page
     if (!user) {
-      console.log("[preview/route.ts] No user found - disabling draft mode");
       draft.disable();
       return new Response("You are not allowed to preview this page", {
         status: 403,
       });
     }
 
-    // Verify the given slug exists
     try {
-      console.log(
-        `[preview/route.ts] Searching for document in collection: ${collection}, slug: ${slug}`,
-      );
       const docs = await payload.find({
         collection: collection,
         draft: true,
@@ -96,19 +81,12 @@ export async function GET(
       });
 
       if (!docs.docs.length) {
-        console.log("[preview/route.ts] Document not found");
         return new Response("Document not found", { status: 404 });
       }
-      console.log("[preview/route.ts] Document found successfully");
     } catch (error) {
-      console.log("[preview/route.ts] Error finding document:", error);
       payload.logger.error("Error verifying token for live preview:", error);
     }
 
-    console.log(
-      "[preview/route.ts] Enabling draft mode and redirecting to:",
-      path,
-    );
     draft.enable();
 
     redirect(path);

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -22,11 +22,11 @@ import { RelationshipFeatureClient as RelationshipFeatureClient_e70f5e05f09f93e0
 import { BlockquoteFeatureClient as BlockquoteFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { UploadFeatureClient as UploadFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
 import { OverviewComponent as OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
 import { MetaTitleComponent as MetaTitleComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
 import { MetaImageComponent as MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
 import { MetaDescriptionComponent as MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
-import { PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
 import { SlugComponent as SlugComponent_92cc057d0a2abb4f6cf0307edf59f986 } from '@/fields/slug/SlugComponent'
 import { BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 
@@ -55,11 +55,11 @@ export const importMap = {
   "@payloadcms/richtext-lexical/client#BlockquoteFeatureClient": BlockquoteFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#UploadFeatureClient": UploadFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient": HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
   "@payloadcms/plugin-seo/client#OverviewComponent": OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
   "@payloadcms/plugin-seo/client#MetaTitleComponent": MetaTitleComponent_a8a977ebc872c5d5ea7ee689724c0860,
   "@payloadcms/plugin-seo/client#MetaImageComponent": MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
   "@payloadcms/plugin-seo/client#MetaDescriptionComponent": MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
   "@/fields/slug/SlugComponent#SlugComponent": SlugComponent_92cc057d0a2abb4f6cf0307edf59f986,
   "@payloadcms/richtext-lexical/client#BlocksFeatureClient": BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864
 }

--- a/src/collections/BlogCategories/config.ts
+++ b/src/collections/BlogCategories/config.ts
@@ -7,6 +7,7 @@ import { publishedOnly } from "@/access/publishedOnly";
 
 // Fields
 import { slugField } from "@/fields/slug";
+import { metaTab } from "@/fields/meta";
 
 export const BlogCategories: CollectionConfig = {
   slug: "categories",
@@ -33,6 +34,10 @@ export const BlogCategories: CollectionConfig = {
       required: true,
     },
     ...slugField(),
+    {
+      type: "tabs",
+      tabs: [metaTab],
+    },
   ],
 
   //* Admin Settings

--- a/src/collections/BlogPosts/config.ts
+++ b/src/collections/BlogPosts/config.ts
@@ -6,7 +6,7 @@ import { isAdmin } from "@/access/isAdmin";
 import { publishedOnly } from "@/access/publishedOnly";
 
 // Fields
-import { seoTab } from "@/fields/seoFields";
+import { metaTab } from "@/fields/meta";
 import { slugField } from "@/fields/slug";
 
 // Utilities & Hooks
@@ -90,7 +90,7 @@ export const BlogPosts: CollectionConfig = {
             },
           ],
         },
-        seoTab,
+        metaTab,
       ],
     },
     {
@@ -205,7 +205,6 @@ export const BlogPosts: CollectionConfig = {
 
       return `${process.env.NEXT_PUBLIC_SERVER_URL}${path}`;
     },
-
     pagination: {
       defaultLimit: 100,
       limits: [25, 50, 100],

--- a/src/collections/Pages/config.ts
+++ b/src/collections/Pages/config.ts
@@ -7,7 +7,7 @@ import { publishedOnly } from "@/access/publishedOnly";
 
 // Field Imports
 import { slugField } from "@/fields/slug";
-import { seoTab } from "@/fields/seoFields";
+import { metaTab } from "@/fields/meta";
 
 // Block Imports
 import { FormBlock } from "@/blocks/Form/config";
@@ -53,7 +53,7 @@ export const Pages: CollectionConfig = {
             },
           ],
         },
-        seoTab,
+        metaTab,
       ],
     },
     ...slugField(),

--- a/src/collections/Play/config.ts
+++ b/src/collections/Play/config.ts
@@ -7,15 +7,8 @@ import { publishedOnly } from "@/access/publishedOnly";
 
 // Fields
 import { slugField } from "@/fields/slug";
-
-// SEO Fields
-import {
-  MetaDescriptionField,
-  MetaImageField,
-  MetaTitleField,
-  OverviewField,
-  PreviewField,
-} from "@payloadcms/plugin-seo/fields";
+import { metaTab } from "@/fields/meta";
+import { generatePreviewPath } from "@root/utilities/generatePreviewPath";
 
 export const Playground: CollectionConfig = {
   slug: "play",
@@ -62,36 +55,7 @@ export const Playground: CollectionConfig = {
 
     {
       type: "tabs",
-      tabs: [
-        {
-          name: "content",
-          label: "Content",
-          fields: [],
-        },
-        {
-          name: "seo",
-          label: "SEO",
-          fields: [
-            OverviewField({
-              titlePath: "meta.title",
-              descriptionPath: "meta.description",
-              imagePath: "meta.image",
-            }),
-            MetaImageField({
-              relationTo: "media",
-            }),
-            MetaTitleField({
-              hasGenerateFn: true,
-            }),
-            MetaDescriptionField({}),
-            PreviewField({
-              hasGenerateFn: true,
-              titlePath: "meta.title",
-              descriptionPath: "meta.description",
-            }),
-          ],
-        },
-      ],
+      tabs: [metaTab],
     },
     // TODO: make sure the slug locks after being published
     ...slugField(),
@@ -154,6 +118,24 @@ export const Playground: CollectionConfig = {
     defaultColumns: ["title", "tagline", "updatedAt"],
     group: "Portfolio",
     listSearchableFields: ["title", "tagline", "description"],
+    livePreview: {
+      url: ({ data }) => {
+        const path = generatePreviewPath({
+          slug: typeof data?.slug === "string" ? data.slug : "",
+          collection: "play",
+        });
+
+        return `${process.env.NEXT_PUBLIC_SERVER_URL}${path}`;
+      },
+    },
+    preview: (data) => {
+      const path = generatePreviewPath({
+        slug: typeof data?.slug === "string" ? data.slug : "",
+        collection: "play",
+      });
+
+      return `${process.env.NEXT_PUBLIC_SERVER_URL}${path}`;
+    },
     pagination: {
       defaultLimit: 25,
       limits: [25, 50, 100],
@@ -165,6 +147,7 @@ export const Playground: CollectionConfig = {
     singular: "Playground",
     plural: "Playground",
   },
+
   hooks: {
     afterRead: [
       ({ doc }) => {

--- a/src/collections/Services/config.ts
+++ b/src/collections/Services/config.ts
@@ -7,15 +7,8 @@ import { publishedOnly } from "@/access/publishedOnly";
 
 // Fields
 import { slugField } from "@/fields/slug";
-
-// SEO Fields
-import {
-  MetaDescriptionField,
-  MetaImageField,
-  MetaTitleField,
-  OverviewField,
-  PreviewField,
-} from "@payloadcms/plugin-seo/fields";
+import { metaTab } from "@/fields/meta";
+import { generatePreviewPath } from "@root/utilities/generatePreviewPath";
 
 export const Services: CollectionConfig = {
   slug: "services",
@@ -93,29 +86,7 @@ export const Services: CollectionConfig = {
           label: "Meta",
           fields: [],
         },
-        {
-          name: "seo",
-          label: "SEO",
-          fields: [
-            PreviewField({
-              hasGenerateFn: true,
-              titlePath: "meta.title",
-              descriptionPath: "meta.description",
-            }),
-            OverviewField({
-              titlePath: "meta.title",
-              descriptionPath: "meta.description",
-              imagePath: "meta.image",
-            }),
-            MetaTitleField({
-              hasGenerateFn: true,
-            }),
-            MetaImageField({
-              relationTo: "media",
-            }),
-            MetaDescriptionField({}),
-          ],
-        },
+        metaTab,
       ],
     },
   ],
@@ -127,6 +98,24 @@ export const Services: CollectionConfig = {
     defaultColumns: ["title"],
     group: "Service",
     listSearchableFields: ["title"],
+    livePreview: {
+      url: ({ data }) => {
+        const path = generatePreviewPath({
+          slug: typeof data?.slug === "string" ? data.slug : "",
+          collection: "services",
+        });
+
+        return `${process.env.NEXT_PUBLIC_SERVER_URL}${path}`;
+      },
+    },
+    preview: (data) => {
+      const path = generatePreviewPath({
+        slug: typeof data?.slug === "string" ? data.slug : "",
+        collection: "services",
+      });
+
+      return `${process.env.NEXT_PUBLIC_SERVER_URL}${path}`;
+    },
     pagination: {
       defaultLimit: 25,
       limits: [10, 25, 50],

--- a/src/collections/Work/config.ts
+++ b/src/collections/Work/config.ts
@@ -7,15 +7,8 @@ import { publishedOnly } from "@/access/publishedOnly";
 
 // Fields
 import { slugField } from "@/fields/slug";
-
-// SEO Fields
-import {
-  MetaDescriptionField,
-  MetaImageField,
-  MetaTitleField,
-  OverviewField,
-  PreviewField,
-} from "@payloadcms/plugin-seo/fields";
+import { metaTab } from "@/fields/meta";
+import { generatePreviewPath } from "@root/utilities/generatePreviewPath";
 
 export const Work: CollectionConfig = {
   slug: "work",
@@ -81,30 +74,7 @@ export const Work: CollectionConfig = {
             },
           ],
         },
-
-        {
-          name: "seo",
-          label: "SEO",
-          fields: [
-            PreviewField({
-              hasGenerateFn: true,
-              titlePath: "meta.title",
-              descriptionPath: "meta.description",
-            }),
-            OverviewField({
-              titlePath: "meta.title",
-              descriptionPath: "meta.description",
-              imagePath: "meta.image",
-            }),
-            MetaTitleField({
-              hasGenerateFn: true,
-            }),
-            MetaImageField({
-              relationTo: "media",
-            }),
-            MetaDescriptionField({}),
-          ],
-        },
+        metaTab,
       ],
     },
     ...slugField(),
@@ -195,6 +165,24 @@ export const Work: CollectionConfig = {
     defaultColumns: ["title", "tagline", "status"],
     group: "Portfolio",
     listSearchableFields: ["title", "tagline"],
+    livePreview: {
+      url: ({ data }) => {
+        const path = generatePreviewPath({
+          slug: typeof data?.slug === "string" ? data.slug : "",
+          collection: "work",
+        });
+
+        return `${process.env.NEXT_PUBLIC_SERVER_URL}${path}`;
+      },
+    },
+    preview: (data) => {
+      const path = generatePreviewPath({
+        slug: typeof data?.slug === "string" ? data.slug : "",
+        collection: "work",
+      });
+
+      return `${process.env.NEXT_PUBLIC_SERVER_URL}${path}`;
+    },
     pagination: {
       defaultLimit: 25,
       limits: [10, 25, 50],

--- a/src/components/LivePreviewListener/index.tsx
+++ b/src/components/LivePreviewListener/index.tsx
@@ -5,10 +5,8 @@ import React from "react";
 
 export const LivePreviewListener: React.FC = () => {
   const router = useRouter();
-  console.log("[LivePreviewListener] Component mounted");
 
   const handleRefresh = () => {
-    console.log("[LivePreviewListener] Refreshing route");
     router.refresh();
   };
 

--- a/src/fields/meta/index.ts
+++ b/src/fields/meta/index.ts
@@ -6,10 +6,15 @@ import {
   PreviewField,
 } from "@payloadcms/plugin-seo/fields";
 
-export const seoTab = {
-  name: "seo",
-  label: "SEO",
+export const metaTab = {
+  name: "meta",
+  label: "Meta",
   fields: [
+    PreviewField({
+      hasGenerateFn: true,
+      titlePath: "meta.title",
+      descriptionPath: "meta.description",
+    }),
     OverviewField({
       titlePath: "meta.title",
       descriptionPath: "meta.description",
@@ -22,10 +27,5 @@ export const seoTab = {
       relationTo: "media",
     }),
     MetaDescriptionField({}),
-    PreviewField({
-      hasGenerateFn: true,
-      titlePath: "meta.title",
-      descriptionPath: "meta.description",
-    }),
   ],
 };

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -110,7 +110,7 @@ export interface Page {
   id: string;
   title: string;
   layout?: FormBlock[] | null;
-  seo?: {
+  meta?: {
     title?: string | null;
     image?: (string | null) | Media;
     description?: string | null;
@@ -335,7 +335,7 @@ export interface Post {
     };
     [k: string]: unknown;
   };
-  seo?: {
+  meta?: {
     title?: string | null;
     image?: (string | null) | Media;
     description?: string | null;
@@ -362,6 +362,11 @@ export interface Category {
   title: string;
   slug: string;
   slugLock?: boolean | null;
+  meta?: {
+    title?: string | null;
+    image?: (string | null) | Media;
+    description?: string | null;
+  };
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -391,7 +396,7 @@ export interface Work {
     };
     [k: string]: unknown;
   } | null;
-  seo?: {
+  meta?: {
     title?: string | null;
     image?: (string | null) | Media;
     description?: string | null;
@@ -452,7 +457,7 @@ export interface Service {
     [k: string]: unknown;
   } | null;
   metadata?: {};
-  seo?: {
+  meta?: {
     title?: string | null;
     image?: (string | null) | Media;
     description?: string | null;
@@ -499,10 +504,9 @@ export interface Play {
   title: string;
   tagline: string;
   description?: string | null;
-  content?: {};
-  seo?: {
-    image?: (string | null) | Media;
+  meta?: {
     title?: string | null;
+    image?: (string | null) | Media;
     description?: string | null;
   };
   slug: string;

--- a/src/utilities/generateMeta.ts
+++ b/src/utilities/generateMeta.ts
@@ -10,19 +10,19 @@ export const generateMeta = async (args: {
   const { doc } = args || {};
 
   const ogImage =
-    typeof doc?.seo?.image === "object" &&
-    doc.seo.image !== null &&
-    "url" in doc.seo.image &&
-    `${process.env.NEXT_PUBLIC_SERVER_URL}${doc.seo.image.url}`;
+    typeof doc?.meta?.image === "object" &&
+    doc.meta.image !== null &&
+    "url" in doc.meta.image &&
+    `${process.env.NEXT_PUBLIC_SERVER_URL}${doc.meta.image.url}`;
 
-  const title = doc?.seo?.title
-    ? doc?.seo?.title + " | Brewww Studio"
+  const title = doc?.meta?.title
+    ? doc?.meta?.title + " | Brewww Studio"
     : "Brewww Studio";
 
   return {
-    description: doc?.seo?.description || "",
+    description: doc?.meta?.description || "",
     openGraph: mergeOpenGraph({
-      description: doc?.seo?.description || "",
+      description: doc?.meta?.description || "",
       images: ogImage
         ? [
             {
@@ -36,5 +36,3 @@ export const generateMeta = async (args: {
     title,
   };
 };
-
-//TODO consider renaming meta and seo for clarity and consistency across the project


### PR DESCRIPTION
# SEO and Preview Updates

- Removed console.log statements from preview and live preview components
- Renamed SEO tab to Meta tab across all collections for consistency
- Added preview functionality to Work, Services, and Playground collections
- Added meta fields to Blog Categories collection
- Reorganized meta fields to prioritize preview functionality
- Updated payload types to reflect meta field changes
- Standardized meta field implementation across all content collections

## Breaking Changes
- Renamed `seo` field to `meta` in all collections and components
- Updated meta field paths in preview configurations

## Testing
- Verify preview functionality works in Work, Services, and Playground collections
- Confirm meta fields are accessible in Blog Categories
- Test meta field updates across all collections
- Validate live preview still functions correctly