### PR TITLE
feat(landing): create portfolio card component for landing

### DIFF
--- a/src/app/(frontend)/(home)/PortfolioCard/index.tsx
+++ b/src/app/(frontend)/(home)/PortfolioCard/index.tsx
@@ -1,0 +1,37 @@
+interface PortfolioCardProps {
+  imageUrl: string;
+  imageSrcSet?: string;
+  title: string;
+  category: string;
+  href: string;
+}
+
+export function PortfolioCard({
+  imageUrl,
+  imageSrcSet,
+  title,
+  category,
+  href,
+}: PortfolioCardProps) {
+  return (
+    <a
+      className="flex max-w-full flex-col items-start justify-start gap-2 text-sm text-blue-700"
+      href={href}
+    >
+      <div className="w-full cursor-pointer overflow-hidden">
+        <img
+          className="inline-block h-96 w-full max-w-full align-middle"
+          src={imageUrl}
+          srcSet={imageSrcSet}
+        />
+      </div>
+      <div className="cursor-pointer">
+        <div className="overflow-hidden">
+          <div className="text-black">{title}</div>
+          <div className="h-0 w-full bg-black" />
+        </div>
+        <div className="text-black">{category}</div>
+      </div>
+    </a>
+  );
+}

--- a/src/app/(frontend)/(home)/page.tsx
+++ b/src/app/(frontend)/(home)/page.tsx
@@ -1,3 +1,5 @@
+import { PortfolioCard } from "./PortfolioCard";
+
 export default function HomePage() {
   return (
     <>
@@ -146,12 +148,37 @@ export default function HomePage() {
               </div>
             </div>
             <div className="grid auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto] gap-x-4 gap-y-16">
-              <div />
-              <div />
-              <div />
-              <div />
+              <PortfolioCard
+                href="https://luminous-template.webflow.io/work/jimmy-wood-portfolio"
+                imageUrl="https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379.webp"
+                imageSrcSet="https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-500.webp 500w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-800.webp 800w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-1080.webp 1080w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-1600.webp 1600w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-2000.webp 2000w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-2600.webp 2600w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-3200.webp 3200w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379.webp 3728w"
+                title="Jimmy Wood Portfolio"
+                category="Visual Identity"
+              />
+              <PortfolioCard
+                href="https://luminous-template.webflow.io/work/jimmy-wood-portfolio"
+                imageUrl="https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379.webp"
+                imageSrcSet="https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-500.webp 500w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-800.webp 800w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-1080.webp 1080w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-1600.webp 1600w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-2000.webp 2000w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-2600.webp 2600w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-3200.webp 3200w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379.webp 3728w"
+                title="Jimmy Wood Portfolio"
+                category="Visual Identity"
+              />
+              <PortfolioCard
+                href="https://luminous-template.webflow.io/work/jimmy-wood-portfolio"
+                imageUrl="https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379.webp"
+                imageSrcSet="https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-500.webp 500w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-800.webp 800w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-1080.webp 1080w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-1600.webp 1600w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-2000.webp 2000w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-2600.webp 2600w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-3200.webp 3200w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379.webp 3728w"
+                title="Jimmy Wood Portfolio"
+                category="Visual Identity"
+              />
+              <PortfolioCard
+                href="https://luminous-template.webflow.io/work/jimmy-wood-portfolio"
+                imageUrl="https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379.webp"
+                imageSrcSet="https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-500.webp 500w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-800.webp 800w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-1080.webp 1080w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-1600.webp 1600w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-2000.webp 2000w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-2600.webp 2600w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379-p-3200.webp 3200w, https://cdn.prod.website-files.com/66d183e958b40be346c82415/66e6841d1167498ba9dda4af_Group%20379.webp 3728w"
+                title="Jimmy Wood Portfolio"
+                category="Visual Identity"
+              />
             </div>
           </section>
+
           <div className="px-4 py-4 pb-48 text-[12.75rem] font-medium leading-none text-white">
             <div className="flex flex-col items-stretch justify-start">
               <h2>Service</h2>
@@ -335,29 +362,6 @@ export default function HomePage() {
                     <div className="h-0 w-full cursor-pointer bg-white" />
                   </a>
                   <div className="col-start-4 col-end-8 row-start-1 row-end-2 flex gap-8 text-blue-700">
-                    <a
-                      className="inline-block max-w-full overflow-hidden"
-                      href=""
-                    >
-                      <div className="cursor-pointer text-white">Licenses</div>
-                      <div className="h-0 w-full cursor-pointer bg-white" />
-                    </a>
-                    <a
-                      className="inline-block max-w-full overflow-hidden"
-                      href=""
-                    >
-                      <div className="cursor-pointer text-white">Changelog</div>
-                      <div className="h-0 w-full cursor-pointer bg-white" />
-                    </a>
-                    <a
-                      className="inline-block max-w-full overflow-hidden"
-                      href=""
-                    >
-                      <div className="cursor-pointer text-white">
-                        Style Guide
-                      </div>
-                      <div className="h-0 w-full cursor-pointer bg-white" />
-                    </a>
                     <a
                       className="inline-block max-w-full overflow-hidden"
                       href=""


### PR DESCRIPTION
### TL;DR
Added a new PortfolioCard component and integrated it into the home page portfolio section.

### What changed?
- Created a new `PortfolioCard` component with props for image, title, category, and link
- Implemented the portfolio grid section with four instances of the PortfolioCard
- Removed unused footer links (Licenses, Changelog, Style Guide)

### How to test?
1. Navigate to the home page
2. Verify the portfolio grid displays four cards with images
3. Check that each card shows:
   - A full-width image
   - Project title
   - Category label
4. Confirm clicking a card navigates to the correct project page
5. Verify responsive image loading works with different screen sizes

### Why make this change?
To create a consistent and reusable portfolio display component that improves code maintainability and provides a better visual presentation of portfolio items. The component standardizes how portfolio items are displayed while supporting responsive images and maintaining a clean grid layout.