### PR TITLE
feat(footer): update copy in footer to better match hero message

### DIFF
--- a/src/app/(frontend)/(inner)/journal/page.tsx
+++ b/src/app/(frontend)/(inner)/journal/page.tsx
@@ -51,7 +51,7 @@ export default async function BlogPage() {
                 <CategoryFilter
                   title={category.title}
                   count={categoryCounts[category.id] || 0}
-                  slug={`/blog/category/${category.slug}`}
+                  slug={`/journal/category/${category.slug}`}
                 />
               </li>
             ))}
@@ -65,20 +65,6 @@ export default async function BlogPage() {
             {posts.docs.map((post) => (
               <BlogCard key={post.id} post={post} />
             ))}
-          </div>
-        </div>
-      </section>
-
-      <section className="bg-neutral-900 py-36 text-white">
-        <div className="container mx-auto px-6">
-          <div className="text-center">
-            <div className="pb-5 font-bold uppercase">+ Its time to wonder</div>
-            <h2 className="mb-8 text-[2.63rem] leading-none">
-              Brewww is a creative studio that finds the places where{" "}
-              <strong className="font-extrabold">needs</strong>,{" "}
-              <strong className="font-extrabold">stories</strong>, and{" "}
-              <strong className="font-extrabold">technology</strong> overlap.
-            </h2>
           </div>
         </div>
       </section>

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -176,19 +176,18 @@ export default async function Footer() {
             </div>
           </div>
         </div>
-        <div className="mb-10 hidden w-full justify-center text-[11rem] font-light leading-none text-white lg:mb-5 lg:flex">
+        <div className="mb-10 hidden w-full justify-center text-[8.5rem] font-light leading-none text-white lg:mb-5 lg:flex">
           <div className="text-center">
-            unbounded{" "}
             <span className="-mr-3 -mt-11 inline-block align-middle">
               <Image
                 src="/images/brewww-mark-white.png"
                 alt="Brewww Mark"
-                width={135}
-                height={135}
+                width={115}
+                height={115}
                 className="inline-block"
               />
             </span>
-            rands
+            rands beyond tomorrow
           </div>
         </div>
         <div className="flex w-full flex-wrap items-center justify-between px-6 lg:pl-20 lg:pr-20 xl:pl-24 xl:pr-24">

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -51,9 +51,9 @@ export default function Header() {
               </Link>
               <Link
                 className="relative inline-block min-w-max after:absolute after:bottom-0 after:left-0 after:h-[1px] after:w-0 after:bg-white after:transition-all after:duration-300 hover:after:w-full"
-                href="/blog"
+                href="/journal"
               >
-                Blog
+                Journal
               </Link>
               <Link
                 className="relative inline-block min-w-max after:absolute after:bottom-0 after:left-0 after:h-[1px] after:w-0 after:bg-white after:transition-all after:duration-300 hover:after:w-full"


### PR DESCRIPTION
### TL;DR
Renamed "Blog" to "Journal" across the site and updated footer branding text.

### What changed?
- Changed navigation link from "/blog" to "/journal"
- Updated category filter URL structure to use "journal" instead of "blog"
- Removed the "Its time to wonder" section from the journal page
- Modified footer text from "unbounded rands" to "rands beyond tomorrow"
- Adjusted footer logo size from 135px to 115px

### How to test?
1. Navigate to the header menu and verify "Blog" is now "Journal"
2. Click on the Journal link to ensure it routes correctly
3. Test category filters to confirm they use the new URL structure
4. Check footer to verify new branding text and logo size

### Why make this change?
To establish consistent branding terminology by using "Journal" instead of "Blog" and update the brand messaging in the footer to better reflect the company's forward-thinking vision.