### PR TITLE
feat(ui): improve CSS specificity of Title component

### DIFF
--- a/src/app/(frontend)/(inner)/location/[slug]/LocationHeroDetails/index.tsx
+++ b/src/app/(frontend)/(inner)/location/[slug]/LocationHeroDetails/index.tsx
@@ -1,0 +1,187 @@
+export function LocationHeroDetails() {
+  return (
+    <section className="w-full bg-brand-dark-bg py-20 text-black lg:pb-24 lg:pt-24 min-[1450px]:pb-32 min-[1450px]:pt-32">
+      <div className="px-2 sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20">
+        <div className="flex w-full flex-wrap justify-between">
+          <div className="relative mb-10 w-full px-2 lg:mb-0 lg:w-[56.25%] lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
+            <div className="flex flex-col items-start">
+              <div className="inline-flex w-auto items-center lg:absolute lg:left-[1.00rem] lg:top-[1.75rem]">
+                <div className="h-1.5 w-1.5 rounded-full bg-white" />
+                <div className="ml-2 font-light text-white">Web Design</div>
+              </div>
+              <h2 className="mb-5 mt-3 indent-48 text-6xl text-white lg:mb-0 lg:mt-5">
+                Are you a startup brand, well established company, in the US or worldwide? It
+                doesn't matter. We work with a range of clients.
+              </h2>
+              <div className="relative mb-0 mt-3 inline-flex items-center lg:mb-0 lg:mt-5">
+                <a
+                  className="inline-flex"
+                  href=""
+                  style={{
+                    outlineOffset: '2px',
+                    outlineStyle: 'solid',
+                    outlineWidth: '2px',
+                  }}
+                >
+                  <div className="inline-flex w-auto cursor-pointer items-center justify-center overflow-hidden rounded-full bg-brand-gold px-5 py-2">
+                    <div className="inline-flex">About Brewww</div>
+                  </div>
+                  <div className="-ml-1 flex h-9 w-9 cursor-pointer items-center justify-center overflow-hidden rounded-full bg-brand-gold" />
+                </a>
+                <div className="absolute right-0 top-0 z-20 flex h-9 w-9 items-center justify-center">
+                  <div className="relative overflow-hidden">
+                    <div>
+                      <svg
+                        className="h-3 w-3"
+                        fill="rgb(1, 2, 2)"
+                        viewBox="0 0 384 512"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M328 96h24v288h-48V177.9L81 401l-17 17-33.9-34 17-17 223-223H64V96h264z"
+                          fill="rgb(1, 2, 2)"
+                        />
+                      </svg>
+                    </div>
+                    <div className="absolute left-0 top-0">
+                      <svg
+                        className="h-3 w-3"
+                        fill="rgb(1, 2, 2)"
+                        viewBox="0 0 384 512"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M328 96h24v288h-48V177.9L81 401l-17 17-33.9-34 17-17 223-223H64V96h264z"
+                          fill="rgb(1, 2, 2)"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="w-full px-2 lg:w-1/4 lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
+            <div className="mb-5 text-sm font-light text-neutral-400">Our Website Capabilities</div>
+            <div className="w-full">
+              <div className="mb-3 w-full">
+                <div className="flex">
+                  <div className="mt-0 flex h-5 w-5 items-center justify-center rounded-full bg-brand-gold text-neutral-950">
+                    <svg
+                      className="h-3 w-3"
+                      fill="rgb(14, 15, 17)"
+                      height="16"
+                      viewBox="0 0 448 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M447.9 142.5l-23.2 22L181 395.3l-22 20.8-22-20.8L23.2 287.6 0 265.6l44-46.5 23.2 22L159 328l221.7-210 23.2-22 44 46.5z"
+                        fill="rgb(14, 15, 17)"
+                      />
+                    </svg>
+                  </div>
+                  <div className="ml-5 font-light text-white">Web Design</div>
+                </div>
+              </div>
+              <div className="mb-3 w-full">
+                <div className="flex">
+                  <div className="mt-0 flex h-5 w-5 items-center justify-center rounded-full bg-brand-gold text-neutral-950">
+                    <svg
+                      className="h-3 w-3"
+                      fill="rgb(14, 15, 17)"
+                      height="16"
+                      viewBox="0 0 448 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M447.9 142.5l-23.2 22L181 395.3l-22 20.8-22-20.8L23.2 287.6 0 265.6l44-46.5 23.2 22L159 328l221.7-210 23.2-22 44 46.5z"
+                        fill="rgb(14, 15, 17)"
+                      />
+                    </svg>
+                  </div>
+                  <div className="ml-5 font-light text-white">eCommerce</div>
+                </div>
+              </div>
+              <div className="mb-3 w-full">
+                <div className="flex">
+                  <div className="mt-0 flex h-5 w-5 items-center justify-center rounded-full bg-brand-gold text-neutral-950">
+                    <svg
+                      className="h-3 w-3"
+                      fill="rgb(14, 15, 17)"
+                      height="16"
+                      viewBox="0 0 448 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M447.9 142.5l-23.2 22L181 395.3l-22 20.8-22-20.8L23.2 287.6 0 265.6l44-46.5 23.2 22L159 328l221.7-210 23.2-22 44 46.5z"
+                        fill="rgb(14, 15, 17)"
+                      />
+                    </svg>
+                  </div>
+                  <div className="ml-5 font-light text-white">UX Design</div>
+                </div>
+              </div>
+              <div className="mb-3 w-full">
+                <div className="flex">
+                  <div className="mt-0 flex h-5 w-5 items-center justify-center rounded-full bg-brand-gold text-neutral-950">
+                    <svg
+                      className="h-3 w-3"
+                      fill="rgb(14, 15, 17)"
+                      height="16"
+                      viewBox="0 0 448 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M447.9 142.5l-23.2 22L181 395.3l-22 20.8-22-20.8L23.2 287.6 0 265.6l44-46.5 23.2 22L159 328l221.7-210 23.2-22 44 46.5z"
+                        fill="rgb(14, 15, 17)"
+                      />
+                    </svg>
+                  </div>
+                  <div className="ml-5 font-light text-white">Responsive Design</div>
+                </div>
+              </div>
+              <div className="mb-3 w-full">
+                <div className="flex">
+                  <div className="mt-0 flex h-5 w-5 items-center justify-center rounded-full bg-brand-gold text-neutral-950">
+                    <svg
+                      className="h-3 w-3"
+                      fill="rgb(14, 15, 17)"
+                      height="16"
+                      viewBox="0 0 448 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M447.9 142.5l-23.2 22L181 395.3l-22 20.8-22-20.8L23.2 287.6 0 265.6l44-46.5 23.2 22L159 328l221.7-210 23.2-22 44 46.5z"
+                        fill="rgb(14, 15, 17)"
+                      />
+                    </svg>
+                  </div>
+                  <div className="ml-5 font-light text-white">Wireframes</div>
+                </div>
+              </div>
+              <div className="mb-3 w-full">
+                <div className="flex">
+                  <div className="mt-0 flex h-5 w-5 items-center justify-center rounded-full bg-brand-gold text-neutral-950">
+                    <svg
+                      className="h-3 w-3"
+                      fill="rgb(14, 15, 17)"
+                      height="16"
+                      viewBox="0 0 448 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M447.9 142.5l-23.2 22L181 395.3l-22 20.8-22-20.8L23.2 287.6 0 265.6l44-46.5 23.2 22L159 328l221.7-210 23.2-22 44 46.5z"
+                        fill="rgb(14, 15, 17)"
+                      />
+                    </svg>
+                  </div>
+                  <div className="ml-5 font-light text-white">Strategy</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/app/(frontend)/(inner)/location/[slug]/LocationHeroText/index.tsx
+++ b/src/app/(frontend)/(inner)/location/[slug]/LocationHeroText/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { RichText } from '@/components/RichText/index'
+import { Title } from '@/components/Title'
 
 interface LocationHeroTextProps {
   title?: string
@@ -16,18 +17,18 @@ export function LocationHeroText({
   description,
 }: LocationHeroTextProps) {
   return (
-    <section className="w-full bg-brand-dark-bg pb-10 pt-20 text-black lg:pb-16 lg:pt-32 xl:pt-40">
-      <div className="px-2 sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20 min-[1800px]:pl-40 min-[1800px]:pr-40 min-[2100px]:pl-60 min-[2100px]:pr-60">
+    <section className="w-full bg-brand-dark-bg pb-10 pt-20 text-white lg:pb-16 lg:pt-32 xl:pt-40">
+      <div className="px-2 sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20">
         <div className="flex w-full flex-wrap justify-between">
           <div className="w-full px-2 lg:w-[56.25%] lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
             <div className="flex flex-col items-start">
               <div className="inline-flex items-center">
                 <div className="h-1.5 w-1.5 rounded-full bg-white" />
-                <div className="ml-2 font-light text-white">Web Design</div>
+                <div className="ml-2 font-light">Web Design</div>
               </div>
-              <h1 className="mb-0 mt-3 text-[4.25rem] leading-none text-white lg:mb-0 lg:mt-5 lg:pr-20">
+              <Title el="h1" size="headline-large" className="mb-0 mt-3 lg:mb-0 lg:mt-5 lg:pr-20">
                 {title}
-              </h1>
+              </Title>
             </div>
           </div>
           <div className="mt-5 w-full px-2 text-lg font-light text-zinc-400 lg:mt-10 lg:w-[43.75%] lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">

--- a/src/app/(frontend)/(inner)/location/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/location/[slug]/page.tsx
@@ -20,6 +20,7 @@ import { LocationHeroText } from './LocationHeroText'
 import { LocationHeroImage } from './LocationHeroImage'
 import { LocationImageLeft } from './LocationImageLeft'
 import { LocationImageRight } from './LocationImageRight'
+import { LocationHeroDetails } from './LocationHeroDetails'
 import { LocationFAQ } from './LocationFAQ'
 
 // Add type definition for page props
@@ -124,199 +125,13 @@ export default async function LocationPage({ params, searchParams }: LocationPag
     <>
       <LocationHeroText title={location.heroTitle} description={location.heroDescription} />
       <LocationHeroImage image={location.heroImage as Media} />
-
-      <section className="w-full bg-brand-dark-bg py-20 text-black lg:pb-24 lg:pt-24 min-[1450px]:pb-32 min-[1450px]:pt-32">
-        <div className="px-2 sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20 min-[1800px]:pl-40 min-[1800px]:pr-40">
-          <div className="flex w-full flex-wrap justify-between">
-            <div className="relative mb-10 w-full px-2 lg:mb-0 lg:w-[56.25%] lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4 min-[1800px]:w-[62.5%]">
-              <div className="flex flex-col items-start">
-                <div className="inline-flex w-auto items-center lg:absolute lg:left-[1.00rem] lg:top-[1.75rem]">
-                  <div className="h-1.5 w-1.5 rounded-full bg-white" />
-                  <div className="ml-2 font-light text-white">Web Design</div>
-                </div>
-                <h2 className="mb-5 mt-3 indent-48 text-6xl text-white lg:mb-0 lg:mt-5">
-                  Are you a startup brand, well established company, in the US or worldwide? It
-                  doesn't matter. We work with a range of clients.
-                </h2>
-                <div className="relative mb-0 mt-3 inline-flex items-center lg:mb-0 lg:mt-5">
-                  <a
-                    className="inline-flex"
-                    href=""
-                    style={{
-                      outlineOffset: '2px',
-                      outlineStyle: 'solid',
-                      outlineWidth: '2px',
-                    }}
-                  >
-                    <div className="inline-flex w-auto cursor-pointer items-center justify-center overflow-hidden rounded-full bg-brand-gold px-5 py-2">
-                      <div className="inline-flex">About Brewww</div>
-                    </div>
-                    <div className="-ml-1 flex h-9 w-9 cursor-pointer items-center justify-center overflow-hidden rounded-full bg-brand-gold" />
-                  </a>
-                  <div className="absolute right-0 top-0 z-20 flex h-9 w-9 items-center justify-center">
-                    <div className="relative overflow-hidden">
-                      <div>
-                        <svg
-                          className="h-3 w-3"
-                          fill="rgb(1, 2, 2)"
-                          viewBox="0 0 384 512"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M328 96h24v288h-48V177.9L81 401l-17 17-33.9-34 17-17 223-223H64V96h264z"
-                            fill="rgb(1, 2, 2)"
-                          />
-                        </svg>
-                      </div>
-                      <div className="absolute left-0 top-0">
-                        <svg
-                          className="h-3 w-3"
-                          fill="rgb(1, 2, 2)"
-                          viewBox="0 0 384 512"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M328 96h24v288h-48V177.9L81 401l-17 17-33.9-34 17-17 223-223H64V96h264z"
-                            fill="rgb(1, 2, 2)"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div className="w-full px-2 lg:w-1/4 lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
-              <div className="mb-5 text-sm font-light text-neutral-400">
-                Our Website Capabilities
-              </div>
-              <div className="w-full">
-                <div className="mb-3 w-full">
-                  <div className="flex">
-                    <div className="mt-0 flex h-5 w-5 items-center justify-center rounded-full bg-brand-gold text-neutral-950">
-                      <svg
-                        className="h-3 w-3"
-                        fill="rgb(14, 15, 17)"
-                        height="16"
-                        viewBox="0 0 448 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M447.9 142.5l-23.2 22L181 395.3l-22 20.8-22-20.8L23.2 287.6 0 265.6l44-46.5 23.2 22L159 328l221.7-210 23.2-22 44 46.5z"
-                          fill="rgb(14, 15, 17)"
-                        />
-                      </svg>
-                    </div>
-                    <div className="ml-5 font-light text-white">Web Design</div>
-                  </div>
-                </div>
-                <div className="mb-3 w-full">
-                  <div className="flex">
-                    <div className="mt-0 flex h-5 w-5 items-center justify-center rounded-full bg-brand-gold text-neutral-950">
-                      <svg
-                        className="h-3 w-3"
-                        fill="rgb(14, 15, 17)"
-                        height="16"
-                        viewBox="0 0 448 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M447.9 142.5l-23.2 22L181 395.3l-22 20.8-22-20.8L23.2 287.6 0 265.6l44-46.5 23.2 22L159 328l221.7-210 23.2-22 44 46.5z"
-                          fill="rgb(14, 15, 17)"
-                        />
-                      </svg>
-                    </div>
-                    <div className="ml-5 font-light text-white">eCommerce</div>
-                  </div>
-                </div>
-                <div className="mb-3 w-full">
-                  <div className="flex">
-                    <div className="mt-0 flex h-5 w-5 items-center justify-center rounded-full bg-brand-gold text-neutral-950">
-                      <svg
-                        className="h-3 w-3"
-                        fill="rgb(14, 15, 17)"
-                        height="16"
-                        viewBox="0 0 448 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M447.9 142.5l-23.2 22L181 395.3l-22 20.8-22-20.8L23.2 287.6 0 265.6l44-46.5 23.2 22L159 328l221.7-210 23.2-22 44 46.5z"
-                          fill="rgb(14, 15, 17)"
-                        />
-                      </svg>
-                    </div>
-                    <div className="ml-5 font-light text-white">UX Design</div>
-                  </div>
-                </div>
-                <div className="mb-3 w-full">
-                  <div className="flex">
-                    <div className="mt-0 flex h-5 w-5 items-center justify-center rounded-full bg-brand-gold text-neutral-950">
-                      <svg
-                        className="h-3 w-3"
-                        fill="rgb(14, 15, 17)"
-                        height="16"
-                        viewBox="0 0 448 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M447.9 142.5l-23.2 22L181 395.3l-22 20.8-22-20.8L23.2 287.6 0 265.6l44-46.5 23.2 22L159 328l221.7-210 23.2-22 44 46.5z"
-                          fill="rgb(14, 15, 17)"
-                        />
-                      </svg>
-                    </div>
-                    <div className="ml-5 font-light text-white">Responsive Design</div>
-                  </div>
-                </div>
-                <div className="mb-3 w-full">
-                  <div className="flex">
-                    <div className="mt-0 flex h-5 w-5 items-center justify-center rounded-full bg-brand-gold text-neutral-950">
-                      <svg
-                        className="h-3 w-3"
-                        fill="rgb(14, 15, 17)"
-                        height="16"
-                        viewBox="0 0 448 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M447.9 142.5l-23.2 22L181 395.3l-22 20.8-22-20.8L23.2 287.6 0 265.6l44-46.5 23.2 22L159 328l221.7-210 23.2-22 44 46.5z"
-                          fill="rgb(14, 15, 17)"
-                        />
-                      </svg>
-                    </div>
-                    <div className="ml-5 font-light text-white">Wireframes</div>
-                  </div>
-                </div>
-                <div className="mb-3 w-full">
-                  <div className="flex">
-                    <div className="mt-0 flex h-5 w-5 items-center justify-center rounded-full bg-brand-gold text-neutral-950">
-                      <svg
-                        className="h-3 w-3"
-                        fill="rgb(14, 15, 17)"
-                        height="16"
-                        viewBox="0 0 448 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M447.9 142.5l-23.2 22L181 395.3l-22 20.8-22-20.8L23.2 287.6 0 265.6l44-46.5 23.2 22L159 328l221.7-210 23.2-22 44 46.5z"
-                          fill="rgb(14, 15, 17)"
-                        />
-                      </svg>
-                    </div>
-                    <div className="ml-5 font-light text-white">Strategy</div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
+      <LocationHeroDetails />
       <LocationImageLeft />
       <LocationImageRight />
       <LocationLogoSlider brands={brands} />
 
       <section className="relative w-full rounded-3xl bg-zinc-900 py-10 text-black lg:pb-16 lg:pt-16 min-[1450px]:pb-24 min-[1450px]:pt-24">
-        <div className="px-2 sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20 min-[1800px]:pl-40 min-[1800px]:pr-40">
+        <div className="px-2 sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20">
           <div className="mb-8 mt-10 flex w-full flex-wrap items-end justify-between lg:mb-16 lg:mt-0">
             <div className="w-full px-2 lg:w-auto lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
               <div className="flex flex-col items-start">
@@ -547,7 +362,7 @@ export default async function LocationPage({ params, searchParams }: LocationPag
         </div>
       </section>
 
-      <section className="bg-neutral-950 px-2 pb-10 text-black sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20 min-[1800px]:pl-40 min-[1800px]:pr-40">
+      <section className="bg-neutral-950 px-2 pb-10 text-black sm:pl-6 sm:pr-6 xl:pl-12 xl:pr-12 min-[1450px]:pl-20 min-[1450px]:pr-20">
         <div className="flex w-full flex-wrap">
           <div className="relative w-full px-2 lg:pl-3 lg:pr-3 xl:pl-4 xl:pr-4">
             <div className="relative flex w-full cursor-pointer flex-wrap lg:min-h-[30.00rem]">

--- a/src/components/Title/index.tsx
+++ b/src/components/Title/index.tsx
@@ -2,14 +2,13 @@ import React from 'react'
 import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/utilities/cn'
 
-// Type scale following Material Design. Update settings in the Tailwind config.
 const headingVariants = cva(
-  // Base styles - removed font-default as it's not defined
-  'tracking-tight leading-none',
+  // Add a base class that will help with specificity
+  '[&.title]:tracking-tight [&.title]:leading-none',
   {
     variants: {
-      level: {
-        h1: '', // Using font-sans instead of font-default
+      el: {
+        h1: '',
         h2: '',
         h3: '',
         h4: '',
@@ -18,20 +17,16 @@ const headingVariants = cva(
         p: '',
       },
       size: {
-        // Display sizes
-        'display-large': 'text-display-large',
-        'display-medium': 'text-display-medium',
-        'display-small': 'text-display-small',
-
-        // Headline sizes
-        'headline-large': 'text-headline-large',
-        'headline-medium': 'text-headline-medium',
-        'headline-small': 'text-headline-small',
-
-        // Title sizes
-        'title-large': 'text-title-large',
-        'title-medium': 'text-title-medium',
-        'title-small': 'text-title-small',
+        // Make size classes more specific with a parent class
+        'display-large': '[&.title]:text-display-large',
+        'display-medium': '[&.title]:text-display-medium',
+        'display-small': '[&.title]:text-display-small',
+        'headline-large': '[&.title]:text-headline-large',
+        'headline-medium': '[&.title]:text-headline-medium',
+        'headline-small': '[&.title]:text-headline-small',
+        'title-large': '[&.title]:text-title-large',
+        'title-medium': '[&.title]:text-title-medium',
+        'title-small': '[&.title]:text-title-small',
       },
       weight: {
         regular: 'font-normal',
@@ -43,7 +38,7 @@ const headingVariants = cva(
     defaultVariants: {
       weight: 'regular',
       size: 'headline-large',
-      level: 'h2',
+      el: 'h2',
     },
     compoundVariants: [
       {
@@ -55,33 +50,36 @@ const headingVariants = cva(
   },
 )
 
-interface TitleProps extends VariantProps<typeof headingVariants> {
+interface TitleProps
+  extends React.HTMLAttributes<HTMLHeadingElement>,
+    Omit<VariantProps<typeof headingVariants>, 'el'> {
   el?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
   children?: React.ReactNode
-  className?: string
 }
 
-export const Title: React.FC<TitleProps> = ({
-  el = 'h2',
-  size = 'headline-large',
-  weight,
-  children,
-  className,
-}) => {
-  const Component = el
+export const Title = React.forwardRef<HTMLHeadingElement, TitleProps>(
+  ({ el = 'h2', size = 'headline-large', weight, children, className, ...props }, ref) => {
+    const Component = el
 
-  return (
-    <Component
-      className={cn(
-        headingVariants({
-          level: el,
-          size,
-          weight,
-        }),
-        className,
-      )}
-    >
-      {children}
-    </Component>
-  )
-}
+    return (
+      <Component
+        ref={ref}
+        // Add 'title' class to increase specificity
+        className={cn(
+          'title',
+          headingVariants({
+            el,
+            size,
+            weight,
+          }),
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </Component>
+    )
+  },
+)
+
+Title.displayName = 'Title'


### PR DESCRIPTION
### TL;DR
Extracted the location hero details section into a separate component and enhanced the Title component implementation.

### What changed?
- Created a new `LocationHeroDetails` component to handle the capabilities section
- Updated `LocationHeroText` to use the enhanced `Title` component
- Refactored the `Title` component to use proper TypeScript forwarded refs
- Added more specific CSS class targeting in the Title component using `[&.title]` syntax
- Removed redundant padding classes from location page sections
- Standardized text color handling in hero sections

### How to test?
1. Navigate to any location page
2. Verify the hero section renders correctly with proper typography
3. Confirm the capabilities section displays with correct styling
4. Check that all text colors and spacing remain consistent
5. Ensure responsive behavior works across different screen sizes

### Why make this change?
- Improves code organization by separating concerns into dedicated components
- Enhances type safety and component reusability through proper ref forwarding
- Reduces CSS specificity conflicts through better class targeting
- Makes the codebase more maintainable by removing duplicate padding configurations