### PR TITLE
chore(deps): remove sentry plugin

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -27,24 +27,30 @@ const config = {
   },
 } as const;
 
-// Revalidate daily (24 hours)
-export const revalidate = 86400;
+// Revalidate daily (every hour)
+export const revalidate = 3600;
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  // Log when sitemap is generating
+  console.log("Generating sitemap at:", new Date().toISOString());
+
   // Fetch all dynamic content in parallel
   const dynamicContent = await Promise.all(
     Object.entries(config.collections).map(async ([_, collection]) => {
       const { docs } = await fetch(
         `${config.serverUrl}/api/${collection.endpoint}?where[_status][equals]=published&limit=0`,
         {
-          next: { revalidate: 86400 },
+          cache: "no-store", // Force fresh data
+          next: {
+            tags: ["sitemap"], // Add a tag for manual revalidation
+          },
         },
       ).then((res) => res.json());
       return { docs, ...collection };
     }),
   );
 
-  return [
+  const sitemapData = [
     // Static routes
     ...config.staticRoutes.map((route) => ({
       url: `${config.serverUrl}${route.path}`,
@@ -63,4 +69,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       })),
     ),
   ];
+
+  // Log the generated sitemap data
+  console.log(
+    "Sitemap entries:",
+    sitemapData.map((entry) => entry.url),
+  );
+
+  return sitemapData;
 }

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -11,7 +11,6 @@ import { mongooseAdapter } from "@payloadcms/db-mongodb";
 import { lexicalEditor } from "@payloadcms/richtext-lexical";
 import { formBuilderPlugin } from "@payloadcms/plugin-form-builder";
 import { redirectsPlugin } from "@payloadcms/plugin-redirects";
-import { sentryPlugin } from "@payloadcms/plugin-sentry";
 
 //* Import Collections
 import { BlogCategories } from "@/collections/BlogCategories/config";


### PR DESCRIPTION
### TL;DR
Enhanced sitemap generation with improved caching, logging, and revalidation controls.

### What changed?
- Reduced sitemap revalidation time from 24 hours to 1 hour
- Added logging for sitemap generation timestamps and entries
- Implemented `cache: "no-store"` to ensure fresh data
- Added `sitemap` tag for manual revalidation
- Removed unused Sentry plugin import
- Restructured sitemap data construction for better debugging

### How to test?
1. Generate a sitemap by accessing the sitemap endpoint
2. Check server logs for new sitemap generation messages
3. Verify sitemap updates within the new 1-hour interval
4. Confirm all URLs are correctly listed in the logs
5. Test manual revalidation using the sitemap tag

### Why make this change?
To improve sitemap reliability and debugging capabilities by providing more frequent updates, better logging visibility, and ensuring fresh data is always served. This helps search engines discover and index content more efficiently while making it easier to troubleshoot sitemap-related issues.