### PR TITLE
fix(media): update Media config to fix preview thumbnail not displaying:

### DIFF
--- a/src/collections/Media/config.ts
+++ b/src/collections/Media/config.ts
@@ -1,5 +1,5 @@
 // Payload Imports
-import type { CollectionConfig } from 'payload'
+import type { CollectionConfig, GetAdminThumbnail } from 'payload'
 
 // Access Control
 import { authenticated } from '@/access/authenticated'
@@ -44,7 +44,16 @@ export const Media: CollectionConfig = {
     listSearchableFields: ['url', 'alt'],
   },
   upload: {
-    adminThumbnail: 'thumbnail',
+    adminThumbnail: (({
+      doc,
+    }: {
+      doc: { sizes: { thumbnail?: { url: string } }; url?: string }
+    }) => {
+      if (doc.sizes?.thumbnail?.url) {
+        return doc.sizes.thumbnail.url
+      }
+      return doc.url || null
+    }) satisfies GetAdminThumbnail,
     focalPoint: true,
     imageSizes: [
       {

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -52,7 +52,12 @@ export const plugins: Plugin[] = [
       media: {
         prefix: 'media',
         disablePayloadAccessControl: true,
-        generateFileURL: (file: { filename: string }) => {
+        generateFileURL: (file: {
+          filename: string
+          prefix?: string
+          size?: { name: string; width?: number; height?: number }
+        }) => {
+          // Just use the filename as-is, since Payload already adds the dimensions
           return `${process.env.CLOUDFLARE_PUBLIC_URL}/${file.filename}`
         },
       },


### PR DESCRIPTION
### TL;DR
Updated media file handling to better support thumbnails and Cloudflare image URLs.

### What changed?
- Enhanced the `adminThumbnail` configuration to properly handle thumbnail URLs by checking for both thumbnail sizes and fallback URLs
- Simplified the `generateFileURL` function to use filenames directly with Cloudflare URLs
- Added TypeScript type definitions for better type safety in media handling

### How to test?
1. Upload a new media file through the admin panel
2. Verify that thumbnails display correctly in the media library
3. Check that the generated Cloudflare URLs are correct and accessible
4. Confirm that both thumbnail and original image sizes work as expected

### Why make this change?
To improve the reliability of media handling in the admin interface and ensure consistent URL generation for Cloudflare-hosted images. This change provides better fallback behavior for thumbnails and more precise TypeScript definitions for media-related functions.