### PR TITLE
feat(ui): add Title component and update BlogCard and WorkCard:

### DIFF
--- a/src/app/(frontend)/(inner)/about/AboutHeroSection/index.tsx
+++ b/src/app/(frontend)/(inner)/about/AboutHeroSection/index.tsx
@@ -1,6 +1,5 @@
-
 import Image from "next/image";
-import { Heading } from "@/components/Heading";
+import { Title } from "@/components/Title";
 
 export function AboutHeroSection() {
   return (
@@ -11,7 +10,7 @@ export function AboutHeroSection() {
             <div className="pb-5">+ About Our Studio</div>
           </div>
           <div className="col-start-1 col-end-6 row-start-2 flex h-full w-full flex-col items-center justify-center self-stretch text-headline-medium leading-none">
-            <h1 className="my-3 min-h-[0vw] mx-0">
+            <h1 className="mx-0 my-3 min-h-[0vw]">
               In a world obsessed with the next big thing, we're focused on
               crafting the next right thing. Our studio exists to transform bold
               visions into enduring brand realities.

--- a/src/app/(frontend)/(inner)/services/page.tsx
+++ b/src/app/(frontend)/(inner)/services/page.tsx
@@ -1,24 +1,27 @@
 import Image from "next/image";
 import { LinkMain } from "@/components/LinkMain";
 import Link from "next/link";
+import { Title } from "@/components/Title";
 
 export default function ServicesPage() {
   return (
     <>
-      <section className="w-full bg-brand-dark-bg pb-10 pt-20 text-black lg:pb-16 lg:pt-32 xl:pt-40">
+      <section className="w-full bg-brand-dark-bg pb-10 pt-20 text-white lg:pb-16 lg:pt-32 xl:pt-40">
         <div className="px-2 sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20 min-[1800px]:pl-40 min-[1800px]:pr-40 min-[2100px]:pl-60 min-[2100px]:pr-60">
           <div className="mb-3 flex flex-wrap justify-between md:mb-5 lg:mb-0">
             <div className="w-full px-2 lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
               <div className="mb-3 inline-flex w-auto items-center">
-                <div className="h-1.5 w-1.5 rounded-full bg-white" />
                 <div className="ml-2 text-lg font-light text-white">
                   Services
                 </div>
               </div>
-              <h1 className="max-w-5xl indent-32 text-display-small leading-none text-white">
-                The talent, tools, and deliverables to spark action for your
-                brand.
-              </h1>
+              <div className="max-w-6xl">
+                {" "}
+                <Title level="h1" size="display-small">
+                  The talent, tools, and deliverables to spark action for your
+                  brand.
+                </Title>
+              </div>
             </div>
           </div>
           <div className="flex w-full flex-wrap pt-20 text-[2.50rem] leading-none text-white md:justify-end">

--- a/src/components/BlogCard/index.tsx
+++ b/src/components/BlogCard/index.tsx
@@ -3,6 +3,7 @@ import { Media } from "@/payload-types";
 import { Category } from "@/payload-types";
 import Link from "next/link";
 import Image from "next/image";
+import { Title } from "../Title";
 
 export const BlogCard = ({ post }: { post: Post }) => {
   return (
@@ -24,7 +25,9 @@ export const BlogCard = ({ post }: { post: Post }) => {
           </span>
           <span className="ml-2">/ {post.readTime} min read</span>
         </p>
-        <h3 className="text-title-medium leading-none">{post.title}</h3>
+        <Title level="h3" size="title-medium" className="leading-none">
+          {post.title}
+        </Title>
       </div>
     </Link>
   );

--- a/src/components/Title/index.tsx
+++ b/src/components/Title/index.tsx
@@ -5,7 +5,7 @@ import { twMerge } from "tailwind-merge";
 // Type scale following Material Design. Update settings in the Tailwind config.
 const headingVariants = cva(
   // Base styles
-  "font-default tracking-tight",
+  "font-default tracking-tight leading-none",
   {
     variants: {
       level: {
@@ -33,11 +33,7 @@ const headingVariants = cva(
         "title-medium": "text-title-medium",
         "title-small": "text-title-small",
       },
-      align: {
-        left: "text-left",
-        center: "text-center",
-        right: "text-right",
-      },
+
       weight: {
         regular: "font-normal",
         medium: "font-medium",
@@ -46,8 +42,7 @@ const headingVariants = cva(
       },
     },
     defaultVariants: {
-      align: "left",
-      weight: "bold",
+      weight: "regular",
     },
     compoundVariants: [
       {
@@ -59,16 +54,15 @@ const headingVariants = cva(
   },
 );
 
-interface HeadingProps extends VariantProps<typeof headingVariants> {
+interface TitleProps extends VariantProps<typeof headingVariants> {
   level?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
   children?: React.ReactNode;
   className?: string;
 }
 
-export const Heading: React.FC<HeadingProps> = ({
+export const Title: React.FC<TitleProps> = ({
   level = "h2",
   size = "headline-large",
-  align,
   weight,
   children,
   className,
@@ -81,7 +75,6 @@ export const Heading: React.FC<HeadingProps> = ({
         headingVariants({
           level,
           size,
-          align,
           weight,
         }),
         className,

--- a/src/components/WorkCard/index.tsx
+++ b/src/components/WorkCard/index.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import type { Work as WorkType } from "@/payload-types";
+import { Title } from "../Title";
 
 export type WorkCardProps = {
   project: WorkType;
@@ -8,7 +9,7 @@ export type WorkCardProps = {
 
 export function WorkCard({ project }: WorkCardProps) {
   return (
-    <div className="relative w-full">
+    <div className="relative w-full text-white">
       <Link
         href={`/work/${project.slug}`}
         className="relative flex flex-col items-start"
@@ -57,9 +58,9 @@ export function WorkCard({ project }: WorkCardProps) {
             {project.title}
           </div>
         </div>
-        <h2 className="max-w-lg cursor-pointer pr-10 text-title-medium leading-none text-white">
+        <Title level="h2" size="title-medium" className="max-w-lg leading-none">
           {project.tagline}
-        </h2>
+        </Title>
       </Link>
     </div>
   );


### PR DESCRIPTION
### TL;DR
Replaced the `Heading` component with a new `Title` component and implemented it across various pages and components.

### What changed?
- Renamed `Heading` component to `Title` and simplified its variant props
- Removed text alignment variants and updated default font weight to regular
- Added default `leading-none` class to base styles
- Implemented the new `Title` component in:
  - About hero section
  - Services page
  - Blog card
  - Work card components

### How to test?
1. Navigate to the following pages and verify heading styles:
   - `/about`
   - `/services`
   - Blog listing page
   - Work listing page
2. Confirm headings maintain proper spacing and typography
3. Verify text remains properly aligned and styled across all breakpoints

### Why make this change?
To standardize heading components across the application and remove unnecessary styling options for better maintainability and consistency in the typography system.