### PR TITLE
feat(ui): add Heading component

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "eslint-plugin-react-compiler": "0.0.0-experimental-75b9fd4-20240912",
+    "framer-motion": "^11.11.17",
     "graphql": "^16.9.0",
     "gsap": "^3.12.5",
     "jsonwebtoken": "9.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       eslint-plugin-react-compiler:
         specifier: 0.0.0-experimental-75b9fd4-20240912
         version: 0.0.0-experimental-75b9fd4-20240912(eslint@8.57.1)
+      framer-motion:
+        specifier: ^11.11.17
+        version: 11.11.17(react-dom@19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021))(react@19.0.0-rc-69d4b800-20241021)
       graphql:
         specifier: ^16.9.0
         version: 16.9.0
@@ -3362,6 +3365,20 @@ packages:
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
+
+  framer-motion@11.11.17:
+    resolution: {integrity: sha512-O8QzvoKiuzI5HSAHbcYuL6xU+ZLXbrH7C8Akaato4JzQbX2ULNeniqC2Vo5eiCtFktX9XsJ+7nUhxcl2E2IjpA==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -7091,17 +7108,17 @@ snapshots:
   '@payloadcms/eslint-config@1.1.1(typescript@5.6.3)':
     dependencies:
       '@types/eslint': 8.44.2
-      '@typescript-eslint/eslint-plugin': 6.6.0(@typescript-eslint/parser@6.6.0(eslint@8.48.0)(typescript@5.6.3))(eslint@8.48.0)(typescript@5.6.3)
+      '@typescript-eslint/eslint-plugin': 6.6.0(@typescript-eslint/parser@8.12.2(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
       '@typescript-eslint/parser': 6.6.0(eslint@8.48.0)(typescript@5.6.3)
       eslint: 8.48.0
       eslint-config-prettier: 9.0.0(eslint@8.48.0)
       eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.6.0(eslint@8.48.0)(typescript@5.6.3))(eslint@8.48.0)
-      eslint-plugin-jest: 27.2.3(@typescript-eslint/eslint-plugin@6.6.0(@typescript-eslint/parser@8.12.2(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
+      eslint-plugin-jest: 27.2.3(@typescript-eslint/eslint-plugin@6.6.0(@typescript-eslint/parser@6.6.0(eslint@8.48.0)(typescript@5.6.3))(eslint@8.48.0)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
       eslint-plugin-jest-dom: 5.1.0(eslint@8.48.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.48.0)
       eslint-plugin-node: 11.1.0(eslint@8.48.0)
       eslint-plugin-perfectionist: 2.0.0(eslint@8.48.0)(typescript@5.6.3)
-      eslint-plugin-playwright: 0.16.0(eslint-plugin-jest@27.2.3(@typescript-eslint/eslint-plugin@6.6.0(@typescript-eslint/parser@8.12.2(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.48.0)(typescript@5.6.3))(eslint@8.48.0)
+      eslint-plugin-playwright: 0.16.0(eslint-plugin-jest@27.2.3(@typescript-eslint/eslint-plugin@6.6.0(@typescript-eslint/parser@6.6.0(eslint@8.48.0)(typescript@5.6.3))(eslint@8.48.0)(typescript@5.6.3))(eslint@8.48.0)(typescript@5.6.3))(eslint@8.48.0)
       eslint-plugin-react: 7.33.2(eslint@8.48.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.48.0)
       eslint-plugin-regexp: 1.15.0(eslint@8.48.0)
@@ -8255,16 +8272,16 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@6.6.0(@typescript-eslint/parser@6.6.0(eslint@8.48.0)(typescript@5.6.3))(eslint@8.48.0)(typescript@5.6.3)':
+  '@typescript-eslint/eslint-plugin@6.6.0(@typescript-eslint/parser@8.12.2(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 6.6.0(eslint@8.48.0)(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.12.2(eslint@8.57.1)(typescript@5.6.3)
       '@typescript-eslint/scope-manager': 6.6.0
       '@typescript-eslint/type-utils': 6.6.0(eslint@8.48.0)(typescript@5.6.3)
       '@typescript-eslint/utils': 6.6.0(eslint@8.48.0)(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 6.6.0
       debug: 4.3.7
-      eslint: 8.48.0
+      eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -9413,12 +9430,12 @@ snapshots:
       eslint: 8.48.0
       requireindex: 1.2.0
 
-  eslint-plugin-jest@27.2.3(@typescript-eslint/eslint-plugin@6.6.0(@typescript-eslint/parser@8.12.2(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3):
+  eslint-plugin-jest@27.2.3(@typescript-eslint/eslint-plugin@6.6.0(@typescript-eslint/parser@6.6.0(eslint@8.48.0)(typescript@5.6.3))(eslint@8.48.0)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.48.0)(typescript@5.6.3)
       eslint: 8.57.1
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 6.6.0(@typescript-eslint/parser@6.6.0(eslint@8.48.0)(typescript@5.6.3))(eslint@8.48.0)(typescript@5.6.3)
+      '@typescript-eslint/eslint-plugin': 6.6.0(@typescript-eslint/parser@8.12.2(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9482,11 +9499,11 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-playwright@0.16.0(eslint-plugin-jest@27.2.3(@typescript-eslint/eslint-plugin@6.6.0(@typescript-eslint/parser@8.12.2(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.48.0)(typescript@5.6.3))(eslint@8.48.0):
+  eslint-plugin-playwright@0.16.0(eslint-plugin-jest@27.2.3(@typescript-eslint/eslint-plugin@6.6.0(@typescript-eslint/parser@6.6.0(eslint@8.48.0)(typescript@5.6.3))(eslint@8.48.0)(typescript@5.6.3))(eslint@8.48.0)(typescript@5.6.3))(eslint@8.48.0):
     dependencies:
       eslint: 8.48.0
     optionalDependencies:
-      eslint-plugin-jest: 27.2.3(@typescript-eslint/eslint-plugin@6.6.0(@typescript-eslint/parser@8.12.2(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
+      eslint-plugin-jest: 27.2.3(@typescript-eslint/eslint-plugin@6.6.0(@typescript-eslint/parser@6.6.0(eslint@8.48.0)(typescript@5.6.3))(eslint@8.48.0)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
 
   eslint-plugin-react-compiler@0.0.0-experimental-75b9fd4-20240912(eslint@8.57.1):
     dependencies:
@@ -9811,6 +9828,13 @@ snapshots:
       mime-types: 2.1.35
 
   fraction.js@4.3.7: {}
+
+  framer-motion@11.11.17(react-dom@19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021))(react@19.0.0-rc-69d4b800-20241021):
+    dependencies:
+      tslib: 2.8.0
+    optionalDependencies:
+      react: 19.0.0-rc-69d4b800-20241021
+      react-dom: 19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021)
 
   fs.realpath@1.0.0: {}
 

--- a/src/app/(frontend)/(inner)/about/AboutHeroSection/index.tsx
+++ b/src/app/(frontend)/(inner)/about/AboutHeroSection/index.tsx
@@ -1,4 +1,6 @@
+
 import Image from "next/image";
+import { Heading } from "@/components/Heading";
 
 export function AboutHeroSection() {
   return (
@@ -9,7 +11,7 @@ export function AboutHeroSection() {
             <div className="pb-5">+ About Our Studio</div>
           </div>
           <div className="col-start-1 col-end-6 row-start-2 flex h-full w-full flex-col items-center justify-center self-stretch text-headline-medium leading-none">
-            <h1 className="my-3min-h-[0vw] mx-0">
+            <h1 className="my-3 min-h-[0vw] mx-0">
               In a world obsessed with the next big thing, we're focused on
               crafting the next right thing. Our studio exists to transform bold
               visions into enduring brand realities.

--- a/src/app/(frontend)/(inner)/about/page.tsx
+++ b/src/app/(frontend)/(inner)/about/page.tsx
@@ -11,23 +11,23 @@ export default function About() {
 
       <section className="bg-brand-dark-bg text-white">
         <div className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-          <h2 className="mb-8 max-w-3xl text-4xl font-bold">
+          <h2 className="mb-6 max-w-3xl text-4xl font-bold">
             Beyond the Expected
           </h2>
-          <p className="mb-4 max-w-3xl text-lg">
+          <p className="mb-2 max-w-3xl text-lg">
             The most powerful brands aren't built on guesswork—they're crafted
             through clarity. We unite strategic thinking with creative vision to
             build brands that don't just capture attention, but convert it into
             lasting value.
           </p>
-          <p className="mb-4 max-w-3xl text-lg">
+          <p className="mb-2 max-w-3xl text-lg">
             Here's the thing about building brands that last: you can't just
             guess. Every choice we make is anchored in real business goals and
             human behavior. But data alone doesn't move people. That's where
             creative courage comes in—turning solid strategy into something that
             sparks imagination and drives action.
           </p>
-          <p className="mb-16 max-w-3xl text-lg">
+          <p className="mb-8 max-w-3xl text-lg">
             We don't do cookie-cutter solutions or paint-by-numbers design. Your
             brand deserves better than that. Instead, we craft unique paths
             forward, shaped by your reality but reaching for your potential.
@@ -38,7 +38,7 @@ export default function About() {
       </section>
 
       <section className="relative bg-brand-dark-bg px-24 py-36 font-light text-white">
-        <div className="relative grid auto-cols-fr grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr] grid-rows-[auto_auto_auto_auto_auto_auto] gap-4">
+        <div className="relative grid auto-cols-fr grid-cols-6 grid-rows-[auto_auto_auto_auto_auto_auto] gap-4">
           <div className="col-start-3 col-end-6 row-start-1 row-end-2 flex h-full w-full flex-col items-end justify-start font-bold uppercase">
             <div className="pb-5">+ Our Values</div>
           </div>

--- a/src/app/(frontend)/(inner)/journal/page.tsx
+++ b/src/app/(frontend)/(inner)/journal/page.tsx
@@ -59,7 +59,7 @@ export default async function BlogPage() {
         </div>
       </section>
 
-      <section className="bg-brand-dark-bg py-24">
+      <section className="bg-brand-dark-bg py-24 text-white">
         <div className="container mx-auto">
           <div className="relative grid auto-rows-auto grid-cols-3 gap-x-8 gap-y-24 text-zinc-100">
             {posts.docs.map((post) => (

--- a/src/components/BlogCard/index.tsx
+++ b/src/components/BlogCard/index.tsx
@@ -6,7 +6,7 @@ import Image from "next/image";
 
 export const BlogCard = ({ post }: { post: Post }) => {
   return (
-    <Link className="relative" href={`/blog/${post.slug}`}>
+    <Link className="relative" href={`/journal/${post.slug}`}>
       <div className="mb-5 overflow-hidden rounded-md">
         <div className="relative h-[0] w-full pb-[66%]">
           <Image

--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -1,0 +1,130 @@
+import React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { twMerge } from "tailwind-merge";
+
+// Type scale following Material Design (with fluid sizes)
+const headingVariants = cva(
+  // Base styles
+  "font-default tracking-tight",
+  {
+    variants: {
+      level: {
+        h1: "", // Default heading level class
+        h2: "",
+        h3: "",
+        h4: "",
+        h5: "",
+        h6: "",
+        p: "",
+      },
+      size: {
+        // Display sizes
+        "display-large": "text-display-large",
+        "display-medium": "text-display-medium",
+        "display-small": "text-display-small",
+
+        // Headline sizes
+        "headline-large": "text-headline-large",
+        "headline-medium": "text-headline-medium",
+        "headline-small": "text-headline-small",
+
+        // Title sizes
+        "title-large": "text-title-large",
+        "title-medium": "text-title-medium",
+        "title-small": "text-title-small",
+      },
+      align: {
+        left: "text-left",
+        center: "text-center",
+        right: "text-right",
+      },
+      weight: {
+        regular: "font-normal",
+        medium: "font-medium",
+        semibold: "font-semibold",
+        bold: "font-bold",
+      },
+    },
+    defaultVariants: {
+      align: "left",
+      weight: "bold",
+    },
+    // Compound variants for specific combinations
+    compoundVariants: [
+      {
+        size: ["display-large", "display-medium", "display-small"],
+        weight: "regular",
+        className: "font-normal tracking-tighter",
+      },
+    ],
+  },
+);
+
+// Types for heading content
+type HeadingContent = {
+  text: string;
+  bold?: boolean;
+  italic?: boolean;
+  className?: string;
+};
+
+interface HeadingProps extends VariantProps<typeof headingVariants> {
+  level?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+  content: string | HeadingContent[];
+  uppercase?: boolean;
+  className?: string;
+}
+
+export const Heading: React.FC<HeadingProps> = ({
+  level = "h2",
+  size = "headline-large",
+  content,
+  align,
+  weight,
+
+  className,
+}) => {
+  const Component = level;
+
+  // Helper function to render rich text content
+  const renderContent = () => {
+    if (typeof content === "string") {
+      return content;
+    }
+
+    return content.map((item, index) => {
+      if (item.bold || item.italic) {
+        return (
+          <span
+            key={index}
+            className={twMerge(
+              item.bold && "font-bold",
+              item.italic && "italic",
+              item.className,
+            )}
+          >
+            {item.text}
+          </span>
+        );
+      }
+      return item.text;
+    });
+  };
+
+  return (
+    <Component
+      className={twMerge(
+        headingVariants({
+          level,
+          size,
+          align,
+          weight,
+        }),
+        "mx-auto",
+        className,
+      )}
+    >
+      {renderContent()}
+    </Component>
+  );
+};

--- a/src/components/YouTube/index.tsx
+++ b/src/components/YouTube/index.tsx
@@ -21,3 +21,4 @@ const YouTube: React.FC<Props> = ({ id, title }) => (
 );
 
 export default YouTube;
+


### PR DESCRIPTION
### TL;DR

Added Framer Motion library and introduced new Heading component with Material Design typography system.

### What changed?

- Added Framer Motion dependency for animation capabilities
- Created new Heading component with Material Design type scale support
- Fixed blog card links to use correct `/journal` path instead of `/blog`
- Adjusted spacing and typography in About and Journal pages
- Simplified grid column notation in About page
- Added text-white class to Journal section for better contrast

### How to test?

1. Install dependencies with `pnpm install`
2. Verify Heading component renders correctly with different variants:
```jsx
<Heading 
  level="h1"
  size="display-large"
  content="Test Heading"
  align="center"
/>
```
3. Check Journal page links navigate to correct URLs
4. Verify typography spacing and grid layouts in About page

### Why make this change?

To establish a consistent typography system following Material Design principles while improving component reusability. The Heading component provides a standardized way to handle text styles across the application, reducing code duplication and maintaining visual consistency.