### PR TITLE
fix(location): allow for heroTitle and heroDescription to be undefined

### DIFF
--- a/src/app/(frontend)/(inner)/location/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/location/[slug]/page.tsx
@@ -124,7 +124,10 @@ export default async function LocationPage({ params, searchParams }: LocationPag
 
   return (
     <>
-      <LocationHeroText title={location.heroTitle} description={location.heroDescription} />
+      <LocationHeroText 
+        title={location.heroTitle || undefined} 
+        description={location.heroDescription || undefined} 
+      />
       <LocationHeroImage image={location.heroImage as Media} />
       <LocationHeroDetails />
       <LocationImageLeft />


### PR DESCRIPTION
### TL;DR
Added undefined fallbacks for location hero title and description props

### What changed?
Modified the `LocationHeroText` component props to include explicit undefined fallbacks when `heroTitle` or `heroDescription` are falsy values

### How to test?
1. Navigate to a location page
2. Verify the hero section renders correctly with:
   - A populated title and description
   - No errors when title or description are missing
   - Graceful handling of empty values

### Why make this change?
Prevents potential runtime errors and improves component reliability by ensuring proper prop types are passed when content data is missing or undefined