### PR TITLE
feat(journal): add ISR to individual journal pages

### DIFF
--- a/src/app/(frontend)/(inner)/journal/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/journal/[slug]/page.tsx
@@ -30,6 +30,8 @@ const emptyLexicalContent = {
   },
 } as const
 
+export const revalidate = 3600 // Revalidate every hour
+
 export async function generateStaticParams() {
   const payload = await getPayload({ config: configPromise })
   const posts = await payload.find({
@@ -42,6 +44,12 @@ export async function generateStaticParams() {
       params: { slug },
     })) || []
   )
+}
+
+export async function generateMetadata({ params }: { params: { slug: string } }): Promise<Metadata> {
+  return {
+    title: 'Blog Post',
+  }
 }
 
 export default async function PostPage({ params }: { params: Promise<{ slug: string }> }) {


### PR DESCRIPTION
### TL;DR
Added page revalidation and metadata generation for journal posts.

### What changed?
- Added a revalidation period of 1 hour (3600 seconds) for journal pages
- Implemented `generateMetadata` function to set the page title to 'Blog Post'

### How to test?
1. Visit any journal post page
2. Verify the page title shows as 'Blog Post'
3. Monitor the page cache behavior to ensure it revalidates hourly

### Why make this change?
To improve SEO by adding proper metadata and implement efficient caching strategy for journal posts, reducing server load while keeping content reasonably fresh.