### PR TITLE
chore(cms): update meta fields in BlogPosts and BlogCategories

### DIFF
--- a/src/app/(frontend)/(inner)/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/[slug]/page.tsx
@@ -63,16 +63,16 @@ export default async function Page({ params: paramsPromise }: Args) {
   })
 
   // If no page is found, render the redirects component
-  // if (!page) {
-  //   return <PayloadRedirects url={url} />
-  // }
+  if (!page) {
+    return <PayloadRedirects url={url} />
+  }
 
   // Extract the layout blocks from the page data
   const { layout } = page
   return (
     <article className="bg-blue-500">
       {/* Handle any configured redirects, but don't show 404 */}
-      {/* <PayloadRedirects disableNotFound url={url} /> */}
+      <PayloadRedirects disableNotFound url={url} />
       {/* Render the page content blocks */}
       <RenderBlocks blocks={layout || []} />
     </article>

--- a/src/collections/BlogCategories/config.ts
+++ b/src/collections/BlogCategories/config.ts
@@ -7,7 +7,7 @@ import { authenticated } from '@/access/authenticated'
 
 // Fields
 import { slugField } from '@/fields/slug'
-import { metaTab } from '@/fields/meta'
+import { PreviewField, OverviewField, MetaTitleField, MetaImageField, MetaDescriptionField } from '@/fields/meta'
 
 export const BlogCategories: CollectionConfig = {
   slug: 'categories',
@@ -33,6 +33,33 @@ export const BlogCategories: CollectionConfig = {
       },
     },
     ...slugField(),
+    {
+      type: 'tabs',
+      tabs: [
+        {
+          label: 'Meta',
+          fields: [
+            PreviewField({
+              hasGenerateFn: true,
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+            }),
+            OverviewField({
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+              imagePath: "meta.image",
+            }),
+            MetaTitleField({
+              hasGenerateFn: true,
+            }),
+            MetaImageField({
+              relationTo: "media",
+            }),
+            MetaDescriptionField({}),
+          ],
+        },
+      ],
+    },
   ],
 
   //* Admin Settings

--- a/src/collections/BlogPosts/config.ts
+++ b/src/collections/BlogPosts/config.ts
@@ -6,7 +6,7 @@ import { authenticated } from '@/access/authenticated'
 import { authenticatedOrPublished } from '@/access/authenticatedOrPublished'
 
 // Fields
-import { metaTab } from '@/fields/meta'
+import { PreviewField, OverviewField, MetaTitleField, MetaImageField, MetaDescriptionField } from '@/fields/meta'
 import { slugField } from '@/fields/slug'
 
 // Utilities & Hooks
@@ -74,8 +74,34 @@ export const BlogPosts: CollectionConfig = {
       }),
       required: true,
     },
-
     ...slugField(),
+    {
+      type: 'tabs',
+      tabs: [
+        {
+          label: 'Meta',
+          fields: [
+            PreviewField({
+              hasGenerateFn: true,
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+            }),
+            OverviewField({
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+              imagePath: "meta.image",
+            }),
+            MetaTitleField({
+              hasGenerateFn: true,
+            }),
+            MetaImageField({
+              relationTo: "media",
+            }),
+            MetaDescriptionField({}),
+          ],
+        },
+      ],
+    },
     {
       name: 'publishedOn',
       type: 'date',

--- a/src/collections/Pages/config.ts
+++ b/src/collections/Pages/config.ts
@@ -7,7 +7,7 @@ import { authenticatedOrPublished } from '@/access/authenticatedOrPublished'
 
 // Field Imports
 import { slugField } from '@/fields/slug'
-import { metaTab } from '@/fields/meta'
+import { PreviewField, OverviewField, MetaTitleField, MetaImageField, MetaDescriptionField } from '@/fields/meta'
 
 // Block Imports
 import { MediaBlock } from '@/blocks/MediaBlock/config'
@@ -52,7 +52,28 @@ export const Pages: CollectionConfig = {
             },
           ],
         },
-        metaTab,
+        {
+          label: 'Meta',
+          fields: [
+            PreviewField({
+              hasGenerateFn: true,
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+            }),
+            OverviewField({
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+              imagePath: "meta.image",
+            }),
+            MetaTitleField({
+              hasGenerateFn: true,
+            }),
+            MetaImageField({
+              relationTo: "media",
+            }),
+            MetaDescriptionField({}),
+          ],
+        },
       ],
     },
     ...slugField(),

--- a/src/collections/Play/config.ts
+++ b/src/collections/Play/config.ts
@@ -7,7 +7,13 @@ import { authenticatedOrPublished } from '@/access/authenticatedOrPublished'
 
 // Fields
 import { slugField } from '@/fields/slug'
-import { metaTab } from '@/fields/meta'
+import {
+  PreviewField,
+  OverviewField,
+  MetaTitleField,
+  MetaImageField,
+  MetaDescriptionField,
+} from '@/fields/meta'
 
 // Utilities
 import { generatePreviewPath } from '@root/utilities/generatePreviewPath'
@@ -58,29 +64,57 @@ export const Playground: CollectionConfig = {
     //   type: 'tabs',
     //   tabs: [metaTab],
     // },
-    // ...slugField(),
-    // {
-    //   name: 'publishedOn',
-    //   type: 'date',
-    //   required: false,
-    //   label: 'Published On',
-    //   admin: {
-    //     position: 'sidebar',
-    //     date: {
-    //       pickerAppearance: 'dayAndTime',
-    //     },
-    //   },
-    //   hooks: {
-    //     beforeChange: [
-    //       ({ siblingData, value }) => {
-    //         if (siblingData._status === 'published' && !value) {
-    //           return new Date()
-    //         }
-    //         return value
-    //       },
-    //     ],
-    //   },
-    // },
+    {
+      type: 'tabs',
+      tabs: [
+        {
+          label: 'Meta',
+          fields: [
+            PreviewField({
+              hasGenerateFn: true,
+              titlePath: 'meta.title',
+              descriptionPath: 'meta.description',
+            }),
+            OverviewField({
+              titlePath: 'meta.title',
+              descriptionPath: 'meta.description',
+              imagePath: 'meta.image',
+            }),
+            MetaTitleField({
+              hasGenerateFn: true,
+            }),
+            MetaImageField({
+              relationTo: 'media',
+            }),
+            MetaDescriptionField({}),
+          ],
+        },
+      ],
+    },
+
+    ...slugField(),
+    {
+      name: 'publishedOn',
+      type: 'date',
+      required: false,
+      label: 'Published On',
+      admin: {
+        position: 'sidebar',
+        date: {
+          pickerAppearance: 'dayAndTime',
+        },
+      },
+      hooks: {
+        beforeChange: [
+          ({ siblingData, value }) => {
+            if (siblingData._status === 'published' && !value) {
+              return new Date()
+            }
+            return value
+          },
+        ],
+      },
+    },
     {
       name: 'image',
       type: 'upload',
@@ -91,24 +125,24 @@ export const Playground: CollectionConfig = {
         position: 'sidebar',
       },
     },
-    // {
-    //   name: 'relatedPlaygrounds',
-    //   type: 'relationship',
-    //   label: 'Related Playgrounds',
-    //   admin: {
-    //     position: 'sidebar',
-    //     description: 'Add the related playgrounds here.',
-    //   },
-    //   filterOptions: ({ id }) => {
-    //     return {
-    //       id: {
-    //         not_in: [id],
-    //       },
-    //     }
-    //   },
-    //   hasMany: true,
-    //   relationTo: 'play',
-    // },
+    {
+      name: 'relatedPlaygrounds',
+      type: 'relationship',
+      label: 'Related Playgrounds',
+      admin: {
+        position: 'sidebar',
+        description: 'Add the related playgrounds here.',
+      },
+      filterOptions: ({ id }) => {
+        return {
+          id: {
+            not_in: [id],
+          },
+        }
+      },
+      hasMany: true,
+      relationTo: 'play',
+    },
   ],
 
   //* Admin Settings
@@ -118,24 +152,24 @@ export const Playground: CollectionConfig = {
     defaultColumns: ['title'],
     group: 'Portfolio',
     listSearchableFields: ['title'],
-    // livePreview: {
-    //   url: ({ data }) => {
-    //     const path = generatePreviewPath({
-    //       slug: typeof data?.slug === 'string' ? data.slug : '',
-    //       collection: 'play',
-    //     })
+    livePreview: {
+      url: ({ data }) => {
+        const path = generatePreviewPath({
+          slug: typeof data?.slug === 'string' ? data.slug : '',
+          collection: 'play',
+        })
 
-    //     return `${process.env.NEXT_PUBLIC_SERVER_URL}${path}`
-    //   },
-    // },
-    // preview: (data) => {
-    //   const path = generatePreviewPath({
-    //     slug: typeof data?.slug === 'string' ? data.slug : '',
-    //     collection: 'play',
-    //   })
+        return `${process.env.NEXT_PUBLIC_SERVER_URL}${path}`
+      },
+    },
+    preview: (data) => {
+      const path = generatePreviewPath({
+        slug: typeof data?.slug === 'string' ? data.slug : '',
+        collection: 'play',
+      })
 
-    //   return `${process.env.NEXT_PUBLIC_SERVER_URL}${path}`
-    // },
+      return `${process.env.NEXT_PUBLIC_SERVER_URL}${path}`
+    },
     pagination: {
       defaultLimit: 25,
       limits: [25, 50, 100],

--- a/src/components/WorkCard/index.tsx
+++ b/src/components/WorkCard/index.tsx
@@ -34,7 +34,7 @@ export function WorkCard({ project }: WorkCardProps) {
                     src={
                       typeof project.image === 'string' ? project.image : project.image?.url || ''
                     }
-                    alt={typeof project.image === 'object' ? project.image?.alt : ''}
+                    alt={(typeof project.image === 'object' && project.image?.alt) || project.title || ''}
                     fill
                     style={{ objectFit: 'cover' }}
                   />

--- a/src/fields/meta/index.ts
+++ b/src/fields/meta/index.ts
@@ -6,26 +6,10 @@ import {
   PreviewField,
 } from "@payloadcms/plugin-seo/fields";
 
-export const metaTab = {
-  name: "meta",
-  label: "Meta",
-  fields: [
-    PreviewField({
-      hasGenerateFn: true,
-      titlePath: "meta.title",
-      descriptionPath: "meta.description",
-    }),
-    OverviewField({
-      titlePath: "meta.title",
-      descriptionPath: "meta.description",
-      imagePath: "meta.image",
-    }),
-    MetaTitleField({
-      hasGenerateFn: true,
-    }),
-    MetaImageField({
-      relationTo: "media",
-    }),
-    MetaDescriptionField({}),
-  ],
+export {
+  MetaDescriptionField,
+  MetaImageField,
+  MetaTitleField,
+  OverviewField,
+  PreviewField,
 };


### PR DESCRIPTION
### TL;DR
Enabled redirects functionality and updated meta field implementation across collections.

### What changed?
- Uncommented and enabled PayloadRedirects component in the page template
- Replaced the generic metaTab with individual meta field implementations in BlogCategories, BlogPosts, Pages, and Play collections
- Re-enabled slug field, publishedOn, and related playgrounds functionality in Play collection
- Enhanced WorkCard alt text fallback to use project title
- Restructured meta fields exports for better modularity

### How to test?
1. Verify redirects are working by setting up a redirect and accessing the original URL
2. Check meta fields are properly displaying in the admin UI for all collections
3. Confirm Play collection's related playgrounds and publishing features are functional
4. Verify WorkCard images display appropriate alt text
5. Test preview functionality in Play collection

### Why make this change?
To improve SEO capabilities, enable proper redirects handling, and ensure consistent meta field implementation across collections while maintaining better code organization and accessibility standards.