### PR TITLE
feat(services): add boilerplate for individual services page

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@payloadcms/db-mongodb": "beta",
-    "@payloadcms/email-nodemailer": "3.0.0-beta.29",
+    "@payloadcms/email-nodemailer": "beta",
     "@payloadcms/live-preview-react": "beta",
     "@payloadcms/next": "beta",
     "@payloadcms/plugin-cloud": "beta",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: beta
         version: 3.0.0-beta.126(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))(payload@3.0.0-beta.126(graphql@16.9.0)(monaco-editor@0.38.0)(react-dom@19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021))(react@19.0.0-rc-69d4b800-20241021)(typescript@5.6.3))
       '@payloadcms/email-nodemailer':
-        specifier: 3.0.0-beta.29
-        version: 3.0.0-beta.29(payload@3.0.0-beta.126(graphql@16.9.0)(monaco-editor@0.38.0)(react-dom@19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021))(react@19.0.0-rc-69d4b800-20241021)(typescript@5.6.3))
+        specifier: beta
+        version: 3.0.0-beta.126(payload@3.0.0-beta.126(graphql@16.9.0)(monaco-editor@0.38.0)(react-dom@19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021))(react@19.0.0-rc-69d4b800-20241021)(typescript@5.6.3))
       '@payloadcms/live-preview-react':
         specifier: beta
         version: 3.0.0-beta.126(react-dom@19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021))(react@19.0.0-rc-69d4b800-20241021)
@@ -1316,11 +1316,11 @@ packages:
     peerDependencies:
       payload: 3.0.0-beta.118
 
-  '@payloadcms/email-nodemailer@3.0.0-beta.29':
-    resolution: {integrity: sha512-8BqO7IynE84D7RH+0pX+5G1DNbseCEkWWEcmFD5aPOAGGhb0x+DcLu99JKg2CNiNzSNEyVmh5WYBPRql+mILFg==}
-    engines: {node: '>=18.20.2'}
+  '@payloadcms/email-nodemailer@3.0.0-beta.126':
+    resolution: {integrity: sha512-r3s4u/3BpHMnaNf4a6f1zqqac2V4CxIcdEYGSscxWXHeZ1DD3mxHbJ9wqKyCcnaCxYRv0K6PvG/L8/AQigVP0A==}
+    engines: {node: ^18.20.2 || >=20.9.0}
     peerDependencies:
-      payload: 3.0.0-beta.29
+      payload: 3.0.0-beta.126
 
   '@payloadcms/eslint-config@1.1.1':
     resolution: {integrity: sha512-LSf9oEPb6aMEMqdTFqj1v+7p/bdrJWG6hp7748xjVO3RL3yQESTKLK/NbjsMYITN4tKFXjfPWDUtcwHv0hS6/A==}
@@ -7067,7 +7067,7 @@ snapshots:
       nodemailer: 6.9.10
       payload: 3.0.0-beta.126(graphql@16.9.0)(monaco-editor@0.38.0)(react-dom@19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021))(react@19.0.0-rc-69d4b800-20241021)(typescript@5.6.3)
 
-  '@payloadcms/email-nodemailer@3.0.0-beta.29(payload@3.0.0-beta.126(graphql@16.9.0)(monaco-editor@0.38.0)(react-dom@19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021))(react@19.0.0-rc-69d4b800-20241021)(typescript@5.6.3))':
+  '@payloadcms/email-nodemailer@3.0.0-beta.126(payload@3.0.0-beta.126(graphql@16.9.0)(monaco-editor@0.38.0)(react-dom@19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021))(react@19.0.0-rc-69d4b800-20241021)(typescript@5.6.3))':
     dependencies:
       nodemailer: 6.9.10
       payload: 3.0.0-beta.126(graphql@16.9.0)(monaco-editor@0.38.0)(react-dom@19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021))(react@19.0.0-rc-69d4b800-20241021)(typescript@5.6.3)

--- a/src/app/(frontend)/(inner)/about/AboutHeroSection/index.tsx
+++ b/src/app/(frontend)/(inner)/about/AboutHeroSection/index.tsx
@@ -10,8 +10,9 @@ export function AboutHeroSection() {
           </div>
           <div className="col-start-1 col-end-6 row-start-2 flex h-full w-full flex-col items-center justify-center self-stretch text-headline-medium leading-none">
             <h1 className="my-3min-h-[0vw] mx-0">
-              We are Brewww Studio. We craft creative for the kind-hearted, the
-              hustlers, and the visionaries.
+              In a world obsessed with the next big thing, we're focused on
+              crafting the next right thing. Our studio exists to transform bold
+              visions into enduring brand realities.
             </h1>
           </div>
           <div className="relative col-start-2 col-end-6 row-start-4 row-end-6 h-[50vh] self-stretch">

--- a/src/app/(frontend)/(inner)/about/page.tsx
+++ b/src/app/(frontend)/(inner)/about/page.tsx
@@ -12,33 +12,27 @@ export default function About() {
       <section className="bg-brand-dark-bg text-white">
         <div className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
           <h2 className="mb-8 max-w-3xl text-4xl font-bold">
-            Brewww: Where Creativity Meets Strategic Execution
+            Beyond the Expected
           </h2>
           <p className="mb-4 max-w-3xl text-lg">
-            At Brewww, we believe that exceptional work is born from a
-            harmonious blend of strategic thinking and creative expression. Our
-            process begins with a deep dive into your objectives, challenges,
-            and target audience, allowing us to craft a tailored approach that
-            resonates with your brand's essence. We meticulously analyze social
-            behaviors, industry trends, and data-driven insights to inform our
-            creative concepts, ensuring they are not only visually captivating
-            but also strategically sound.
+            The most powerful brands aren't built on guesswork—they're crafted
+            through clarity. We unite strategic thinking with creative vision to
+            build brands that don't just capture attention, but convert it into
+            lasting value.
           </p>
           <p className="mb-4 max-w-3xl text-lg">
-            Our multidisciplinary team seamlessly integrates strategy, design,
-            and technology, fostering a collaborative environment where ideas
-            flourish and innovative solutions take shape. We don't just create
-            campaigns; we weave together a holistic narrative that connects with
-            your audience on multiple levels, amplifying your brand's reach and
-            impact.
+            Here's the thing about building brands that last: you can't just
+            guess. Every choice we make is anchored in real business goals and
+            human behavior. But data alone doesn't move people. That's where
+            creative courage comes in—turning solid strategy into something that
+            sparks imagination and drives action.
           </p>
           <p className="mb-16 max-w-3xl text-lg">
-            Throughout the creative process, we embrace an iterative mindset,
-            constantly refining and problem-solving to deliver
-            thought-provoking, dynamic, and relevant work that leaves a lasting
-            impression. Our commitment to excellence drives us to push
-            boundaries, challenge conventions, and craft experiences that
-            captivate and inspire.
+            We don't do cookie-cutter solutions or paint-by-numbers design. Your
+            brand deserves better than that. Instead, we craft unique paths
+            forward, shaped by your reality but reaching for your potential.
+            Because when strategy and creativity align, that's when brands stop
+            following trends and start setting them.
           </p>
         </div>
       </section>
@@ -127,15 +121,15 @@ export default function About() {
         </div>
       </section>
 
-      <section className="cursor-none border-t-2 border-solid border-t-neutral-100/[0.23] bg-brand-dark-bg text-[1.38rem] font-light leading-7 text-zinc-100">
+      <section className="border-t-2 border-solid border-t-neutral-100/[0.23] bg-brand-dark-bg text-[1.38rem] font-light leading-7 text-zinc-100">
         <div className="container mx-auto py-16 lg:py-24">
           <div className="float-left mr-5 mt-1 text-sm lg:mr-8 lg:mt-3 lg:min-w-[7.50rem]">
             BREWWW
           </div>
           <h2 className="text-[5.00rem] leading-none">
-            We're a team of strategists, creatives and technical specialists,
-            combining branding expertise, cutting-edge ux design and creative
-            excellence to build <b>sophisticated</b> brands and experiences.
+            We're a small team that solves big problems. By blending sharp
+            strategy with fearless creativity, we build brands that don't just
+            look different—they act different.
           </h2>
         </div>
       </section>
@@ -267,9 +261,10 @@ export default function About() {
               <span className="inline-block pr-9 text-sm uppercase text-stone-500">
                 Hello!
               </span>
-              Brewww is a branding and web design team. We've crafted custom
-              solutions for leaders and dreamers like The Merry Beggars, IES
-              National, Pietra Fitness,
+              We're Brewww, a studio that builds brands and digital experiences
+              worth remembering. Since 2017, we've partnered with clients like
+              The Merry Beggars, IES National, and Pietra Fitness to turn
+              ambitious ideas into reality
               <a className="inline-block underline" href="">
                 and more.
                 <span className="cursor-pointer text-sm uppercase text-stone-500">
@@ -285,9 +280,10 @@ export default function About() {
             }}
           >
             <p>
-              Here since 2017, we believe in taking on challenges. In turn, we
-              challenge ourselves and our partners, molding every idea into
-              something exceptional.
+              We keep things straightforward here. Take on exciting challenges.
+              Push creative boundaries. Build things that last. Every strategy
+              we develop, every pixel we place, and every line of code we write
+              is crafted with tomorrow in mind.
             </p>
           </div>
           <div
@@ -319,10 +315,12 @@ export default function About() {
             }}
           >
             <p>
-              Our vision is not a convoluted puzzle. It's simple and honest:{" "}
-              <span className="text-rose-600">We want to do top work.</span>{" "}
-              Every strategy, every px in every design, every line of code, is
-              something Brewww proudly{" "}
+              Our best work happens when we truly collaborate with our clients.
+              No egos, no unnecessary complexity—just clear thinking and
+              purposeful design that moves businesses forward.{" "}
+              <span className="text-brand-gold">We want to do top work.</span>{" "}
+              Got something big you want to build? Or maybe you need help
+              shaping that vision? Either way, we're all in. (let's talk)
               <a className="inline-block underline" href="">
                 stands behind.
                 <span className="cursor-pointer text-sm uppercase text-stone-500">
@@ -346,8 +344,9 @@ export default function About() {
                   </span>
                 </span>
               </a>{" "}
-              And this is possible only thanks to our deep partnerships with our
-              clients.
+              That's been our approach since day one. While we've grown stronger
+              and sharper, our drive to craft something exceptional hasn't
+              changed.
             </p>
           </div>
           <div
@@ -381,9 +380,8 @@ export default function About() {
                   </span>
                 </span>
               </a>{" "}
-              that stay busy, and we like it that way. Transform a crazy idea
-              into a product impossible to ignore? We're in. Provide guidance
-              and structure while we're at it? That's what we do.
+              Got something big you want to build? Or maybe you need help
+              shaping that vision? Either way, we're all in.
             </p>
           </div>
           <div
@@ -393,9 +391,9 @@ export default function About() {
             }}
           >
             <p>
-              Fearlessly going all in is what Brewww was built on. Our feet may
-              be firmly on the ground today, but our restless resolve isn't
-              going anywhere.
+              That's been our approach since day one. While we've grown stronger
+              and sharper, our drive to craft something exceptional hasn't
+              changed.
             </p>
           </div>
           <div
@@ -459,11 +457,13 @@ export default function About() {
           <div className="m-auto w-[95vw] max-w-[95vw]">
             <div className="m-auto flex min-h-[calc(240px)] max-w-[56.25rem] flex-col flex-wrap content-center items-center justify-center py-20 text-center">
               <h1 className="mb-8 text-display-large leading-none">
-                Honest Folks Doing Honest Work
+                Future-Forward, Human-First
               </h1>
               <h3 className="mb-8 text-[2.38rem] leading-none">
-                Our strategy remains: work hard, create lasting relationships,
-                and deliver the very best quality work.
+                We're a team of strategists and creators who see beyond the
+                obvious to craft brands that endure. Our secret? We never forget
+                that behind every pixel and strategy lives a human story waiting
+                to be told.
               </h3>
             </div>
           </div>

--- a/src/app/(frontend)/(inner)/services/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/services/[slug]/page.tsx
@@ -1,0 +1,187 @@
+// Next Imports
+import React from "react";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Image from "next/image";
+import Link from "next/link";
+
+// Payload Imports
+import { PayloadRedirects } from "@/components/PayloadRedirects";
+import configPromise from "@payload-config";
+import { getPayloadHMR } from "@payloadcms/next/utilities";
+import { Post, Service } from "@/payload-types";
+
+// Components
+import RichText from "@/components/RichText/index";
+import TableOfContents from "@/components/TableOfContents/index";
+import { LexicalNode } from "@/components/RichText/nodeFormat";
+
+// Utilities
+import { formatDate } from "@root/utilities/dateFormatter";
+
+export async function generateStaticParams() {
+  const payload = await getPayloadHMR({ config: configPromise });
+  const services = await payload.find({
+    collection: "services",
+    limit: 1000,
+    overrideAccess: false,
+  });
+  return (
+    services.docs?.map(({ slug }) => ({
+      params: { slug },
+    })) || []
+  );
+}
+
+export default async function ServicePage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const resolvedParams = await params;
+  if (!resolvedParams.slug) {
+    notFound();
+  }
+
+  const service = await queryServiceBySlug({ slug: resolvedParams.slug });
+  if (!service) {
+    notFound();
+  }
+
+  return (
+    <article className="bg-white pt-24 text-black">
+      <div className="container mx-auto px-4 py-4">
+        <div className="flex items-center justify-between">
+          <ul className="hidden list-none flex-wrap gap-4 md:flex">
+            <li>
+              <Link href="/posts" className="hover:underline">
+                All Posts
+              </Link>
+            </li>
+            <li>
+              <Link href="/posts/category/branding" className="hover:underline">
+                Branding
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/posts/category/web-design"
+                className="hover:underline"
+              >
+                Web Design
+              </Link>
+            </li>
+            <li>
+              <Link href="/posts/category/content" className="hover:underline">
+                Content
+              </Link>
+            </li>
+            <li>
+              <Link href="/posts/category/guides" className="hover:underline">
+                Guides
+              </Link>
+            </li>
+            <li>
+              <Link href="/posts/category/updates" className="hover:underline">
+                Updates
+              </Link>
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <section className="container mx-auto px-4 pb-12 pt-12">
+        <div className="max-w-5xl">
+          <h1 className="mb-4 text-5xl font-medium leading-tight md:text-6xl">
+            {service.title}
+          </h1>
+          <p className="mb-8 max-w-3xl text-xl text-gray-700">
+            {service.description || "Add a cool description here."}
+          </p>
+          <div className="flex items-center gap-1 text-sm text-gray-500">
+            <span>
+              By{" "}
+              <Link className="text-gray-950" href={""}>
+                Kevin Wessa
+              </Link>
+            </span>
+            <span>•</span>
+            <span>
+              {service.publishedOn
+                ? formatDate(service.publishedOn)
+                : "Date not available"}
+            </span>
+            <span>•</span>
+            <span>
+              {service.readTime
+                ? `${service.readTime} min read`
+                : "Add Read Time"}
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <div className="w-full">
+        <div className="px-2">
+          <div className="relative aspect-[3/2] w-full">
+            <Image
+              src={
+                typeof service.image === "string"
+                  ? service.image
+                  : service.image?.url || ""
+              }
+              fill
+              alt={
+                typeof service.image === "object"
+                  ? service.image?.alt || ""
+                  : "Featured image for blog post"
+              }
+              className="rounded-md object-cover"
+              priority
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="container mx-auto grid grid-cols-1 gap-8 pt-8 md:grid-cols-3">
+        <div className="md:col-span-1">
+          <TableOfContents
+            content={(service.content?.root?.children || []) as LexicalNode[]}
+          />
+        </div>
+        <div className="md:col-span-2">
+          <article className="prose mx-auto pb-24">
+            <RichText
+              content={service.description || ""}
+              enableProse={true}
+              enableGutter={false}
+              theme="light"
+            />
+          </article>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+async function queryServiceBySlug({
+  slug,
+}: {
+  slug: string;
+}): Promise<Service | null> {
+  const payload = await getPayloadHMR({ config: configPromise });
+  try {
+    const result = await payload.find({
+      collection: "services",
+      limit: 1,
+      where: {
+        slug: {
+          equals: slug,
+        },
+      },
+    });
+    return result.docs[0] || null;
+  } catch (error) {
+    return null;
+  }
+}

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -36,6 +36,33 @@ export interface Config {
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
+  collectionsJoins: {};
+  collectionsSelect: {
+    media: MediaSelect<false> | MediaSelect<true>;
+    pages: PagesSelect<false> | PagesSelect<true>;
+    posts: PostsSelect<false> | PostsSelect<true>;
+    categories: CategoriesSelect<false> | CategoriesSelect<true>;
+    work: WorkSelect<false> | WorkSelect<true>;
+    play: PlaySelect<false> | PlaySelect<true>;
+    services: ServicesSelect<false> | ServicesSelect<true>;
+    faq: FaqSelect<false> | FaqSelect<true>;
+    brands: BrandsSelect<false> | BrandsSelect<true>;
+    pillars: PillarsSelect<false> | PillarsSelect<true>;
+    testimonials: TestimonialsSelect<false> | TestimonialsSelect<true>;
+    technologies: TechnologiesSelect<false> | TechnologiesSelect<true>;
+    journeys: JourneysSelect<false> | JourneysSelect<true>;
+    locations: LocationsSelect<false> | LocationsSelect<true>;
+    results: ResultsSelect<false> | ResultsSelect<true>;
+    team: TeamSelect<false> | TeamSelect<true>;
+    users: UsersSelect<false> | UsersSelect<true>;
+    industries: IndustriesSelect<false> | IndustriesSelect<true>;
+    redirects: RedirectsSelect<false> | RedirectsSelect<true>;
+    forms: FormsSelect<false> | FormsSelect<true>;
+    'form-submissions': FormSubmissionsSelect<false> | FormSubmissionsSelect<true>;
+    'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
+    'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
+    'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
+  };
   db: {
     defaultIDType: string;
   };
@@ -43,9 +70,17 @@ export interface Config {
     header: Header;
     footer: Footer;
   };
+  globalsSelect: {
+    header: HeaderSelect<false> | HeaderSelect<true>;
+    footer: FooterSelect<false> | FooterSelect<true>;
+  };
   locale: null;
   user: User & {
     collection: 'users';
+  };
+  jobs?: {
+    tasks: unknown;
+    workflows?: unknown;
   };
 }
 export interface UserAuthOperations {
@@ -864,6 +899,582 @@ export interface PayloadMigration {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "media_select".
+ */
+export interface MediaSelect<T extends boolean = true> {
+  title?: T;
+  alt?: T;
+  caption?: T;
+  prefix?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  url?: T;
+  thumbnailURL?: T;
+  filename?: T;
+  mimeType?: T;
+  filesize?: T;
+  width?: T;
+  height?: T;
+  focalX?: T;
+  focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "pages_select".
+ */
+export interface PagesSelect<T extends boolean = true> {
+  title?: T;
+  layout?:
+    | T
+    | {
+        formBlock?:
+          | T
+          | {
+              form?: T;
+              enableIntro?: T;
+              introContent?: T;
+              id?: T;
+              blockName?: T;
+            };
+      };
+  meta?:
+    | T
+    | {
+        preview?: T;
+        overview?: T;
+        title?: T;
+        image?: T;
+        description?: T;
+      };
+  slug?: T;
+  slugLock?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "posts_select".
+ */
+export interface PostsSelect<T extends boolean = true> {
+  title?: T;
+  tagline?: T;
+  description?: T;
+  content?: T;
+  meta?:
+    | T
+    | {
+        preview?: T;
+        overview?: T;
+        title?: T;
+        image?: T;
+        description?: T;
+      };
+  featured?: T;
+  slug?: T;
+  slugLock?: T;
+  publishedOn?: T;
+  image?: T;
+  status?: T;
+  readTime?: T;
+  categories?: T;
+  relatedPosts?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "categories_select".
+ */
+export interface CategoriesSelect<T extends boolean = true> {
+  title?: T;
+  slug?: T;
+  slugLock?: T;
+  meta?:
+    | T
+    | {
+        preview?: T;
+        overview?: T;
+        title?: T;
+        image?: T;
+        description?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "work_select".
+ */
+export interface WorkSelect<T extends boolean = true> {
+  title?: T;
+  tagline?: T;
+  description?: T;
+  storyTitle?: T;
+  storyContent?: T;
+  meta?:
+    | T
+    | {
+        preview?: T;
+        overview?: T;
+        title?: T;
+        image?: T;
+        description?: T;
+      };
+  slug?: T;
+  slugLock?: T;
+  image?: T;
+  brand?: T;
+  featured?: T;
+  services?: T;
+  projectYear?: T;
+  testimonial?: T;
+  relatedWorks?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "play_select".
+ */
+export interface PlaySelect<T extends boolean = true> {
+  title?: T;
+  tagline?: T;
+  description?: T;
+  meta?:
+    | T
+    | {
+        preview?: T;
+        overview?: T;
+        title?: T;
+        image?: T;
+        description?: T;
+      };
+  slug?: T;
+  slugLock?: T;
+  publishedOn?: T;
+  image?: T;
+  relatedPlaygrounds?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "services_select".
+ */
+export interface ServicesSelect<T extends boolean = true> {
+  title?: T;
+  tagline?: T;
+  slug?: T;
+  slugLock?: T;
+  image?: T;
+  description?: T;
+  overview?: T;
+  metadata?: T | {};
+  meta?:
+    | T
+    | {
+        preview?: T;
+        overview?: T;
+        title?: T;
+        image?: T;
+        description?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "faq_select".
+ */
+export interface FaqSelect<T extends boolean = true> {
+  title?: T;
+  answer?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "brands_select".
+ */
+export interface BrandsSelect<T extends boolean = true> {
+  title?: T;
+  logoLight?: T;
+  logoDark?: T;
+  city?: T;
+  state?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "pillars_select".
+ */
+export interface PillarsSelect<T extends boolean = true> {
+  title?: T;
+  tagline?: T;
+  services?: T;
+  slug?: T;
+  slugLock?: T;
+  description?: T;
+  content?: T | {};
+  metadata?: T | {};
+  seo?:
+    | T
+    | {
+        overview?: T;
+        image?: T;
+        title?: T;
+        description?: T;
+        preview?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "testimonials_select".
+ */
+export interface TestimonialsSelect<T extends boolean = true> {
+  title?: T;
+  callout?: T;
+  testimonial?: T;
+  brand?: T;
+  author?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "technologies_select".
+ */
+export interface TechnologiesSelect<T extends boolean = true> {
+  title?: T;
+  image?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "journeys_select".
+ */
+export interface JourneysSelect<T extends boolean = true> {
+  title?: T;
+  tagline?: T;
+  slug?: T;
+  slugLock?: T;
+  services?: T;
+  description?: T;
+  content?: T | {};
+  seo?:
+    | T
+    | {
+        overview?: T;
+        image?: T;
+        title?: T;
+        description?: T;
+        preview?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "locations_select".
+ */
+export interface LocationsSelect<T extends boolean = true> {
+  title?: T;
+  slug?: T;
+  slugLock?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "results_select".
+ */
+export interface ResultsSelect<T extends boolean = true> {
+  title?: T;
+  client?: T;
+  number?: T;
+  support?: T;
+  description?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "team_select".
+ */
+export interface TeamSelect<T extends boolean = true> {
+  title?: T;
+  slug?: T;
+  slugLock?: T;
+  role?: T;
+  image?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "users_select".
+ */
+export interface UsersSelect<T extends boolean = true> {
+  firstName?: T;
+  lastName?: T;
+  photo?: T;
+  roles?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  email?: T;
+  resetPasswordToken?: T;
+  resetPasswordExpiration?: T;
+  salt?: T;
+  hash?: T;
+  loginAttempts?: T;
+  lockUntil?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "industries_select".
+ */
+export interface IndustriesSelect<T extends boolean = true> {
+  title?: T;
+  tagline?: T;
+  slug?: T;
+  slugLock?: T;
+  description?: T;
+  content?: T | {};
+  metadata?:
+    | T
+    | {
+        services?: T;
+      };
+  seo?:
+    | T
+    | {
+        overview?: T;
+        image?: T;
+        title?: T;
+        description?: T;
+        preview?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "redirects_select".
+ */
+export interface RedirectsSelect<T extends boolean = true> {
+  from?: T;
+  to?:
+    | T
+    | {
+        type?: T;
+        reference?: T;
+        url?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "forms_select".
+ */
+export interface FormsSelect<T extends boolean = true> {
+  title?: T;
+  fields?:
+    | T
+    | {
+        checkbox?:
+          | T
+          | {
+              name?: T;
+              label?: T;
+              width?: T;
+              required?: T;
+              defaultValue?: T;
+              id?: T;
+              blockName?: T;
+            };
+        country?:
+          | T
+          | {
+              name?: T;
+              label?: T;
+              width?: T;
+              required?: T;
+              id?: T;
+              blockName?: T;
+            };
+        email?:
+          | T
+          | {
+              name?: T;
+              label?: T;
+              width?: T;
+              required?: T;
+              id?: T;
+              blockName?: T;
+            };
+        message?:
+          | T
+          | {
+              message?: T;
+              id?: T;
+              blockName?: T;
+            };
+        number?:
+          | T
+          | {
+              name?: T;
+              label?: T;
+              width?: T;
+              defaultValue?: T;
+              required?: T;
+              id?: T;
+              blockName?: T;
+            };
+        select?:
+          | T
+          | {
+              name?: T;
+              label?: T;
+              width?: T;
+              defaultValue?: T;
+              options?:
+                | T
+                | {
+                    label?: T;
+                    value?: T;
+                    id?: T;
+                  };
+              required?: T;
+              id?: T;
+              blockName?: T;
+            };
+        state?:
+          | T
+          | {
+              name?: T;
+              label?: T;
+              width?: T;
+              required?: T;
+              id?: T;
+              blockName?: T;
+            };
+        text?:
+          | T
+          | {
+              name?: T;
+              label?: T;
+              width?: T;
+              defaultValue?: T;
+              required?: T;
+              id?: T;
+              blockName?: T;
+            };
+        textarea?:
+          | T
+          | {
+              name?: T;
+              label?: T;
+              width?: T;
+              defaultValue?: T;
+              required?: T;
+              id?: T;
+              blockName?: T;
+            };
+      };
+  submitButtonLabel?: T;
+  confirmationType?: T;
+  confirmationMessage?: T;
+  redirect?:
+    | T
+    | {
+        url?: T;
+      };
+  emails?:
+    | T
+    | {
+        emailTo?: T;
+        cc?: T;
+        bcc?: T;
+        replyTo?: T;
+        emailFrom?: T;
+        subject?: T;
+        message?: T;
+        id?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "form-submissions_select".
+ */
+export interface FormSubmissionsSelect<T extends boolean = true> {
+  form?: T;
+  submissionData?:
+    | T
+    | {
+        field?: T;
+        value?: T;
+        id?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-locked-documents_select".
+ */
+export interface PayloadLockedDocumentsSelect<T extends boolean = true> {
+  document?: T;
+  globalSlug?: T;
+  user?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-preferences_select".
+ */
+export interface PayloadPreferencesSelect<T extends boolean = true> {
+  user?: T;
+  key?: T;
+  value?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-migrations_select".
+ */
+export interface PayloadMigrationsSelect<T extends boolean = true> {
+  name?: T;
+  batch?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "header".
  */
 export interface Header {
@@ -889,6 +1500,34 @@ export interface Footer {
   copyrightNotice?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "header_select".
+ */
+export interface HeaderSelect<T extends boolean = true> {
+  logo?: T;
+  nav?:
+    | T
+    | {
+        label?: T;
+        link?: T;
+        id?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "footer_select".
+ */
+export interface FooterSelect<T extends boolean = true> {
+  logo?: T;
+  copyrightNotice?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -10,7 +10,7 @@ import { seoPlugin } from "@payloadcms/plugin-seo";
 import { GenerateTitle, GenerateURL } from "@payloadcms/plugin-seo/types";
 import { mongooseAdapter } from "@payloadcms/db-mongodb";
 import { lexicalEditor } from "@payloadcms/richtext-lexical";
-import { nodemailerAdapter } from "@payloadcms/email-nodemailer";
+// import { nodemailerAdapter } from "@payloadcms/email-nodemailer";
 import { s3Storage } from "@payloadcms/storage-s3";
 
 //* Import Collections
@@ -18,6 +18,7 @@ import { BlogCategories } from "@/collections/BlogCategories/config";
 import { BlogPosts } from "@/collections/BlogPosts/config";
 import { Brands } from "@/collections/Brands/config";
 import { FAQ } from "@/collections/FAQ/config";
+import { Industries } from "./collections/Industries/config";
 import { Journeys } from "@/collections/Journeys/config";
 import { Location } from "@/collections/Locations/config";
 import { Media } from "@/collections/Media/config";
@@ -41,7 +42,6 @@ import { Footer } from "./globals/Footer/index";
 
 //* Import Types
 import { Page, Post } from "@/payload-types";
-import { Industries } from "./collections/Industries/config";
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
@@ -216,4 +216,11 @@ export default buildConfig({
   typescript: {
     outputFile: path.resolve(dirname, "payload-types.ts"),
   },
+  // email: nodemailerAdapter({
+  //   defaultFromAddress: "hello@brewww.studio",
+  //   defaultFromName: "Brewww Studio",
+  //   transportOptions: {
+  //     apiKey: process.env.MAILEROO_API_KEY,
+  //   },
+  // }),
 });


### PR DESCRIPTION
### TL;DR

Updated brand messaging and copy across the About page while adding a new Services page template.

### What changed?

- Updated the hero section copy to focus on transforming visions into brand realities
- Rewrote the "Beyond the Expected" section to emphasize strategic thinking and creative vision
- Modified team description to highlight problem-solving capabilities
- Added new Services page template with dynamic routing and content display
- Updated email-nodemailer dependency to use beta version
- Temporarily commented out nodemailer adapter configuration

### How to test?

1. Visit the About page to verify updated copy and messaging
2. Navigate to /services/[slug] to confirm new service page template works
3. Verify dynamic content loading for services
4. Check that email functionality continues to work with updated nodemailer version

### Why make this change?

The copy updates better align with the company's strategic positioning and value proposition, while the new Services page template provides a dedicated space for detailed service offerings. The email dependency update ensures compatibility with the latest features while maintaining flexibility for future email provider configuration.