### PR TITLE
refactor(journal): break slug page into components

### DIFF
--- a/src/app/(frontend)/(inner)/journal/[slug]/JournalContent/index.tsx
+++ b/src/app/(frontend)/(inner)/journal/[slug]/JournalContent/index.tsx
@@ -1,0 +1,11 @@
+import { RichText } from '@/components/RichText'
+import { Post } from '@root/payload-types'
+export function JournalContent({ post }: { post: Post }) {
+  return (
+    <div className="container mx-auto px-4 pt-8">
+      <article className="prose mx-auto max-w-4xl pb-24">
+        <RichText content={post.content} enableProse={true} enableGutter={false} />
+      </article>
+    </div>
+  )
+}

--- a/src/app/(frontend)/(inner)/journal/[slug]/JournalHero/index.tsx
+++ b/src/app/(frontend)/(inner)/journal/[slug]/JournalHero/index.tsx
@@ -1,0 +1,74 @@
+import { formatDate } from "@root/utilities/formatDateTime";
+import Link from "next/link";
+import { Post } from '@/payload-types';
+
+interface JournalHeroProps {
+  post: Post;
+}
+
+export function JournalHero({ post }: JournalHeroProps) {
+  return (
+    <>
+      <div className="container mx-auto px-4 py-4">
+        <div className="flex items-center justify-between">
+          <ul className="hidden list-none flex-wrap gap-4 md:flex">
+            <li>
+              <Link href="/posts" className="hover:underline">
+                All Posts
+              </Link>
+            </li>
+            <li>
+              <Link href="/posts/category/branding" className="hover:underline">
+                Branding
+              </Link>
+            </li>
+            <li>
+              <Link href="/posts/category/web-design" className="hover:underline">
+                Web Design
+              </Link>
+            </li>
+            <li>
+              <Link href="/posts/category/content" className="hover:underline">
+                Content
+              </Link>
+            </li>
+            <li>
+              <Link href="/posts/category/guides" className="hover:underline">
+                Guides
+              </Link>
+            </li>
+            <li>
+              <Link href="/posts/category/updates" className="hover:underline">
+                Updates
+              </Link>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <section className="container mx-auto px-4 pb-12 pt-12">
+        <div className="max-w-5xl">
+          <h1 className="mb-4 text-5xl font-medium leading-tight md:text-6xl">{post.title}</h1>
+          <p className="mb-8 max-w-3xl text-xl text-gray-700">
+            {post.description || 'Add a cool description here.'}
+          </p>
+          <div className="flex items-center gap-1 text-sm text-gray-500">
+            <span>
+              By{' '}
+              <Link className="text-gray-950" href={''}>
+                Kevin Wessa
+              </Link>
+            </span>
+            <span>•</span>
+            <span>
+              {post.publishedOn
+                ? formatDate({ date: post.publishedOn, format: 'shortDateStamp' })
+                : 'Date not available'}
+            </span>
+            <span>•</span>
+            {/* <span>{post.readTime ? `${post.readTime} min read` : 'Add Read Time'}</span> */}
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/app/(frontend)/(inner)/journal/[slug]/JournalHeroImage/index.tsx
+++ b/src/app/(frontend)/(inner)/journal/[slug]/JournalHeroImage/index.tsx
@@ -1,0 +1,22 @@
+import { Post } from '@root/payload-types'
+import Image from 'next/image'
+
+export function JournalHeroImage({ post }: { post: Post }) {
+  return (
+    <div className="w-full">
+      <div className="px-2">
+        <div className="relative aspect-[3/2] w-full">
+      <Image
+        src={typeof post.image === 'string' ? post.image : post.image?.url || ''}
+        fill
+        alt={
+          typeof post.image === 'object' ? post.image?.alt || '' : 'Featured image for blog post'
+        }
+        className="rounded-md object-cover"
+        priority
+      />
+    </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(frontend)/(inner)/journal/[slug]/page.tsx
+++ b/src/app/(frontend)/(inner)/journal/[slug]/page.tsx
@@ -1,23 +1,18 @@
 // Next Imports
 import React, { cache } from 'react'
 import type { Metadata } from 'next'
-import { notFound } from 'next/navigation'
-import Image from 'next/image'
-import Link from 'next/link'
 import { draftMode } from 'next/headers'
 
 // Payload Imports
 import { PayloadRedirects } from '@/components/PayloadRedirects'
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
-import { Post } from '@/payload-types'
 
 // Components
-import { RichText } from '@/components/RichText/index'
 import { generateMeta } from '@/utilities/generateMeta'
-
-// Utilities
-import { formatDate } from '@/utilities/formatDateTime'
+import { JournalHero } from './JournalHero'
+import { JournalHeroImage } from './JournalHeroImage'
+import { JournalContent } from './JournalContent'
 
 export const revalidate = 3600
 
@@ -47,104 +42,18 @@ type Args = {
 }
 
 export default async function PostPage({ params: paramsPromise }: Args) {
-  const { slug = "" } = await paramsPromise
+  const { slug = '' } = await paramsPromise
   const url = `/journal/${slug}`
- const post = await queryPostBySlug({ slug })
- 
+  const post = await queryPostBySlug({ slug })
+
   if (!post) return <PayloadRedirects url={url} />
 
   return (
     <article className="bg-white pt-24 text-black">
-        <PayloadRedirects disableNotFound url={url} />
-      <div className="container mx-auto px-4 py-4">
-        <div className="flex items-center justify-between">
-          <ul className="hidden list-none flex-wrap gap-4 md:flex">
-            <li>
-              <Link href="/posts" className="hover:underline">
-                All Posts
-              </Link>
-            </li>
-            <li>
-              <Link href="/posts/category/branding" className="hover:underline">
-                Branding
-              </Link>
-            </li>
-            <li>
-              <Link href="/posts/category/web-design" className="hover:underline">
-                Web Design
-              </Link>
-            </li>
-            <li>
-              <Link href="/posts/category/content" className="hover:underline">
-                Content
-              </Link>
-            </li>
-            <li>
-              <Link href="/posts/category/guides" className="hover:underline">
-                Guides
-              </Link>
-            </li>
-            <li>
-              <Link href="/posts/category/updates" className="hover:underline">
-                Updates
-              </Link>
-            </li>
-          </ul>
-        </div>
-      </div>
-
-      <section className="container mx-auto px-4 pb-12 pt-12">
-        <div className="max-w-5xl">
-          <h1 className="mb-4 text-5xl font-medium leading-tight md:text-6xl">{post.title}</h1>
-          <p className="mb-8 max-w-3xl text-xl text-gray-700">
-            {post.description || 'Add a cool description here.'}
-          </p>
-          <div className="flex items-center gap-1 text-sm text-gray-500">
-            <span>
-              By{' '}
-              <Link className="text-gray-950" href={''}>
-                Kevin Wessa
-              </Link>
-            </span>
-            <span>•</span>
-            <span>
-              {post.publishedOn
-                ? formatDate({ date: post.publishedOn, format: 'shortDateStamp' })
-                : 'Date not available'}
-            </span>
-            <span>•</span>
-            {/* <span>{post.readTime ? `${post.readTime} min read` : 'Add Read Time'}</span> */}
-          </div>
-        </div>
-      </section>
-
-      <div className="w-full">
-        <div className="px-2">
-          <div className="relative aspect-[3/2] w-full">
-            <Image
-              src={typeof post.image === 'string' ? post.image : post.image?.url || ''}
-              fill
-              alt={
-                typeof post.image === 'object'
-                  ? post.image?.alt || ''
-                  : 'Featured image for blog post'
-              }
-              className="rounded-md object-cover"
-              priority
-            />
-          </div>
-        </div>
-      </div>
-
-      <div className="container mx-auto px-4 pt-8">
-        <article className="prose mx-auto max-w-4xl pb-24">
-          <RichText
-            content={post.content}
-            enableProse={true}
-            enableGutter={false}
-          />
-        </article>
-      </div>
+      <PayloadRedirects disableNotFound url={url} />
+      <JournalHero post={post} />
+      <JournalHeroImage post={post} />
+      <JournalContent post={post} />
     </article>
   )
 }
@@ -155,8 +64,6 @@ export async function generateMetadata({ params: paramsPromise }: Args): Promise
 
   return generateMeta({ doc: post })
 }
-
-
 
 const queryPostBySlug = cache(async ({ slug }: { slug: string }) => {
   const { isEnabled: draft } = await draftMode()


### PR DESCRIPTION
### TL;DR
Refactored the journal post page by splitting it into reusable components for better maintainability and organization.

### What changed?
- Created three new components:
  - `JournalHero`: Displays post title, author, date, and category navigation
  - `JournalHeroImage`: Handles the featured image display
  - `JournalContent`: Renders the post content using RichText component
- Simplified the main page component by utilizing these new components
- Maintained existing functionality while improving code organization

### How to test?
1. Navigate to any journal post page
2. Verify that the post header displays correctly with title, author, and date
3. Confirm the featured image renders properly
4. Check that the post content appears with proper formatting
5. Ensure category navigation links work as expected

### Why make this change?
This restructuring improves code maintainability by separating concerns into discrete components. Each component now has a single responsibility, making the code easier to update and debug. This also enables potential reuse of these components in other parts of the application if needed.