### PR TITLE
fix(forms): update checkbox UI import statement

### DIFF
--- a/src/blocks/Form/Checkbox/index.tsx
+++ b/src/blocks/Form/Checkbox/index.tsx
@@ -3,7 +3,7 @@ import type { FieldErrorsImpl, FieldValues, UseFormRegister } from 'react-hook-f
 
 import { useFormContext } from 'react-hook-form'
 
-import { Checkbox as CheckboxUi } from '@/components/ui/Checkbox'
+import { Checkbox as CheckboxUi } from '@/components/ui/Checkbox/index'
 import { Label } from '@/components/ui/Label'
 import React from 'react'
 


### PR DESCRIPTION
### TL;DR
Updated import path for Checkbox component to include explicit index file reference

### What changed?
Modified the import statement for the Checkbox UI component to use the full path including `/index`

### How to test?
1. Verify that the Checkbox component still renders correctly in forms
2. Ensure no TypeScript errors are present
3. Confirm that form functionality remains intact

### Why make this change?
To maintain consistent import paths and prevent potential bundling issues by explicitly referencing the index file. This helps ensure reliable module resolution across different build environments.