### PR TITLE
feat(cms): add optional Project Link to Works collection

### DIFF
--- a/src/collections/Work/config.ts
+++ b/src/collections/Work/config.ts
@@ -138,6 +138,15 @@ export const Work: CollectionConfig = {
       },
     },
     {
+      name: "projectLink",
+      type: "text",
+      label: "Project Link",
+      required: false,
+      admin: {
+        position: "sidebar",
+      },
+    },
+    {
       name: "relatedWorks",
       type: "relationship",
       label: "Related Case Studies",

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -444,6 +444,7 @@ export interface Work {
   services?: (string | Service)[] | null;
   projectYear?: number | null;
   testimonial?: (string | null) | Testimonial;
+  projectLink?: string | null;
   relatedWorks?: (string | Work)[] | null;
   updatedAt: string;
   createdAt: string;
@@ -1031,6 +1032,7 @@ export interface WorkSelect<T extends boolean = true> {
   services?: T;
   projectYear?: T;
   testimonial?: T;
+  projectLink?: T;
   relatedWorks?: T;
   updatedAt?: T;
   createdAt?: T;


### PR DESCRIPTION
### TL;DR
Added a new `projectLink` field to the Work collection to support external project URLs.

### What changed?
- Added a new optional text field `projectLink` to the Work collection configuration
- Field appears in the sidebar of the admin interface
- Updated TypeScript types to include the new field

### How to test?
1. Navigate to any Work item in the admin panel
2. Verify the "Project Link" field appears in the sidebar
3. Try adding a URL to the field and saving the work item
4. Confirm the field accepts null values for works without external links

### Why make this change?
To enable linking work items to external project URLs, allowing visitors to view live projects or additional project resources directly from the portfolio.