### PR TITLE
feat(cms): add setMetaImageFallback to use image if no other image is set for the field

### DIFF
--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -1,8 +1,8 @@
-import { PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
-import { OverviewComponent as OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
 import { MetaTitleComponent as MetaTitleComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
 import { MetaImageComponent as MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
 import { MetaDescriptionComponent as MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
+import { OverviewComponent as OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
+import { PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
 import { SlugComponent as SlugComponent_92cc057d0a2abb4f6cf0307edf59f986 } from '@/fields/slug/SlugComponent'
 import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
@@ -29,11 +29,11 @@ import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864
 import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 
 export const importMap = {
-  "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  "@payloadcms/plugin-seo/client#OverviewComponent": OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
   "@payloadcms/plugin-seo/client#MetaTitleComponent": MetaTitleComponent_a8a977ebc872c5d5ea7ee689724c0860,
   "@payloadcms/plugin-seo/client#MetaImageComponent": MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
   "@payloadcms/plugin-seo/client#MetaDescriptionComponent": MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@payloadcms/plugin-seo/client#OverviewComponent": OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
   "@/fields/slug/SlugComponent#SlugComponent": SlugComponent_92cc057d0a2abb4f6cf0307edf59f986,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,8 +1,39 @@
 import type { MetadataRoute } from 'next'
 
+// Define types for API responses
+interface PayloadResponse<T> {
+  docs: T[]
+  totalDocs: number
+  limit: number
+  totalPages: number
+  page: number
+  pagingCounter: number
+  hasPrevPage: boolean
+  hasNextPage: boolean
+  prevPage: number | null
+  nextPage: number | null
+}
+
+interface Document {
+  id: string
+  slug: string
+  updatedAt: string
+  _status: 'draft' | 'published'
+}
+
+type SitemapEntry = {
+  url: string
+  lastModified: string
+  changeFrequency: 'weekly'
+  priority: number
+}
+
 // Site-specific configuration
 const config = {
   serverUrl: process.env.SITE_URL || 'https://brewww.studio',
+  maxRetries: 3,
+  retryDelay: 1000, // 1 second
+  timeout: 5000, // 5 seconds
   // Add static routes with their configurations
   staticRoutes: [
     { path: '/', priority: 1.0 },
@@ -30,32 +61,91 @@ const config = {
   },
 } as const
 
-// Revalidate every 6 hours (21600 seconds)
-export const revalidate = 21600
+// Helper function to validate and format URLs
+function formatUrl(base: string, path: string): string {
+  try {
+    const url = new URL(path, base)
+    return url.toString()
+  } catch (error) {
+    console.error(`Invalid URL: ${base}${path}`, error)
+    return ''
+  }
+}
+
+// Helper function to fetch with retry logic
+async function fetchWithRetry(
+  url: string, 
+  options: RequestInit, 
+  retries: number = config.maxRetries
+): Promise<Response> {
+  try {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), config.timeout)
+
+    const response = await fetch(url, {
+      ...options,
+      signal: controller.signal,
+    })
+
+    clearTimeout(timeoutId)
+
+    if (!response.ok && retries > 0) {
+      await new Promise(resolve => setTimeout(resolve, config.retryDelay))
+      return fetchWithRetry(url, options, retries - 1)
+    }
+
+    return response
+  } catch (error) {
+    if (retries > 0 && error instanceof Error && error.name !== 'AbortError') {
+      await new Promise(resolve => setTimeout(resolve, config.retryDelay))
+      return fetchWithRetry(url, options, retries - 1)
+    }
+    throw error
+  }
+}
+
+// Revalidate every 1 hour (3600 seconds)
+export const revalidate = 3600
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const dynamicContent = await Promise.all(
     Object.entries(config.collections).map(async ([_, collection]) => {
       try {
-        const response = await fetch(
-          `${config.serverUrl}/api/${collection.endpoint}?where[_status][equals]=published&limit=0`,
+        const apiUrl = formatUrl(config.serverUrl, `/api/${collection.endpoint}?where[_status][equals]=published&limit=100`)
+        if (!apiUrl) return { docs: [], ...collection }
+
+        const response = await fetchWithRetry(
+          apiUrl,
           {
-            // Use stale-while-revalidate caching
-            next: {
-              revalidate: 21600, // Cache for 6 hours
-              tags: ['sitemap', `collection-${collection.endpoint}`], // Tag-based invalidation
+            headers: {
+              'Accept': 'application/json',
+              'Cache-Control': 'no-cache',
             },
-          },
+            next: {
+              revalidate: 3600,
+              tags: ['sitemap', `collection-${collection.endpoint}`],
+            },
+          }
         )
 
         if (!response.ok) {
-          console.error(`Failed to fetch ${collection.endpoint}: ${response.status}`)
+          console.error(
+            `Failed to fetch ${collection.endpoint}: ${response.status}`,
+            `URL: ${apiUrl}`,
+            await response.text()
+          )
           return { docs: [], ...collection }
         }
 
-        const data = await response.json()
+        const data = await response.json() as PayloadResponse<Document>
+        if (!data?.docs || !Array.isArray(data.docs)) {
+          console.error(`Invalid response format for ${collection.endpoint}:`, data)
+          return { docs: [], ...collection }
+        }
+
+        console.log(`Successfully fetched ${data.docs.length} items from ${collection.endpoint}`)
         return {
-          docs: Array.isArray(data?.docs) ? data.docs : [],
+          docs: data.docs,
           ...collection,
         }
       } catch (error) {
@@ -65,28 +155,38 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     }),
   )
 
-  const sitemapData: MetadataRoute.Sitemap = [
+  const sitemapEntries: MetadataRoute.Sitemap = [
     // Static routes
-    ...config.staticRoutes.map(({ path, priority }) => ({
-      url: `${config.serverUrl}${path}`,
-      lastModified: new Date().toISOString(),
-      changeFrequency: 'weekly' as const,
-      priority,
-    })),
+    ...config.staticRoutes.map(({ path, priority }): MetadataRoute.Sitemap[number] => {
+      const url = formatUrl(config.serverUrl, path)
+      if (!url) return {
+        url: `${config.serverUrl}${path}`,
+        lastModified: new Date().toISOString(),
+        changeFrequency: 'weekly',
+        priority,
+      }
+      return {
+        url,
+        lastModified: new Date().toISOString(),
+        changeFrequency: 'weekly',
+        priority,
+      }
+    }),
 
     // Dynamic routes
     ...dynamicContent.flatMap(
       ({ docs, prefix, priority }) =>
-        (docs || [])
-          .map((doc: any) => ({
-            url: `${config.serverUrl}${prefix}${doc?.slug || ''}`,
+        (docs || []).map((doc: Document): MetadataRoute.Sitemap[number] => {
+          const url = formatUrl(config.serverUrl, `${prefix}${doc?.slug || ''}`)
+          return {
+            url: url || `${config.serverUrl}${prefix}${doc?.slug || ''}`,
             lastModified: new Date(doc?.updatedAt || Date.now()).toISOString(),
-            changeFrequency: 'weekly' as const,
+            changeFrequency: 'weekly',
             priority,
-          }))
-          .filter((entry) => entry.url.endsWith('/')), // Filter out any malformed URLs
+          }
+        })
     ),
   ]
 
-  return sitemapData
+  return sitemapEntries
 }

--- a/src/collections/BlogPosts/config.ts
+++ b/src/collections/BlogPosts/config.ts
@@ -20,6 +20,7 @@ import { slugField } from '@/fields/slug'
 import { generatePreviewPath } from '@/utilities/generatePreviewPath'
 import { populatePublishedOn } from '@/hooks/populatePublishedOn'
 import { revalidatePost } from './hooks/revalidatePost'
+import { setMetaImageFallback } from '@/hooks/setMetaImageFallback'
 
 import { BlocksFeature, HeadingFeature, lexicalEditor } from '@payloadcms/richtext-lexical'
 
@@ -216,7 +217,7 @@ export const BlogPosts: CollectionConfig = {
     maxPerDoc: 25,
   },
   hooks: {
-    beforeChange: [populatePublishedOn],
+    beforeChange: [populatePublishedOn, setMetaImageFallback],
     afterChange: [revalidatePost],
   },
 }

--- a/src/collections/Media/config.ts
+++ b/src/collections/Media/config.ts
@@ -21,7 +21,6 @@ export const Media: CollectionConfig = {
 
   //* Collection Fields
   fields: [
-  
     {
       name: 'alt',
       type: 'text',
@@ -41,7 +40,7 @@ export const Media: CollectionConfig = {
           'This is the caption for the image. Optional, but helpful for Blog Posts requiring a caption.',
       },
     },
-      {
+    {
       name: 'fileHash',
       type: 'text',
       admin: {
@@ -53,9 +52,10 @@ export const Media: CollectionConfig = {
 
   //* Admin Settings
   admin: {
-    listSearchableFields: ['url', 'alt'],
+    defaultColumns: ['url', 'alt', 'caption'],
+    listSearchableFields: ['url', 'alt', 'caption'],
   },
-  
+
   hooks: {
     beforeChange: [generateFileHash],
   },

--- a/src/hooks/setMetaImageFallback.ts
+++ b/src/hooks/setMetaImageFallback.ts
@@ -1,0 +1,13 @@
+import { BeforeChangeHook } from 'payload/dist/collections/config/types'
+
+export const setMetaImageFallback: BeforeChangeHook = ({ data, operation }) => {
+  if (operation === 'create' || operation === 'update') {
+    if (!data.meta?.image && data.image) {
+      data.meta = {
+        ...data.meta,
+        image: data.image,
+      }
+    }
+  }
+  return data
+} 


### PR DESCRIPTION
### TL;DR
Enhanced sitemap generation and improved SEO metadata handling for blog posts.

### What changed?
- Implemented robust sitemap generation with retry logic, timeout handling, and URL validation
- Added fallback mechanism to automatically set meta image from blog post's main image
- Reduced sitemap revalidation time from 6 hours to 1 hour
- Added caption to Media collection's default columns and search fields
- Reordered SEO plugin component imports for better organization

### How to test?
1. Visit `/sitemap.xml` to verify the sitemap is generating correctly
2. Create a new blog post with a main image but no meta image
3. Verify the meta image is automatically set from the main image
4. Check Media collection to confirm caption is visible in the default view
5. Verify sitemap updates within 1 hour of content changes

### Why make this change?
To improve SEO capabilities and content discoverability by:
- Making the sitemap more reliable and up-to-date
- Ensuring blog posts always have meta images for social sharing
- Providing better visibility of media captions in the admin interface
- Reducing the time for search engines to discover new content