### PR TITLE
feat(home): add ImpactCard and ImpactCardSection

### DIFF
--- a/src/app/(frontend)/(inner)/home/BlogGridSection/index.tsx
+++ b/src/app/(frontend)/(inner)/home/BlogGridSection/index.tsx
@@ -1,5 +1,7 @@
 import { Post } from "@/payload-types";
 import { BlogCard } from "@/components/BlogCard/index";
+import { Title } from "@/components/Title";
+import { Text } from "@/components/Text";
 
 export function BlogGridSection({ posts }: { posts: Post[] }) {
   return (
@@ -7,13 +9,17 @@ export function BlogGridSection({ posts }: { posts: Post[] }) {
       <div className="relative z-10 m-auto w-full max-w-[100.00rem] px-24 pt-24">
         <div className="flex flex-wrap px-24">
           <div className="-ml-3.5 w-full max-w-[91.6667%] basis-7/12 text-label-large">
-            <p className="mb-6 uppercase">
+            <Text level="p" size="label-large" className="mb-6 uppercase">
               <span className="mr-2 font-bold text-brand-gold">/</span>Featured
               Insights
-            </p>
-            <h2 className="mb-28 text-headline-medium leading-none">
+            </Text>
+            <Title
+              el="h2"
+              size="headline-medium"
+              className="mb-28 leading-none"
+            >
               Branding, tech, and business insights.
-            </h2>
+            </Title>
           </div>
         </div>
       </div>

--- a/src/app/(frontend)/(inner)/home/HomeAboutSection/index.tsx
+++ b/src/app/(frontend)/(inner)/home/HomeAboutSection/index.tsx
@@ -1,0 +1,21 @@
+import { Title } from "@/components/Title";
+
+export function HomeAboutSection() {
+  return (
+    <section className="bg-brand-dark-bg py-24 text-zinc-50">
+      <div className="container mx-auto px-4">
+        <div className="flex flex-col items-center">
+          <div className="grid grid-cols-12 py-16 sm:py-24 md:py-32">
+            <div className="col-span-9 col-start-1">
+              <Title size="headline-large">
+                From fast-growing startups to experienced companies, we deliver
+                functional design, high-quality code and well-thought strategy
+                to increase your odds of success in the digital world.
+              </Title>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(frontend)/(inner)/home/HomeImpactSection/index.tsx
+++ b/src/app/(frontend)/(inner)/home/HomeImpactSection/index.tsx
@@ -1,0 +1,56 @@
+import { ImpactCard } from "@/components/ImpactCard";
+
+const impactData = [
+  {
+    value: "2024",
+    title: "Years of experience",
+    description: "We elevated our design agency to new heights, embracing cutting-edge trends and innovative practices",
+  },
+  {
+    value: "137%",
+    title: "Growth",
+    description: "The trust our clients place in our ability to deliver exceptional design solutions.",
+  },
+  {
+    value: "+26",
+    title: "Awards",
+    description: "Celebrating our commitment to excellence, innovation, and the transformative power of outstanding design.",
+  },
+  {
+    value: "+30",
+    title: "Clients",
+    description: "Bringing unique challenges that have enriched our creative journey and expanded our industry impact.",
+  },
+  {
+    value: "+56",
+    title: "Cases",
+    description: "Our diverse project experience showcases our ability to tailor bespoke solutions that drive success",
+  },
+];
+
+export const HomeImpactSection = () => {
+  return (
+    <section className="bg-brand-dark-bg py-16 text-zinc-50">
+      <div className="container mx-auto px-4">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 lg:grid-rows-3 lg:gap-8">
+          {/* Desktop positioning classes are only applied on large screens */}
+          <div className="lg:col-start-1 lg:col-end-2 lg:row-start-1 lg:row-end-2">
+            <ImpactCard {...impactData[0]} />
+          </div>
+          <div className="lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-2">
+            <ImpactCard {...impactData[1]} />
+          </div>
+          <div className="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-3">
+            <ImpactCard {...impactData[2]} />
+          </div>
+          <div className="lg:col-start-2 lg:col-end-3 lg:row-start-2 lg:row-end-3">
+            <ImpactCard {...impactData[3]} />
+          </div>
+          <div className="lg:col-start-2 lg:col-end-3 lg:row-start-3 lg:row-end-4">
+            <ImpactCard {...impactData[4]} />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/app/(frontend)/(inner)/home/page.tsx
+++ b/src/app/(frontend)/(inner)/home/page.tsx
@@ -7,6 +7,8 @@ import { HomeHeroSection } from "./HomeHeroSection/index";
 import { WorkGridSection } from "./WorkGridSection/index";
 import { BlogGridSection } from "./BlogGridSection/index";
 import { ServicesSection } from "./ServicesSection/index";
+import { HomeAboutSection } from "./HomeAboutSection";
+import { HomeImpactSection } from "./HomeImpactSection";
 
 export default async function Home() {
   const payload = await getPayloadHMR({ config: configPromise });
@@ -46,115 +48,12 @@ export default async function Home() {
   return (
     <>
       <HomeHeroSection />
-      <section className="bg-brand-dark-bg py-24 text-zinc-50">
-        <div className="container mx-auto px-4">
-          <div className="flex flex-col items-center">
-            <div className="grid grid-cols-12 py-16 sm:py-24 md:py-32">
-              <div className="col-span-9 col-start-1 text-headline-large leading-none">
-                From fast-growing startups to experienced companies, we deliver
-                functional design, high-quality code and well-thought strategy
-                to increase your odds of success in the digital world.
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
+      <HomeAboutSection />
       <WorkGridSection projects={projects.docs} />
       <ImageGrow />
       <ServicesSection services={services.docs} />
       <BlogGridSection posts={posts.docs} />
-      <section className="bg-brand-dark-bg py-16 text-zinc-50">
-        <div className="container mx-auto px-4">
-          <div className="grid auto-cols-fr grid-cols-[1fr_1fr_1fr] grid-rows-[1fr_1fr_1fr] gap-8">
-            <div
-              className="col-start-3 col-end-4 row-start-2 row-end-3 flex min-h-[20vw] flex-col justify-between gap-[6.50rem] overflow-hidden rounded-lg bg-brand-dark-surface p-6"
-              style={{ gridArea: "2 / 3 / 3 / 4" }}
-            >
-              <div className="text-right text-[5.88rem] font-medium leading-none">
-                <div>+26</div>
-              </div>
-              <div className="flex flex-col gap-[1.13rem]">
-                <div className="text-5xl font-medium">Awards</div>
-                <div className="text-base opacity-80">
-                  <div>
-                    Celebrating our commitment to excellence, innovation, and
-                    the transformative power of outstanding design.
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              className="col-start-1 col-end-2 row-start-1 row-end-2 flex min-h-[20vw] flex-col justify-between gap-[6.50rem] overflow-hidden rounded-lg bg-brand-dark-surface p-6"
-              style={{ gridArea: "1 / 1 / 2 / 2" }}
-            >
-              <div className="text-right text-[5.88rem] font-medium leading-none">
-                <div>2024</div>
-              </div>
-              <div className="flex flex-col gap-[1.13rem]">
-                <div className="text-5xl font-medium">Years of experience</div>
-                <div className="text-base opacity-80">
-                  <div>
-                    We elevated our design agency to new heights, embracing
-                    cutting-edge trends and innovative practices
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              className="col-start-3 col-end-4 row-start-1 row-end-2 flex min-h-[20vw] flex-col justify-between gap-[6.50rem] overflow-hidden rounded-lg bg-brand-dark-surface p-6"
-              style={{ gridArea: "1 / 3 / 2 / 4" }}
-            >
-              <div className="text-right text-[5.88rem] font-medium leading-none">
-                <div>137%</div>
-              </div>
-              <div className="flex flex-col gap-[1.13rem]">
-                <div className="text-5xl font-medium">Growth</div>
-                <div className="text-base opacity-80">
-                  <div>
-                    The trust our clients place in our ability to deliver
-                    exceptional design solutions.
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              className="col-start-2 col-end-3 row-start-2 row-end-3 flex min-h-[20vw] flex-col justify-between gap-[6.50rem] overflow-hidden rounded-lg bg-brand-dark-surface p-6"
-              style={{ gridArea: "2 / 2 / 3 / 3" }}
-            >
-              <div className="text-right text-[5.88rem] font-medium leading-none">
-                <div>+30</div>
-              </div>
-              <div className="flex flex-col gap-[1.13rem]">
-                <div className="text-5xl font-medium">Clients</div>
-                <div className="text-base opacity-80">
-                  <div>
-                    Bringing unique challenges that have enriched our creative
-                    journey and expanded our industry impact.
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              className="col-start-2 col-end-3 row-start-3 row-end-4 flex min-h-[20vw] flex-col justify-between gap-[6.50rem] overflow-hidden rounded-lg bg-brand-dark-surface p-6"
-              style={{ gridArea: "3 / 2 / 4 / 3" }}
-            >
-              <div className="text-right text-[5.88rem] font-medium leading-none">
-                <div>+56</div>
-              </div>
-              <div className="flex flex-col gap-[1.13rem]">
-                <div className="text-5xl font-medium">Cases</div>
-                <div className="text-base opacity-80">
-                  <div>
-                    Our diverse project experience showcases our ability to
-                    tailor bespoke solutions that drive success
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
+      <HomeImpactSection />
       <section className="bg-brand-dark-bg text-zinc-50">
         <div className="relative content-stretch items-start justify-start px-24 py-48 font-light">
           <div className="relative m-auto flex w-full max-w-[62.50rem] flex-grow auto-cols-fr grid-cols-[1fr_1fr] grid-rows-[auto_auto] flex-col items-stretch justify-center self-start">

--- a/src/app/(frontend)/(inner)/services/page.tsx
+++ b/src/app/(frontend)/(inner)/services/page.tsx
@@ -17,7 +17,7 @@ export default function ServicesPage() {
               </div>
               <div className="max-w-6xl">
                 {" "}
-                <Title level="h1" size="display-small">
+                <Title el="h1" size="display-small">
                   The talent, tools, and deliverables to spark action for your
                   brand.
                 </Title>
@@ -627,12 +627,6 @@ export default function ServicesPage() {
         </div>
         <div className="m-auto w-[92%] pt-24 min-[1921px]:max-w-[118.75rem]">
           <div className="relative">
-            <div className="mb-4 flex items-center">
-              <span className="mr-2 inline-block h-2 w-2 rounded-full bg-brand-dark-bg"></span>
-              <span className="text-md font-medium uppercase">
-                Related Projects
-              </span>
-            </div>
             <ul className="list-none flex-wrap min-[769px]:flex">
               <li className="relative list-item min-[769px]:w-[48.2105%]">
                 <span className="absolute left-0 top-0 z-[2] w-full text-lg uppercase text-white min-[1025px]:p-8">
@@ -709,7 +703,7 @@ export default function ServicesPage() {
                     >
                       <span className="relative cursor-pointer lg:pb-1.5 lg:pl-3.5 lg:pr-3.5 lg:pt-1.5 min-[1025px]:pb-1.5 min-[1025px]:pl-3.5 min-[1025px]:pr-3.5 min-[1025px]:pt-1.5">
                         View
-                        <span className="absolute left-0 top-full w-full rounded-tl-full rounded-tr-full bg-white lg:pb-1.5 lg:pl-3.5 lg:pr-3.5 lg:pt-1.5 min-[1025px]:pb-1.5 min-[1025px]:pl-3.5 min-[1025px]:pr-3.5 min-[1925px]:pt-1.5" />
+                        <span className="absolute left-0 top-full w-full rounded-tl-full rounded-tr-full bg-white lg:pb-1.5 lg:pl-3.5 lg:pr-3.5 lg:pt-1.5 min-[1025px]:pb-1.5 min-[1025px]:pl-3.5 min-[1025px]:pr-3.5 min-[1025px]:pt-1.5" />
                       </span>
                     </Link>
                   </div>

--- a/src/components/BlogCard/index.tsx
+++ b/src/components/BlogCard/index.tsx
@@ -30,7 +30,7 @@ export const BlogCard = ({ post }: { post: Post }) => {
           </span>
           <span className="ml-2">/ {post.readTime} min read</span>
         </Text>
-        <Title level="h3" size="title-medium" className="leading-none">
+        <Title el="h3" size="title-medium" className="leading-none">
           {post.title}
         </Title>
       </div>

--- a/src/components/ImpactCard/index.tsx
+++ b/src/components/ImpactCard/index.tsx
@@ -1,0 +1,52 @@
+import { Title } from "@/components/Title";
+import { Text } from "@/components/Text";
+
+interface ImpactCardProps {
+  value: string;
+  title: string;
+  description: string;
+  size?:
+    | "display-large"
+    | "display-medium"
+    | "display-small"
+    | "headline-large"
+    | "headline-medium"
+    | "headline-small";
+  descriptionSize?:
+    | "body-large"
+    | "body-medium"
+    | "body-small"
+    | "label-large"
+    | "label-medium"
+    | "label-small";
+}
+
+export const ImpactCard = ({
+  value,
+  title,
+  description,
+  size = "headline-large",
+  descriptionSize = "body-medium",
+}: ImpactCardProps) => {
+  return (
+    <div className="flex min-h-[20vw] flex-col justify-between gap-[6.50rem] overflow-hidden rounded-lg bg-brand-dark-surface p-6">
+      <div className="text-right">
+        <Title
+          el="h4"
+          size={size}
+          className="font-medium leading-none text-zinc-50"
+        >
+          {value}
+        </Title>
+      </div>
+      <div className="flex flex-col gap-[1.13rem]">
+        <Title el="h3" size={size} className="text-zinc-50">
+          {title}
+        </Title>
+        <Text el="p" size={descriptionSize} className="text-zinc-50 opacity-80">
+          {description}
+        </Text>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
-import { twMerge } from "tailwind-merge";
+import { cn } from "@/utilities/cn";
 
 // Text component following Material Design type scale from Tailwind config
 const textVariants = cva(
@@ -60,7 +60,7 @@ export function Text({
 
   return (
     <Component
-      className={twMerge(
+      className={cn(
         textVariants({ 
           level, 
           size, 

--- a/src/components/Title/index.tsx
+++ b/src/components/Title/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
-import { twMerge } from "tailwind-merge";
+import { cn } from "@/utilities/cn";
 
 // Type scale following Material Design. Update settings in the Tailwind config.
 const headingVariants = cva(
@@ -55,25 +55,25 @@ const headingVariants = cva(
 );
 
 interface TitleProps extends VariantProps<typeof headingVariants> {
-  level?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+  el?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
   children?: React.ReactNode;
   className?: string;
 }
 
 export const Title: React.FC<TitleProps> = ({
-  level = "h2",
+  el = "h2",
   size = "headline-large",
   weight,
   children,
   className,
 }) => {
-  const Component = level;
+  const Component = el;
 
   return (
     <Component
-      className={twMerge(
+      className={cn(
         headingVariants({
-          level,
+          level: el,
           size,
           weight,
         }),

--- a/src/components/WorkCard/index.tsx
+++ b/src/components/WorkCard/index.tsx
@@ -65,7 +65,7 @@ export function WorkCard({ project }: WorkCardProps) {
         </div>
 
         <Title
-          level="h3"
+          el="h3"
           size="title-medium"
           className="max-w-2xl leading-none"
         >


### PR DESCRIPTION
### TL;DR

Refactored homepage sections and introduced reusable components for improved maintainability and consistency.

### What changed?

- Created new `HomeAboutSection` and `HomeImpactSection` components
- Introduced new `ImpactCard` component for displaying statistics and metrics
- Updated `Title` component to use `el` prop instead of `level`
- Replaced hardcoded text elements with `Text` and `Title` components
- Switched from `twMerge` to `cn` utility for className handling
- Removed "Related Projects" section header from services page

### How to test?

1. Navigate to the homepage and verify all sections render correctly
2. Check responsive behavior of the Impact cards grid layout
3. Verify typography styling and hierarchy across all sections
4. Ensure all links and interactions work as expected
5. Test responsive layouts across different screen sizes

### Why make this change?

- Improves code organization by extracting sections into dedicated components
- Enhances maintainability through consistent component usage
- Standardizes typography implementation across the application
- Makes the codebase more modular and easier to update
- Ensures consistent styling and layout patterns