### PR TITLE
feat(ui): add Text component

### DIFF
--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { twMerge } from "tailwind-merge";
+
+// Text component following Material Design type scale from Tailwind config
+const textVariants = cva(
+  // Base styles
+  "font-default tracking-tight",
+  {
+    variants: {
+      level: {
+        p: "", // Paragraph
+        span: "", // Inline text
+        div: "", // Block-level text
+      },
+      size: {
+        // Body sizes
+        "body-large": "text-body-large",
+        "body-medium": "text-body-medium",
+        "body-small": "text-body-small",
+
+        // Label sizes
+        "label-large": "text-label-large",
+        "label-medium": "text-label-medium",
+        "label-small": "text-label-small",
+      },
+      weight: {
+        regular: "font-normal",
+        medium: "font-medium",
+        semibold: "font-semibold",
+        bold: "font-bold",
+      },
+    },
+    defaultVariants: {
+      level: "p",
+      size: "body-medium",
+      weight: "regular",
+    },
+  }
+);
+
+export interface TextProps extends React.HTMLAttributes<HTMLElement>, 
+  VariantProps<typeof textVariants> {
+  children?: React.ReactNode;
+  className?: string;
+  el?: "p" | "span" | "div";
+}
+
+export function Text({
+  level,
+  size,
+  weight,
+  children,
+  className,
+  el = "p",
+  ...props
+}: TextProps) {
+  const Component = el;
+
+  return (
+    <Component
+      className={twMerge(
+        textVariants({ 
+          level, 
+          size, 
+          weight 
+        }),
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </Component>
+  );
+}


### PR DESCRIPTION
### TL;DR
Added a new Text component that implements Material Design type scale with configurable styles

### What changed?
Created a new Text component that:
- Supports different HTML elements (p, span, div)
- Implements Material Design typography scale
- Provides configurable text sizes (body and label variants)
- Allows font weight customization
- Uses class-variance-authority for variant management
- Integrates with Tailwind classes

### How to test?
1. Import the Text component
2. Test different combinations of props:
```jsx
<Text size="body-large" weight="bold">Large bold text</Text>
<Text el="span" size="label-small">Small label</Text>
<Text size="body-medium" className="custom-class">Custom styled text</Text>
```
3. Verify that the rendered text matches the expected styling
4. Confirm that custom classes properly merge with component styles

### Why make this change?
To establish a consistent typography system that:
- Follows Material Design principles
- Provides a reusable component for text styling
- Ensures maintainable and scalable text styles across the application
- Reduces redundant styling code