### PR TITLE
feat(ui): update Heading component to use children prop

### DIFF
--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { twMerge } from "tailwind-merge";
 
-// Type scale following Material Design (with fluid sizes)
+// Type scale following Material Design. Update settings in the Tailwind config.
 const headingVariants = cva(
   // Base styles
   "font-default tracking-tight",
@@ -49,7 +49,6 @@ const headingVariants = cva(
       align: "left",
       weight: "bold",
     },
-    // Compound variants for specific combinations
     compoundVariants: [
       {
         size: ["display-large", "display-medium", "display-small"],
@@ -60,56 +59,21 @@ const headingVariants = cva(
   },
 );
 
-// Types for heading content
-type HeadingContent = {
-  text: string;
-  bold?: boolean;
-  italic?: boolean;
-  className?: string;
-};
-
 interface HeadingProps extends VariantProps<typeof headingVariants> {
   level?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
-  content: string | HeadingContent[];
-  uppercase?: boolean;
+  children?: React.ReactNode;
   className?: string;
 }
 
 export const Heading: React.FC<HeadingProps> = ({
   level = "h2",
   size = "headline-large",
-  content,
   align,
   weight,
-
+  children,
   className,
 }) => {
   const Component = level;
-
-  // Helper function to render rich text content
-  const renderContent = () => {
-    if (typeof content === "string") {
-      return content;
-    }
-
-    return content.map((item, index) => {
-      if (item.bold || item.italic) {
-        return (
-          <span
-            key={index}
-            className={twMerge(
-              item.bold && "font-bold",
-              item.italic && "italic",
-              item.className,
-            )}
-          >
-            {item.text}
-          </span>
-        );
-      }
-      return item.text;
-    });
-  };
 
   return (
     <Component
@@ -120,11 +84,10 @@ export const Heading: React.FC<HeadingProps> = ({
           align,
           weight,
         }),
-        "mx-auto",
         className,
       )}
     >
-      {renderContent()}
+      {children}
     </Component>
   );
 };


### PR DESCRIPTION
### TL;DR
Simplified the Heading component by removing rich text handling and switching to a children prop pattern.

### What changed?
- Removed the `HeadingContent` type and related rich text rendering logic
- Replaced `content` prop with standard React `children` prop
- Removed `uppercase` prop as it was unused
- Removed `mx-auto` default class
- Updated Material Design type scale comment for clarity

### How to test?
1. Import and use the Heading component with direct child content:
```jsx
<Heading level="h1" size="display-large">
  Your heading text here
</Heading>
```
2. Verify headings render correctly with different levels and sizes
3. Confirm styling variants (alignment, weight) still work as expected

### Why make this change?
The component was overly complex with custom rich text handling. Using React's children prop pattern provides more flexibility and follows standard React patterns, making the component easier to use and maintain. This change also allows for nested elements and components within headings.