### PR TITLE
feat(ui): add base styles to global css

### DIFF
--- a/src/components/Title/index.tsx
+++ b/src/components/Title/index.tsx
@@ -1,73 +1,74 @@
-import React from "react";
-import { cva, type VariantProps } from "class-variance-authority";
-import { cn } from "@/utilities/cn";
+import React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/utilities/cn'
 
 // Type scale following Material Design. Update settings in the Tailwind config.
 const headingVariants = cva(
-  // Base styles
-  "font-default tracking-tight leading-none",
+  // Base styles - removed font-default as it's not defined
+  'tracking-tight leading-none',
   {
     variants: {
       level: {
-        h1: "", // Default heading level class
-        h2: "",
-        h3: "",
-        h4: "",
-        h5: "",
-        h6: "",
-        p: "",
+        h1: '', // Using font-sans instead of font-default
+        h2: '',
+        h3: '',
+        h4: '',
+        h5: '',
+        h6: '',
+        p: '',
       },
       size: {
         // Display sizes
-        "display-large": "text-display-large",
-        "display-medium": "text-display-medium",
-        "display-small": "text-display-small",
+        'display-large': 'text-display-large',
+        'display-medium': 'text-display-medium',
+        'display-small': 'text-display-small',
 
         // Headline sizes
-        "headline-large": "text-headline-large",
-        "headline-medium": "text-headline-medium",
-        "headline-small": "text-headline-small",
+        'headline-large': 'text-headline-large',
+        'headline-medium': 'text-headline-medium',
+        'headline-small': 'text-headline-small',
 
         // Title sizes
-        "title-large": "text-title-large",
-        "title-medium": "text-title-medium",
-        "title-small": "text-title-small",
+        'title-large': 'text-title-large',
+        'title-medium': 'text-title-medium',
+        'title-small': 'text-title-small',
       },
-
       weight: {
-        regular: "font-normal",
-        medium: "font-medium",
-        semibold: "font-semibold",
-        bold: "font-bold",
+        regular: 'font-normal',
+        medium: 'font-medium',
+        semibold: 'font-semibold',
+        bold: 'font-bold',
       },
     },
     defaultVariants: {
-      weight: "regular",
+      weight: 'regular',
+      size: 'headline-large',
+      level: 'h2',
     },
     compoundVariants: [
       {
-        size: ["display-large", "display-medium", "display-small"],
-        weight: "regular",
-        className: "font-normal tracking-tighter",
+        size: ['display-large', 'display-medium', 'display-small'],
+        weight: 'regular',
+        className: 'font-normal tracking-tighter',
       },
     ],
   },
-);
+)
 
 interface TitleProps extends VariantProps<typeof headingVariants> {
-  el?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
-  children?: React.ReactNode;
-  className?: string;
+  el?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+  children?: React.ReactNode
+  className?: string
 }
 
 export const Title: React.FC<TitleProps> = ({
-  el = "h2",
-  size = "headline-large",
+  el = 'h2',
+  size = 'headline-large',
   weight,
   children,
   className,
 }) => {
-  const Component = el;
+  const Component = el
 
   return (
     <Component
@@ -82,5 +83,5 @@ export const Title: React.FC<TitleProps> = ({
     >
       {children}
     </Component>
-  );
-};
+  )
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,20 +2,52 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Base HTML styles */
 html {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  scroll-behavior: smooth;
+  text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
 }
 
-@keyframes marquee-reverse {
-  0% {
-    transform: translateX(0);
-  }
-  100% {
-    transform: translateX(-100%);
-  }
+body {
+  min-height: 100vh;
+  text-rendering: optimizeSpeed;
+  line-height: 1.5;
 }
 
-.animate-marquee-reverse {
-  animation: marquee-reverse 80s linear infinite;
+/* Remove default margin and padding */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+/* Make images easier to work with */
+img,
+picture,
+video,
+canvas,
+svg {
+  display: block;
+  max-width: 100%;
+}
+
+/* Remove built-in form typography styles */
+input,
+button,
+textarea,
+select {
+  font: inherit;
+}
+
+/* Avoid text overflows */
+p, h1, h2, h3, h4, h5, h6 {
+  overflow-wrap: break-word;
+}
+
+/* Create a root stacking context */
+#root, #__next {
+  isolation: isolate;
 }


### PR DESCRIPTION
### TL;DR
Removed font-default class and enhanced global CSS styles with modern best practices.

### What changed?
- Removed `font-default` class from Title component as it wasn't defined
- Added default variants for size and level in Title component
- Enhanced global CSS with modern reset styles including:
  - Improved font smoothing and text size adjustments
  - Better image and media element handling
  - Form element typography normalization
  - Text overflow protection
  - Proper stacking context for root elements
- Removed unused marquee animation styles

### How to test?
1. Check that Title component renders correctly with default styling
2. Verify text rendering and smoothing across different browsers
3. Test form elements maintain consistent typography
4. Confirm images and media elements scale properly
5. Verify text wrapping works correctly on all heading levels

### Why make this change?
To improve the foundation of our styling system by implementing modern CSS reset practices and removing unused code. These changes provide better cross-browser consistency and improved accessibility while maintaining a cleaner codebase.