### PR TITLE
fix(hooks): update import statement for newly created MetaImageFallback

### DIFF
--- a/src/hooks/setMetaImageFallback.ts
+++ b/src/hooks/setMetaImageFallback.ts
@@ -1,6 +1,6 @@
-import { BeforeChangeHook } from 'payload/dist/collections/config/types'
+import type { CollectionBeforeChangeHook } from "payload";
 
-export const setMetaImageFallback: BeforeChangeHook = ({ data, operation }) => {
+export const setMetaImageFallback: CollectionBeforeChangeHook = ({ data, operation }) => {
   if (operation === 'create' || operation === 'update') {
     if (!data.meta?.image && data.image) {
       data.meta = {


### PR DESCRIPTION
### TL;DR
Updated type import for collection hook from Payload CMS

### What changed?
- Replaced `BeforeChangeHook` import from `payload/dist/collections/config/types` with `CollectionBeforeChangeHook` from `payload`
- Updated type annotation for `setMetaImageFallback` function to use the new type

### How to test?
1. Verify the meta image fallback functionality still works when creating/updating collections
2. Ensure TypeScript compilation succeeds without errors
3. Test both create and update operations to confirm meta image is set correctly when an image exists

### Why make this change?
The change aligns with Payload CMS's recommended type imports and uses the more specific `CollectionBeforeChangeHook` type, which provides better type safety and maintainability.