### PR TITLE
feat(journal): add ISR to journal page to improve loading speed

### DIFF
--- a/src/app/(frontend)/(inner)/journal/page.tsx
+++ b/src/app/(frontend)/(inner)/journal/page.tsx
@@ -4,6 +4,9 @@ import { BlogCard } from '@/components/BlogCard/index'
 import { CategoryFilter } from '@/components/CategoryFilter/index'
 import { Category, Post } from '@/payload-types'
 
+// Add revalidation time - 1 hour
+export const revalidate = 3600
+
 export default async function BlogPage() {
   const payload = await getPayload({ config: configPromise })
   const posts = await payload.find({


### PR DESCRIPTION
### TL;DR
Added a 1-hour revalidation period to the journal page.

### What changed?
Added the `revalidate` export with a value of 3600 seconds (1 hour) to the journal page component.

### How to test?
1. Visit the journal page
2. Verify that content updates are reflected after the 1-hour cache period
3. Monitor server logs to confirm revalidation is occurring as expected

### Why make this change?
Implementing revalidation improves performance by caching the journal page while ensuring content remains fresh by updating every hour. This reduces server load and improves user experience by serving cached content when appropriate.