### PR TITLE
feat(cms): change tagline/description order for consistency

### DIFF
--- a/src/collections/BlogPosts/config.ts
+++ b/src/collections/BlogPosts/config.ts
@@ -40,21 +40,21 @@ export const BlogPosts: CollectionConfig = {
       },
     },
     {
-      name: 'description',
-      type: 'textarea',
-      label: 'Post Description',
-      required: false,
-      admin: {
-        description: 'The description of the article as it appears around the site.',
-      },
-    },
-    {
       name: 'tagline',
       type: 'text',
       label: 'Post Tagline',
       required: false,
       admin: {
         description: 'The tagline of the article as it appears around the site.',
+      },
+    },
+    {
+      name: 'description',
+      type: 'textarea',
+      label: 'Post Description',
+      required: false,
+      admin: {
+        description: 'The description of the article as it appears around the site.',
       },
     },
     {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -171,8 +171,8 @@ export interface MediaBlock {
 export interface Post {
   id: string;
   title: string;
-  description?: string | null;
   tagline?: string | null;
+  description?: string | null;
   content: {
     root: {
       type: string;
@@ -602,8 +602,8 @@ export interface PagesSelect<T extends boolean = true> {
  */
 export interface PostsSelect<T extends boolean = true> {
   title?: T;
-  description?: T;
   tagline?: T;
+  description?: T;
   content?: T;
   slug?: T;
   slugLock?: T;


### PR DESCRIPTION
### TL;DR
Reordered the `tagline` and `description` fields in the blog post collection to maintain consistent field ordering.

### What changed?
- Swapped the order of `tagline` and `description` fields in the BlogPosts collection configuration
- Updated corresponding type definitions to match the new field order
- Field functionality remains unchanged, only the display order in the admin UI is affected

### How to test?
1. Navigate to the admin panel
2. Create or edit a blog post
3. Verify that the tagline field appears before the description field
4. Confirm that both fields still function as expected

### Why make this change?
Improves the content editing experience by presenting fields in a more logical order, with the shorter tagline field appearing before the longer description field. This matches common content authoring patterns where concise summaries precede detailed descriptions.