### PR TITLE
fix(header): repair file path for logo

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -29,7 +29,7 @@ export default function Header() {
               <Link href="/home">
                 <Image
                   className="w-36 max-w-full cursor-pointer"
-                  src="/images/brewww-logotype-gold.png"
+                  src="/images/brand/brewww-logotype-gold.png"
                   alt="Brewww Logo"
                   width={144}
                   height={40}


### PR DESCRIPTION
### TL;DR
Updated the logo image path to reference the new brand directory structure

### What changed?
Modified the logo image source path from `/images/brewww-logotype-gold.png` to `/images/brand/brewww-logotype-gold.png`

### How to test?
1. Navigate to any page with the header component
2. Verify the Brewww logo appears correctly
3. Confirm no broken image icons are displayed

### Why make this change?
Reorganizes image assets to follow a more structured directory pattern, placing brand-related assets in a dedicated folder for better asset management