### PR TITLE
chore(deps): install latest motion dev version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "eslint-plugin-react-compiler": "0.0.0-experimental-75b9fd4-20240912",
-    "framer-motion": "^11.11.17",
+    "framer-motion": "12.0.0-alpha.1",
     "graphql": "^16.9.0",
     "gsap": "^3.12.5",
     "jsonwebtoken": "9.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         specifier: 0.0.0-experimental-75b9fd4-20240912
         version: 0.0.0-experimental-75b9fd4-20240912(eslint@8.57.1)
       framer-motion:
-        specifier: ^11.11.17
-        version: 11.11.17(react-dom@19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021))(react@19.0.0-rc-69d4b800-20241021)
+        specifier: 12.0.0-alpha.1
+        version: 12.0.0-alpha.1(react-dom@19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021))(react@19.0.0-rc-69d4b800-20241021)
       graphql:
         specifier: ^16.9.0
         version: 16.9.0
@@ -3366,8 +3366,8 @@ packages:
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
-  framer-motion@11.11.17:
-    resolution: {integrity: sha512-O8QzvoKiuzI5HSAHbcYuL6xU+ZLXbrH7C8Akaato4JzQbX2ULNeniqC2Vo5eiCtFktX9XsJ+7nUhxcl2E2IjpA==}
+  framer-motion@12.0.0-alpha.1:
+    resolution: {integrity: sha512-WpMrDfk6I5Q4T/7+LEjQOVbAD5Yb/cGbbV+LLllFEg+dHi8XZ7QecJ9aYS9bn12cWuF7gGy+uqskyAkGTWHs3w==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0
@@ -9829,7 +9829,7 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
-  framer-motion@11.11.17(react-dom@19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021))(react@19.0.0-rc-69d4b800-20241021):
+  framer-motion@12.0.0-alpha.1(react-dom@19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021))(react@19.0.0-rc-69d4b800-20241021):
     dependencies:
       tslib: 2.8.0
     optionalDependencies:


### PR DESCRIPTION
### TL;DR
Upgraded framer-motion from v11.11.17 to v12.0.0-alpha.1

### What changed?
- Updated framer-motion dependency to the latest alpha release (12.0.0-alpha.1)
- Updated corresponding lockfile entries to reflect the new version

### How to test?
1. Run `pnpm install` to update dependencies
2. Verify all animations and motion components continue to work as expected
3. Check for any console warnings or errors related to framer-motion
4. Test all interactive components that use motion animations

### Why make this change?
To take advantage of the latest features and improvements in framer-motion's alpha release. This update allows early testing of upcoming features and ensures compatibility with future releases.