### PR TITLE
refactor(location): use Button component where appropriate and remove unneeded styles

### DIFF
--- a/src/app/(frontend)/(inner)/location/[slug]/LocationFAQ/index.tsx
+++ b/src/app/(frontend)/(inner)/location/[slug]/LocationFAQ/index.tsx
@@ -1,6 +1,7 @@
 import { AccordionCard } from "@/components/AccordionCard";
 import { Faq } from "@/payload-types";
 import { Title } from "@/components/Title";
+import { Button } from "@/components/Button";
 
 export function LocationFAQ({ faqs }: { faqs: Faq[] }) {
   return (
@@ -25,48 +26,13 @@ export function LocationFAQ({ faqs }: { faqs: Faq[] }) {
                   The answers to your questions.
                 </Title>
                 <div className="relative mt-8 inline-flex items-center">
-                  <a
-                    className="inline-flex"
-                    href=""
-                    style={{
-                      outlineOffset: "2px",
-                    }}
-                  >
-                    <div className="inline-flex w-auto cursor-pointer items-center justify-center overflow-hidden rounded-full bg-brand-gold px-5 py-2">
-                      <div className="inline-flex">View all FAQs</div>
-                    </div>
-                    <div className="-ml-1 flex h-9 w-9 cursor-pointer items-center justify-center overflow-hidden rounded-full bg-brand-gold" />
-                  </a>
-                  <div className="absolute right-0 top-0 z-20 flex h-9 w-9 items-center justify-center">
-                    <div className="relative overflow-hidden">
-                      <div>
-                        <svg
-                          className="h-3 w-3"
-                          fill="rgb(1, 2, 2)"
-                          viewBox="0 0 384 512"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M328 96h24v288h-48V177.9L81 401l-17 17-33.9-34 17-17 223-223H64V96h264z"
-                            fill="rgb(1, 2, 2)"
-                          />
-                        </svg>
-                      </div>
-                      <div className="absolute left-0 top-0">
-                        <svg
-                          className="h-3 w-3"
-                          fill="rgb(1, 2, 2)"
-                          viewBox="0 0 384 512"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M328 96h24v288h-48V177.9L81 401l-17 17-33.9-34 17-17 223-223H64V96h264z"
-                            fill="rgb(1, 2, 2)"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
+                  <Button
+                    label="View all FAQs"
+                    intent="primary"
+                    size="default"
+                    icon="arrow"
+                    iconPosition="right"
+                  />
                 </div>
               </div>
             </div>

--- a/src/app/(frontend)/(inner)/location/[slug]/LocationImageLeft/index.tsx
+++ b/src/app/(frontend)/(inner)/location/[slug]/LocationImageLeft/index.tsx
@@ -1,8 +1,9 @@
 import Image from 'next/image'
+import { Button } from '@/components/Button'
 
 export function LocationImageLeft() {
   return (
-    <section className="bg-brand-dark-bg px-2 py-10 text-black sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20 min-[1800px]:pl-40 min-[1800px]:pr-40">
+    <section className="bg-brand-dark-bg px-2 py-10 text-black sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20">
       <div className="flex w-full flex-col lg:flex-row lg:justify-between">
         <div className="relative mb-10 inline-flex w-full px-2 lg:mb-0 lg:w-2/4 lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
           <div className="relative w-full pb-[100%] md:pb-[56.25%] lg:h-full lg:pb-0">
@@ -105,50 +106,13 @@ export function LocationImageLeft() {
               </div>
             </div>
             <div className="relative mt-8 inline-flex items-center">
-              <a
-                className="inline-flex"
-                href=""
-                style={{
-                  outlineOffset: '2px',
-                  outlineStyle: 'solid',
-                  outlineWidth: '2px',
-                }}
-              >
-                <div className="inline-flex w-auto cursor-pointer items-center justify-center overflow-hidden rounded-full bg-brand-gold px-5 py-2">
-                  <div className="inline-flex">Schedule a call with our team</div>
-                </div>
-                <div className="-ml-1 flex h-9 w-9 cursor-pointer items-center justify-center overflow-hidden rounded-full bg-brand-gold" />
-              </a>
-              <div className="absolute right-0 top-0 z-20 flex h-9 w-9 items-center justify-center">
-                <div className="relative overflow-hidden">
-                  <div>
-                    <svg
-                      className="h-3 w-3"
-                      fill="rgb(1, 2, 2)"
-                      viewBox="0 0 384 512"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M328 96h24v288h-48V177.9L81 401l-17 17-33.9-34 17-17 223-223H64V96h264z"
-                        fill="rgb(1, 2, 2)"
-                      />
-                    </svg>
-                  </div>
-                  <div className="absolute left-0 top-0">
-                    <svg
-                      className="h-3 w-3"
-                      fill="rgb(1, 2, 2)"
-                      viewBox="0 0 384 512"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M328 96h24v288h-48V177.9L81 401l-17 17-33.9-34 17-17 223-223H64V96h264z"
-                        fill="rgb(1, 2, 2)"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
+              <Button
+                label="Schedule a call with our team"
+                intent="primary"
+                size="default"
+                icon="arrow"
+                iconPosition="right"
+              />
             </div>
           </div>
         </div>

--- a/src/app/(frontend)/(inner)/location/[slug]/LocationImageRight/index.tsx
+++ b/src/app/(frontend)/(inner)/location/[slug]/LocationImageRight/index.tsx
@@ -1,8 +1,9 @@
 import Image from 'next/image'
+import { Button } from '@/components/Button'
 
 export function LocationImageRight() {
   return (
-    <section className="bg-brand-dark-bg px-2 py-20 text-black sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20 min-[1800px]:pl-40 min-[1800px]:pr-40">
+    <section className="bg-brand-dark-bg px-2 py-20 text-black sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20">
       <div className="flex w-full flex-col lg:flex-row-reverse lg:justify-between">
         <div className="relative mb-10 inline-flex w-full px-2 lg:mb-0 lg:w-2/4 lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
           <div className="relative w-full pb-[100%] md:pb-[56.25%] lg:h-full lg:pb-0">
@@ -65,50 +66,13 @@ export function LocationImageRight() {
               </p>
             </div>
             <div className="relative mt-8 inline-flex items-center">
-              <a
-                className="inline-flex"
-                href=""
-                style={{
-                  outlineOffset: '2px',
-                  outlineStyle: 'solid',
-                  outlineWidth: '2px',
-                }}
-              >
-                <div className="inline-flex w-auto cursor-pointer items-center justify-center overflow-hidden rounded-full bg-brand-gold px-5 py-2">
-                  <div className="inline-flex">Start a project today</div>
-                </div>
-                <div className="-ml-1 flex h-9 w-9 cursor-pointer items-center justify-center overflow-hidden rounded-full bg-brand-gold" />
-              </a>
-              <div className="absolute right-0 top-0 z-20 flex h-9 w-9 items-center justify-center">
-                <div className="relative overflow-hidden">
-                  <div>
-                    <svg
-                      className="h-3 w-3"
-                      fill="rgb(1, 2, 2)"
-                      viewBox="0 0 384 512"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M328 96h24v288h-48V177.9L81 401l-17 17-33.9-34 17-17 223-223H64V96h264z"
-                        fill="rgb(1, 2, 2)"
-                      />
-                    </svg>
-                  </div>
-                  <div className="absolute left-0 top-0">
-                    <svg
-                      className="h-3 w-3"
-                      fill="rgb(1, 2, 2)"
-                      viewBox="0 0 384 512"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M328 96h24v288h-48V177.9L81 401l-17 17-33.9-34 17-17 223-223H64V96h264z"
-                        fill="rgb(1, 2, 2)"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
+              <Button
+                label="Start a project today"
+                intent="primary"
+                size="default"
+                icon="arrow"
+                iconPosition="right"
+              />
             </div>
           </div>
         </div>

--- a/src/app/(frontend)/(inner)/location/[slug]/LocationLogoSlider/index.tsx
+++ b/src/app/(frontend)/(inner)/location/[slug]/LocationLogoSlider/index.tsx
@@ -4,6 +4,7 @@
 import Image from 'next/image'
 import React from 'react'
 import { motion } from 'framer-motion'
+import { Button } from '@/components/Button'
 
 // Payload Imports
 import { Brand, Media } from '@/payload-types'
@@ -55,9 +56,9 @@ export function LocationLogoSlider({ brands }: LocationLogoSliderProps) {
   }, [brands])
 
   return (
-    <section className="w-full bg-brand-dark-bg px-2 pb-20 text-black lg:pb-24 lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4 min-[1450px]:pb-32 min-[2100px]:pb-40">
-      <div className="px-2 sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20 min-[1800px]:pl-40 min-[1800px]:pr-40 min-[2100px]:pl-60 min-[2100px]:pr-60">
-        <div className="relative w-full overflow-hidden rounded-bl-3xl rounded-br-3xl rounded-tr-3xl bg-zinc-900 py-20 lg:pb-24 lg:pt-24 min-[1450px]:pb-32 min-[1450px]:pt-32 min-[2100px]:pb-40 min-[2100px]:pt-40">
+    <section className="w-full bg-brand-dark-bg px-2 pb-20 text-black lg:pb-24 lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4 min-[1450px]:pb-32">
+      <div className="px-2 sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20">
+        <div className="relative w-full overflow-hidden rounded-bl-3xl rounded-br-3xl rounded-tr-3xl bg-zinc-900 py-20 lg:pb-24 lg:pt-24 min-[1450px]:pb-32 min-[1450px]:pt-32">
           <div>
             <div className="absolute left-0 top-0 h-12 w-[31.25%] bg-neutral-950 text-neutral-950 lg:h-20 lg:w-72">
               <svg
@@ -86,7 +87,7 @@ export function LocationLogoSlider({ brands }: LocationLogoSliderProps) {
               </svg>
             </div>
 
-            <div className="flex w-full flex-wrap px-2 sm:pl-6 sm:pr-6 lg:justify-end xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20 min-[1800px]:pl-40 min-[1800px]:pr-40 min-[2100px]:pl-60 min-[2100px]:pr-60">
+            <div className="flex w-full flex-wrap px-2 sm:pl-6 sm:pr-6 lg:justify-end xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20">
               <div className="flex w-auto flex-col items-start px-2 lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
                 <div className="flex flex-col items-start">
                   <div className="inline-flex items-center">
@@ -99,48 +100,13 @@ export function LocationLogoSlider({ brands }: LocationLogoSliderProps) {
                 </div>
                 <div className="mt-5 flex">
                   <div className="relative inline-flex items-center">
-                    <a
-                      className="inline-flex"
-                      href=""
-                      style={{
-                        outlineOffset: '2px',
-                      }}
-                    >
-                      <div className="inline-flex w-auto cursor-pointer items-center justify-center overflow-hidden rounded-full bg-brand-gold px-5 py-2">
-                        <div className="inline-flex">Join them</div>
-                      </div>
-                      <div className="-ml-1 flex h-9 w-9 cursor-pointer items-center justify-center overflow-hidden rounded-full bg-brand-gold" />
-                    </a>
-                    <div className="absolute right-0 top-0 z-20 flex h-9 w-9 items-center justify-center">
-                      <div className="relative overflow-hidden">
-                        <div>
-                          <svg
-                            className="h-3 w-3"
-                            fill="rgb(1, 2, 2)"
-                            viewBox="0 0 384 512"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M328 96h24v288h-48V177.9L81 401l-17 17-33.9-34 17-17 223-223H64V96h264z"
-                              fill="rgb(1, 2, 2)"
-                            />
-                          </svg>
-                        </div>
-                        <div className="absolute left-0 top-0">
-                          <svg
-                            className="h-3 w-3"
-                            fill="rgb(1, 2, 2)"
-                            viewBox="0 0 384 512"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M328 96h24v288h-48V177.9L81 401l-17 17-33.9-34 17-17 223-223H64V96h264z"
-                              fill="rgb(1, 2, 2)"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
+                    <Button
+                      label="Join them"
+                      intent="primary"
+                      size="default"
+                      icon="arrow"
+                      iconPosition="right"
+                    />
                   </div>
                 </div>
               </div>

--- a/src/app/(frontend)/(inner)/location/[slug]/LocationWorkSlider/index.tsx
+++ b/src/app/(frontend)/(inner)/location/[slug]/LocationWorkSlider/index.tsx
@@ -1,6 +1,7 @@
 import { WorkCard } from "@/components/WorkCard";
 import { Title } from "@/components/Title";
 import { Work } from "@/payload-types";
+import { Button } from "@/components/Button";
 
 interface LocationWorkSliderProps {
   workItems: Work[];
@@ -10,7 +11,7 @@ export function LocationWorkSlider({ workItems }: LocationWorkSliderProps) {
   return (
     <>
       <section className="flex w-full flex-wrap bg-brand-dark-bg py-24 text-black">
-        <div className="mb-10 flex w-full flex-wrap items-end justify-between px-2 sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20 min-[1800px]:pl-40 min-[1800px]:pr-40 min-[2100px]:pl-60 min-[2100px]:pr-60">
+        <div className="mb-10 flex w-full flex-wrap items-end justify-between px-2 sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20">
           <div className="w-[87.5%] px-2 lg:w-auto lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
             <div className="flex flex-col items-start">
               <div className="inline-flex items-center">
@@ -29,48 +30,14 @@ export function LocationWorkSlider({ workItems }: LocationWorkSliderProps) {
           </div>
           <div className="mt-3 w-full px-2 lg:mt-0 lg:w-auto lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
             <div className="relative inline-flex items-center">
-              <a
-                className="inline-flex"
+              <Button
+                label="View our work"
+                intent="primary"
+                size="default"
+                icon="arrow"
+                iconPosition="right"
                 href="#"
-                style={{
-                  outlineOffset: "2px",
-                }}
-              >
-                <div className="inline-flex w-auto cursor-pointer items-center justify-center overflow-hidden rounded-full bg-brand-gold px-5 py-2">
-                  <div className="inline-flex">View our work</div>
-                </div>
-                <div className="-ml-1 flex h-9 w-9 cursor-pointer items-center justify-center overflow-hidden rounded-full bg-brand-gold" />
-              </a>
-              <div className="absolute right-0 top-0 z-20 flex h-9 w-9 items-center justify-center">
-                <div className="relative overflow-hidden">
-                  <div>
-                    <svg
-                      className="h-3 w-3"
-                      fill="rgb(1, 2, 2)"
-                      viewBox="0 0 384 512"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M328 96h24v288h-48V177.9L81 401l-17 17-33.9-34 17-17 223-223H64V96h264z"
-                        fill="rgb(1, 2, 2)"
-                      />
-                    </svg>
-                  </div>
-                  <div className="absolute left-0 top-0">
-                    <svg
-                      className="h-3 w-3"
-                      fill="rgb(1, 2, 2)"
-                      viewBox="0 0 384 512"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M328 96h24v288h-48V177.9L81 401l-17 17-33.9-34 17-17 223-223H64V96h264z"
-                        fill="rgb(1, 2, 2)"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
### TL;DR
Replaced custom button implementations with the reusable Button component across location page sections.

### What changed?
- Integrated the Button component in LocationFAQ, LocationImageLeft, LocationImageRight, LocationLogoSlider, and LocationWorkSlider
- Removed redundant SVG arrow implementations and custom button styling
- Standardized button appearance with consistent props (intent, size, icon, iconPosition)
- Simplified padding classes by removing unnecessary breakpoints above 1450px

### How to test?
1. Navigate to any location page
2. Verify buttons appear and function correctly in:
   - FAQ section ("View all FAQs")
   - Left image section ("Schedule a call with our team")
   - Right image section ("Start a project today")
   - Logo slider section ("Join them")
   - Work slider section ("View our work")
3. Confirm buttons maintain consistent styling and hover states
4. Check that arrow icons appear correctly on the right side of each button

### Why make this change?
This change improves maintainability and consistency by utilizing a single Button component instead of duplicating button markup across multiple files. It reduces code complexity, ensures consistent styling, and makes future button-related changes easier to implement.